### PR TITLE
Migrate version number file from L to Ghul

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -29,7 +29,7 @@ echo $BUILD_NUMBER: Starting bootstrap...
 for PASS in "${BUILD_NAME}-1" "${BUILD_NAME}-2" "${BUILD_NAME}" ; do
     echo $PASS: Start compile...
 
-    echo "namespace Source is class BUILD is public static System.String number=\"${PASS}\"; si si" >source/build.l
+    echo "namespace Source is class BUILD is number: System.String public static => \"local-${PASS}\"; si si" >source/build.ghul
 
     docker run --name "bootstrap-`date +'%s'`" --rm -e LFLAGS="$LFLAGS" -e GHUL=/usr/bin/ghul -v `pwd`:/home/dev/source -w /home/dev/source -u `id -u`:`id -g` $BUILD_WITH bash -c ./build.sh || exit 1
 

--- a/build.sh
+++ b/build.sh
@@ -17,4 +17,4 @@ if [ -z "$GHUL" ]; then
 fi
 
 echo "Building with $GHUL (`$GHUL`)..."
-find compiler driver ioc system logging source lexical syntax semantic ir -name '*.ghul' |  xargs $GHUL -L $GHULFLAGS -o ghul imports.l source/*.l
+find compiler driver ioc system logging source lexical syntax semantic ir -name '*.ghul' |  xargs $GHUL -L $GHULFLAGS -o ghul imports.l

--- a/dev-build.ps1
+++ b/dev-build.ps1
@@ -1,4 +1,4 @@
-copy source/build.l.template source/build.l
+copy source/build.ghul.template source/build.ghul
 docker volume create lcache
 $workspace=(pwd).path
 docker run --rm -e LFLAGS="-FB -FN" -v lcache:/tmp/lcache/ -v ${workspace}:/home/dev/source/ -w /home/dev/source -t ghul/compiler:stable ./build.sh

--- a/dev-build.sh
+++ b/dev-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "namespace Source is class BUILD is public static System.String number=\"local-`date +'%s'`\"; si si" >source/build.l
+echo "namespace Source is class BUILD is number: System.String static => \"local-`date +'%s'`\"; si si" >source/build.ghul
 
 if [ -z "$GHUL" ]; then
     export PATH=$PATH:`pwd`
@@ -10,4 +10,4 @@ fi
 export LFLAGS="-Ws -WM -FC"
 
 echo "Building with $GHUL (`$GHUL`)..."
-find compiler driver ioc system logging source lexical syntax semantic ir -name '*.ghul' |  xargs $GHUL -D -P ghul -L $GHULFLAGS -o ghul imports.l source/*.l
+find compiler driver ioc system logging source lexical syntax semantic ir -name '*.ghul' |  xargs $GHUL -D -P ghul -L $GHULFLAGS -o ghul imports.l 

--- a/profile.sh
+++ b/profile.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "namespace Source is class BUILD is public static System.String number=\"local-`date +'%s'`\"; si si" >source/build.l
+echo "namespace Source is class BUILD is number: System.String static => \"local-`date +'%s'`\"; si si" >source/build.ghul
 
 if [ -z "$GHUL" ]; then
     export PATH=$PATH:`pwd`
@@ -10,4 +10,4 @@ fi
 export LFLAGS="-Ws -WM -FB -FN"
 
 echo "Profiling $GHUL (`$GHUL`)..."
-find lib compiler driver ioc system logging source lexical syntax semantic ir -name '*.ghul' | xargs valgrind --tool=callgrind $GHUL -D -P ghul -G -X -o ghul imports.l source/*.l
+find lib compiler driver ioc system logging source lexical syntax semantic ir -name '*.ghul' | xargs valgrind --tool=callgrind $GHUL -D -P ghul -G -X -o ghul imports.l

--- a/source/.gitignore
+++ b/source/.gitignore
@@ -1,1 +1,1 @@
-build.l
+build.ghul

--- a/source/build.ghul.template
+++ b/source/build.ghul.template
@@ -1,0 +1,1 @@
+namespace Source is class BUILD is number: System.String public static => "local"; si si

--- a/source/build.l.template
+++ b/source/build.l.template
@@ -1,1 +1,0 @@
-namespace Source is class BUILD is public static System.String number="local"; si si

--- a/source/dummy.ghul
+++ b/source/dummy.ghul
@@ -1,3 +1,0 @@
-namespace Source is
-
-si

--- a/time.sh
+++ b/time.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "namespace Source is class BUILD is public static System.String number=\"local-`date +'%s'`\"; si si" >source/build.l
+echo "namespace Source is class BUILD is number: System.String static => \"local-`date +'%s'`\"; si si" >source/build.ghul
 
 if [ -z "$GHUL" ]; then
     export PATH=$PATH:`pwd`
@@ -10,4 +10,4 @@ fi
 export LFLAGS="-Ws -WM -FB -FN"
 
 echo "Profiling $GHUL (`$GHUL`)..."
-find lib compiler driver ioc system logging source lexical syntax semantic ir -name '*.ghul' | xargs time -v $GHUL -D -P ghul -G -X -o ghul imports.l source/*.l
+find lib compiler driver ioc system logging source lexical syntax semantic ir -name '*.ghul' | xargs time -v $GHUL -D -P ghul -G -X -o ghul imports.l


### PR DESCRIPTION
Migrate the script generated source file holding the compiler version number from L to Ghul, which fixes some spurious errors from the VSCE when editing the compiler source