### PR TITLE
Remove references to lcache

### DIFF
--- a/build/bootstrap.sh
+++ b/build/bootstrap.sh
@@ -43,7 +43,7 @@ for PASS in "${BUILD_NAME}-bs-1" "${BUILD_NAME}-bs-2" "${BUILD_NAME}" ; do
 
         echo $PASS: Start tests... 
 
-        docker run --name "bootstrap-`date +'%s'`" --rm -v test-lcache:/tmp/lcache -v `pwd`:/home/dev/source/ -w /home/dev/source/test -u `id -u`:`id -g` $BUILD_WITH ../tester/tester
+        docker run --name "bootstrap-`date +'%s'`" --rm -v `pwd`:/home/dev/source/ -w /home/dev/source/test -u `id -u`:`id -g` $BUILD_WITH ../tester/tester
 
         echo $PASS: Tests complete
     fi

--- a/build/dev.sh
+++ b/build/dev.sh
@@ -1,11 +1,4 @@
 #!/bin/bash
 
-if [[ -d /tmp/lcache-dev ]]; then
-    LCACHE=/tmp/lcache-dev
-else
-    docker volume create lcache
-    LCACHE=lcache
-fi
-
 MSYS_NO_PATHCONV=1 \
-docker run --name "dev-`date +'%s'`" --rm -v ${LCACHE}:/tmp/lcache -v `pwd`:/home/dev/source/ -w /home/dev/source -u `id -u`:`id -g` -it ghul/compiler:stable /bin/bash
+docker run --name "dev-`date +'%s'`" --rm -v `pwd`:/home/dev/source/ -w /home/dev/source -u `id -u`:`id -g` -it ghul/compiler:stable /bin/bash

--- a/tasks/test.sh
+++ b/tasks/test.sh
@@ -11,5 +11,5 @@ if [ ! -f $CASE/ghulflags ] ; then
     exit 1;
 fi
 
-docker run --name "test-`date +'%s'`" --rm --env PATH='/home/dev/source:/bin:/usr/bin:/usr/local/bin' -v test-lcache:/tmp/lcache -v `pwd`/../../..:/home/dev/source/ -w /home/dev/source/test -u `id -u`:`id -g` ghul/compiler:stable ../tester/tester ${@:1}
+docker run --name "test-`date +'%s'`" --rm --env PATH='/home/dev/source:/bin:/usr/bin:/usr/local/bin' -v `pwd`/../../..:/home/dev/source/ -w /home/dev/source/test -u `id -u`:`id -g` ghul/compiler:stable ../tester/tester ${@:1}
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-docker run --name "test-`date +'%s'`" --rm --env PATH='/home/dev/source:/bin:/usr/bin:/usr/local/bin' -v test-lcache:/tmp/lcache -v `pwd`:/home/dev/source/ -w /home/dev/source/test -u `id -u`:`id -g` ghul/compiler:stable ../tester/tester ${CASE}
+docker run --name "test-`date +'%s'`" --rm --env PATH='/home/dev/source:/bin:/usr/bin:/usr/local/bin' -v `pwd`:/home/dev/source/ -w /home/dev/source/test -u `id -u`:`id -g` ghul/compiler:stable ../tester/tester ${CASE}
 

--- a/tester/build.sh
+++ b/tester/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 
-docker run --name "dev-`date +'%s'`" --rm -e LFLAGS="-FB -FN -Ws -WM" -v /tmp/lcache/ -v `pwd`:/home/dev/source/ -w /home/dev/source -u `id -u`:`id -g` ghul/compiler:stable /bin/sh ./_build.sh
+docker run --name "dev-`date +'%s'`" --rm -e LFLAGS="-FB -FN -Ws -WM" -v `pwd`:/home/dev/source/ -w /home/dev/source -u `id -u`:`id -g` ghul/compiler:stable /bin/sh ./_build.sh


### PR DESCRIPTION
Remove remaining references to lcache Docker volume from all scripts
Remove references to the LCACHE environment variable from scripts, except for scripts that actually run within an L compiler container. 