### PR TITLE
Output a runtimeconfig.json for DotNET executables

### DIFF
--- a/src/driver/main.ghul
+++ b/src/driver/main.ghul
@@ -262,6 +262,18 @@ namespace Driver is
                 return result;
             fi
 
+            let runtime_config_file: String;
+
+            if output_file.lastIndexOf('.') == output_file.Length - 4 then
+                runtime_config_file = output_file.substring(0, output_file.lastIndexOf('.')) + ".runtimeconfig.json";
+            else
+                runtime_config_file = output_file + ".runtimeconfig.json";
+            fi
+            
+            let runtime_config = IO.File.openCreate(runtime_config_file);
+            runtime_config.write("{\"runtimeOptions\":{\"tfm\":\"netcoreapp3.1\",\"framework\":{\"name\":\"Microsoft.NETCore.App\",\"version\":\"3.1.0\"}}}");
+            runtime_config.close();
+
             let chmod = new Util.Process();
             result = chmod.run("/usr/bin/chmod", ["chmod", "+x", output_file]);
 


### PR DESCRIPTION
DotNET Core requires an `<app>.runtimeconfig.json` before it is prepared to run a CIL executable. Output a boilerplate `runtimeconfig.json` for the target executable with canned JSON targeting DotNet Core 3.1. 