### PR TITLE
Bug fixes

### DIFF
--- a/driver/compiler.ghul
+++ b/driver/compiler.ghul
@@ -39,7 +39,8 @@ namespace Driver is
             add_pass(build_passes, "resolve-explicit-types", (wi: WORK_ITEM) is resolve_explicit_types_pass(wi); si);
             add_pass(build_passes, "infer-types", (wi: WORK_ITEM) is infer_types_pass(wi); si);
             add_pass(build_passes, "write-objects", (wi: WORK_ITEM) is write_objects_pass(wi); si);
-            add_pass(build_passes, "lay-out-frames", (wi: WORK_ITEM) is lay_out_frames_pass(wi); si);
+            
+            // add_pass(build_passes, "lay-out-frames", (wi: WORK_ITEM) is lay_out_frames_pass(wi); si);
             // add_pass(build_passes, "generate-ir-for-expressions", (wi: WORK_ITEM) is generate_ir_for_expressions_pass(wi); si);
 
             add_pass(build_passes, "generate-il", (wi: WORK_ITEM) is generate_il_pass(wi); si);

--- a/ir/type_repository.ghul
+++ b/ir/type_repository.ghul
@@ -10,7 +10,6 @@ namespace IR is
         si
     si
     
-
     class TYPE_REPOSITORY is
         _type_map: Dict[Semantic.Type.BASE,IR.Type];
         _named_map: Dict[String,IR.Type];

--- a/semantic/symbol/symbol.ghul
+++ b/semantic/symbol/symbol.ghul
@@ -106,7 +106,7 @@ namespace Semantic.Symbol is
         ancestors: List[Type.BASE] => new Type.BASE[](0);
 
         specialized_from: Symbol.BASE public;
-        specializations: Iterable[List[Type.BASE]] => new List[Type.BASE][](0);
+        // specializations: Iterable[List[Type.BASE]] => new List[Type.BASE][](0);
 
         access: ACCESS => ACCESS.PUBLIC;
 

--- a/semantic/symbol_use_locations.ghul
+++ b/semantic/symbol_use_locations.ghul
@@ -10,7 +10,7 @@ namespace Semantic is
 
     class SYMBOL_USE_LOCATIONS: Object, SymbolUseListener is
         _symbol_use_map: LOCATION_MAP[Symbol.BASE];
-        _symbol_reference_map: Dict[Symbol.BASE,List[LOCATION]];
+        _symbol_reference_map: Dict[Symbol.BASE,Set[LOCATION]];
 
         init() is
             clear();
@@ -23,13 +23,24 @@ namespace Semantic is
 
         clear() is
             _symbol_use_map = new LOCATION_MAP[Symbol.BASE]();
-            _symbol_reference_map = new Map[Symbol.BASE,List[LOCATION]](65521);
+            _symbol_reference_map = new Map[Symbol.BASE,Set[LOCATION]](65521);
         si
 
         add_symbol_use(location: LOCATION, symbol: Symbol.BASE) is
             if symbol? && symbol.location.file_name !~ "internal" && !symbol.name.startsWith("__") then
+                while symbol.specialized_from? do
+                    symbol = symbol.specialized_from;
+                od
+
                 _symbol_use_map.put(location, symbol);
-                get_references_list(symbol).add(location);
+
+                let set_ = get_references_set(symbol);
+
+                if !set_.contains(location) then
+                    // FIXME: why is this getting called multiple times for the same symbol and location?
+                    set_.add(location);
+
+                fi
             fi
         si
 
@@ -38,14 +49,14 @@ namespace Semantic is
         si
 
         find_references_to_symbol(symbol: Symbol.BASE) -> Iterable[LOCATION] is
-            return get_references_list(symbol);    
+            return get_references_set(symbol);    
         si
 
-        get_references_list(symbol: Symbol.BASE) -> List[LOCATION] is
+        get_references_set(symbol: Symbol.BASE) -> Set[LOCATION] is
             var result = _symbol_reference_map[symbol];
 
             if result == null then
-                result = new Vector[LOCATION]();
+                result = new Set[LOCATION]();
 
                 _symbol_reference_map[symbol] = result;
             fi

--- a/syntax/process/lay_out_frames.ghul
+++ b/syntax/process/lay_out_frames.ghul
@@ -98,17 +98,18 @@ namespace Syntax.Process is
             let symbol = _symbol_table.current_function;
 
             if symbol? then
-
                 if symbol.override? then
                     IO.Std.err.println("function " + symbol.qualified_name + " should pick up slot number from " + symbol.override.qualified_name);
                 fi
 
+                /*
                 for f in symbol.specializations do
                     let key = new Semantic.GENERIC_KEY(null, symbol, f);
                     let specialization =  _generic_cache[key];
 
                     IO.Std.err.println("    " + symbol.qualified_name + "[" + f + "] -> " + specialization);
                 od
+                */
 
                 symbol.allocate(_builder, _type_repository, _ghul_symbol_lookup);
 


### PR DESCRIPTION
Fix issue where find symbol references results could find the same type multiple times at the same location (#137)
Fix issue where find symbol references found only references to the exact generic specialization, rather than the unspecialized generic type.
Remove dead code.