### PR TITLE
Use original formal generic arguments in IL names

### DIFF
--- a/src/semantic/symbol/symbol.ghul
+++ b/src/semantic/symbol/symbol.ghul
@@ -520,9 +520,6 @@ namespace Semantic.Symbol is
             fi
         si
 
-        // used by the language server to offer code completion suggestions - as code completion is
-        // only possible from within the class/trait/struct, we do not need to specialize - the user
-        // needs to see unspecialized member symbols and formal type parameters 
         find_direct_matches(prefix: String, matches: Dict[String, Symbol.BASE]) is
             let m = new Map[String, Symbol.BASE]();
 
@@ -535,9 +532,6 @@ namespace Semantic.Symbol is
             od
         si
 
-        // used by the language server to offer code completion suggestions - as code completion is
-        // only possible from within the class/trait/struct, we do not need to specialize - the user
-        // needs to see unspecialized member symbols and formal type parameters 
         find_member_matches(prefix: String, matches: Dict[String, Symbol.BASE]) is
             find_direct_matches(prefix, matches);
             symbol.find_ancestor_matches(prefix, matches);
@@ -1838,9 +1832,18 @@ namespace Semantic.Symbol is
                 IO.Std.err.println("" + result + " is already owned by " + owner);
             fi
             
-            result.unspecialized_arguments = arguments;
-            result.unspecialized_return_type = return_type;
+            if unspecialized_arguments? then
+                result.unspecialized_arguments = unspecialized_arguments;
+            else
+                result.unspecialized_arguments = arguments;
+            fi
 
+            if unspecialized_return_type? then
+                result.unspecialized_return_type = unspecialized_return_type;
+            else
+                result.unspecialized_return_type = return_type;
+            fi
+            
             result.arguments = new Vector[Type.BASE](arguments);
 
             for i in 0..arguments.Length do


### PR DESCRIPTION
Fix issue where incorrect position-notated generic arguments were used in IL names in some circumstances
 