### PR TITLE
Fix issue where legacy test suite not run on release builds

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -203,4 +203,4 @@ jobs:
       with:
         name: test-results
         path: |
-          tests/test-results.md
+          tests-legacy/test-results.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
     - name: Make tester executable
       run: chmod +x tester/tester
 
-    - name: Test compiler
+    - name: Run .NET tests
       run: ./tests/test.sh
 
     - uses: actions/upload-artifact@v2
@@ -201,15 +201,15 @@ jobs:
     - name: Make tester executable
       run: chmod +x tester/tester
 
-    - name: Test compiler
-      run: ./tests/test.sh
+    - name: Run legacy tests
+      run: ./tests-legacy/test.sh
 
     - uses: actions/upload-artifact@v2
       if: ${{ always() }}
       with:
         name: test-results
         path: |
-          tests/test-results.md
+          tests-legacy/test-results.md
 
   build_container:
     needs: [build_compiler]


### PR DESCRIPTION
Fix for the release workflow, similar to the fix already applied to the merge workflow for #333 