### PR TITLE
Add additional types to .NET stubs

### DIFF
--- a/lib/dotnet/ghul/ghul.ghul
+++ b/lib/dotnet/ghul/ghul.ghul
@@ -89,91 +89,6 @@ namespace Ghul is
         address: E ptr ptr => null;
         value: E => null, = value is si
     si
-
-    class TUPLE_1[T0] is
-        item_0: T0;
-    si
-
-    class TUPLE_2[T0,T1] is
-        item_0: T0;
-        item_1: T1;
-    si
-
-    class TUPLE_3[T0,T1,T2] is
-        item_0: T0;
-        item_1: T1;
-        item_2: T2;
-    si
-
-    class TUPLE_4[T0,T1,T2,T3] is
-        item_0: T0;
-        item_1: T1;
-        item_2: T2;
-        item_3: T3;
-    si
-
-    class TUPLE_5[T0,T1,T2,T3,T4] is
-        item_0: T0;
-        item_1: T1;
-        item_2: T2;
-        item_3: T3;
-        item_4: T4;
-    si
-
-    class TUPLE_6[T0,T1,T2,T3,T4,T5] is
-        item_0: T0;
-        item_1: T1;
-        item_2: T2;
-        item_3: T3;
-        item_4: T4;
-        item_5: T5;
-    si
-
-    class TUPLE_7[T0,T1,T2,T3,T4,T5,T6] is
-        item_0: T0;
-        item_1: T1;
-        item_2: T2;
-        item_3: T3;
-        item_4: T4;
-        item_5: T5;
-        item_6: T6;
-    si
-
-    class TUPLE_8[T0,T1,T2,T3,T4,T5,T6,T7] is
-        item_0: T0;
-        item_1: T1;
-        item_2: T2;
-        item_3: T3;
-        item_4: T4;
-        item_5: T5;
-        item_6: T6;
-        item_7: T7;
-    si
-
-    class TUPLE_9[T0,T1,T2,T3,T4,T5,T6,T7,T8] is
-        item_0: T0;
-        item_1: T1;
-        item_2: T2;
-        item_3: T3;
-        item_4: T4;
-        item_5: T5;
-        item_6: T6;
-        item_7: T7;
-        item_8: T8;
-    si
-
-    class TUPLE_10[T0,T1,T2,T3,T4,T5,T6,T7,T8,T9] is
-        item_0: T0;
-        item_1: T1;
-        item_2: T2;
-        item_3: T3;
-        item_4: T4;
-        item_5: T5;
-        item_6: T6;
-        item_7: T7;
-        item_8: T8;
-        item_9: T9;
-    si
     
     ==(a: System.Object, b: System.Object) -> bool innate compare.reference;
 
@@ -283,34 +198,7 @@ si
 @IL.stub()
 namespace System is
 
-    // @IL.built_in_type("object")
-    // class Object is
-    //     // address: Object ptr => null;
-    //     ClassName: String => null;
-
-    //     @IL.name(".ctor")
-    //     init();
-
-    //     clone() -> Object;
-    //     dump(object: Object) -> String static;
-
-    //     @IL.name("ToString")
-    //     toString() -> String;
-
-    //     @IL.name("ToString")
-    //     to_string() -> String;
-
-    //     @IL.name("GetHashCode")
-    //     hash() -> int;
-
-    //     // FIXME: just to silence some false positive errors when compiling compiler itself:
-    //     opCompare(other: Object) -> int;
-    // si
-
-    @IL.name("class [mscorlib]System.ValueType")
-    class ValueType is
-    si
-
+ 
     class StringBuffer: String is
         init();
         init(initial_capacity: int);

--- a/lib/dotnet/stubs/ghul.ghul
+++ b/lib/dotnet/stubs/ghul.ghul
@@ -539,19 +539,56 @@ namespace Ghul is
         method: System.Reflection.MethodInfo;
 
     si
-
     @IL.stub()
     @IL.name("class [mscorlib]System.Action")
     class ACTION_0: System.MulticastDelegate,System.ICloneable,System.Runtime.Serialization.ISerializable is
         @IL.name("Invoke")
         invoke();
-    si
 
+        @IL.name("BeginInvoke")
+        begin_invoke(callback: System.AsyncCallback, object: System.Object) -> System.IAsyncResult;
+
+        @IL.name("EndInvoke")
+        end_invoke(result: System.IAsyncResult);
+
+        @IL.name("GetObjectData")
+        get_object_data(info: System.Runtime.Serialization.SerializationInfo, context: System.Runtime.Serialization.StreamingContext);
+
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("GetInvocationList")
+        get_invocation_list() -> System.Delegate[];
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("Clone")
+        clone() -> System.Object;
+
+        @IL.name("DynamicInvoke")
+        dynamic_invoke(args: System.Object[]) -> System.Object;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name(".ctor")
+        init(object: System.Object, method: word);
+        @IL.name.read("get_Target") 
+        target: System.Object;
+
+        @IL.name.read("get_Method") 
+        method: System.Reflection.MethodInfo;
+
+    si
     @IL.stub()
     @IL.name("class [mscorlib]System.Action`1")
     class ACTION_1[T]: System.MulticastDelegate,System.ICloneable,System.Runtime.Serialization.ISerializable is
         @IL.name("Invoke")
-        invoke(obj: T);
+        call(obj: T);
 
         @IL.name("BeginInvoke")
         begin_invoke(obj: T, callback: System.AsyncCallback, object: System.Object) -> System.IAsyncResult;
@@ -596,7 +633,7 @@ namespace Ghul is
     @IL.name("class [mscorlib]System.Action`2")
     class ACTION_2[T1,T2]: System.MulticastDelegate,System.ICloneable,System.Runtime.Serialization.ISerializable is
         @IL.name("Invoke")
-        invoke(arg1: T1, arg2: T2);
+        call(arg1: T1, arg2: T2);
 
         @IL.name("BeginInvoke")
         begin_invoke(arg1: T1, arg2: T2, callback: System.AsyncCallback, object: System.Object) -> System.IAsyncResult;
@@ -641,7 +678,7 @@ namespace Ghul is
     @IL.name("class [mscorlib]System.Action`3")
     class ACTION_3[T1,T2,T3]: System.MulticastDelegate,System.ICloneable,System.Runtime.Serialization.ISerializable is
         @IL.name("Invoke")
-        invoke(arg1: T1, arg2: T2, arg3: T3);
+        call(arg1: T1, arg2: T2, arg3: T3);
 
         @IL.name("BeginInvoke")
         begin_invoke(arg1: T1, arg2: T2, arg3: T3, callback: System.AsyncCallback, object: System.Object) -> System.IAsyncResult;
@@ -686,7 +723,7 @@ namespace Ghul is
     @IL.name("class [mscorlib]System.Action`4")
     class ACTION_4[T1,T2,T3,T4]: System.MulticastDelegate,System.ICloneable,System.Runtime.Serialization.ISerializable is
         @IL.name("Invoke")
-        invoke(arg1: T1, arg2: T2, arg3: T3, arg4: T4);
+        call(arg1: T1, arg2: T2, arg3: T3, arg4: T4);
 
         @IL.name("BeginInvoke")
         begin_invoke(arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: System.AsyncCallback, object: System.Object) -> System.IAsyncResult;
@@ -731,7 +768,7 @@ namespace Ghul is
     @IL.name("class [mscorlib]System.Action`5")
     class ACTION_5[T1,T2,T3,T4,T5]: System.MulticastDelegate,System.ICloneable,System.Runtime.Serialization.ISerializable is
         @IL.name("Invoke")
-        invoke(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5);
+        call(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5);
 
         @IL.name("BeginInvoke")
         begin_invoke(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: System.AsyncCallback, object: System.Object) -> System.IAsyncResult;
@@ -776,7 +813,7 @@ namespace Ghul is
     @IL.name("class [mscorlib]System.Action`6")
     class ACTION_6[T1,T2,T3,T4,T5,T6]: System.MulticastDelegate,System.ICloneable,System.Runtime.Serialization.ISerializable is
         @IL.name("Invoke")
-        invoke(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6);
+        call(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6);
 
         @IL.name("BeginInvoke")
         begin_invoke(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callback: System.AsyncCallback, object: System.Object) -> System.IAsyncResult;
@@ -821,7 +858,7 @@ namespace Ghul is
     @IL.name("class [mscorlib]System.Action`7")
     class ACTION_7[T1,T2,T3,T4,T5,T6,T7]: System.MulticastDelegate,System.ICloneable,System.Runtime.Serialization.ISerializable is
         @IL.name("Invoke")
-        invoke(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7);
+        call(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7);
 
         @IL.name("BeginInvoke")
         begin_invoke(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, callback: System.AsyncCallback, object: System.Object) -> System.IAsyncResult;
@@ -866,7 +903,7 @@ namespace Ghul is
     @IL.name("class [mscorlib]System.Action`8")
     class ACTION_8[T1,T2,T3,T4,T5,T6,T7,T8]: System.MulticastDelegate,System.ICloneable,System.Runtime.Serialization.ISerializable is
         @IL.name("Invoke")
-        invoke(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8);
+        call(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8);
 
         @IL.name("BeginInvoke")
         begin_invoke(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, callback: System.AsyncCallback, object: System.Object) -> System.IAsyncResult;
@@ -911,7 +948,7 @@ namespace Ghul is
     @IL.name("class [mscorlib]System.Action`9")
     class ACTION_9[T1,T2,T3,T4,T5,T6,T7,T8,T9]: System.MulticastDelegate,System.ICloneable,System.Runtime.Serialization.ISerializable is
         @IL.name("Invoke")
-        invoke(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9);
+        call(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9);
 
         @IL.name("BeginInvoke")
         begin_invoke(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, callback: System.AsyncCallback, object: System.Object) -> System.IAsyncResult;
@@ -956,7 +993,7 @@ namespace Ghul is
     @IL.name("class [mscorlib]System.Action`10")
     class ACTION_10[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10]: System.MulticastDelegate,System.ICloneable,System.Runtime.Serialization.ISerializable is
         @IL.name("Invoke")
-        invoke(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10);
+        call(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10);
 
         @IL.name("BeginInvoke")
         begin_invoke(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, callback: System.AsyncCallback, object: System.Object) -> System.IAsyncResult;
@@ -1001,7 +1038,7 @@ namespace Ghul is
     @IL.name("class [mscorlib]System.Action`11")
     class ACTION_11[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11]: System.MulticastDelegate,System.ICloneable,System.Runtime.Serialization.ISerializable is
         @IL.name("Invoke")
-        invoke(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11);
+        call(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11);
 
         @IL.name("BeginInvoke")
         begin_invoke(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, callback: System.AsyncCallback, object: System.Object) -> System.IAsyncResult;
@@ -1046,7 +1083,7 @@ namespace Ghul is
     @IL.name("class [mscorlib]System.Action`12")
     class ACTION_12[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12]: System.MulticastDelegate,System.ICloneable,System.Runtime.Serialization.ISerializable is
         @IL.name("Invoke")
-        invoke(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12);
+        call(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12);
 
         @IL.name("BeginInvoke")
         begin_invoke(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, callback: System.AsyncCallback, object: System.Object) -> System.IAsyncResult;
@@ -1131,5 +1168,269 @@ namespace Ghul is
         @IL.name.read("get_Method") 
         method: System.Reflection.MethodInfo;
 
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.ValueTuple`1")
+    struct TUPLE_1[T1]: System.Equatable[Ghul.TUPLE_1[T1]],System.Comparable[Ghul.TUPLE_1[T1]],System.IValueTupleInternal,System.Runtime.CompilerServices.ITuple is
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("Equals")
+        equals(other: Ghul.TUPLE_1[T1]) -> bool;
+
+        @IL.name("CompareTo")
+        compare_to(other: Ghul.TUPLE_1[T1]) -> int;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name(".ctor")
+        init(item1: T1);
+        @IL.name("Item1")
+        _0: T1 public;
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.ValueTuple`2")
+    struct TUPLE_2[T1,T2]: System.Equatable[Ghul.TUPLE_2[T1,T2]],System.Comparable[Ghul.TUPLE_2[T1,T2]],System.IValueTupleInternal,System.Runtime.CompilerServices.ITuple is
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("Equals")
+        equals(other: Ghul.TUPLE_2[T1,T2]) -> bool;
+
+        @IL.name("CompareTo")
+        compare_to(other: Ghul.TUPLE_2[T1,T2]) -> int;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name(".ctor")
+        init(item1: T1, item2: T2);
+        @IL.name("Item1")
+        _0: T1 public;
+        @IL.name("Item2")
+        _1: T2 public;
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.ValueTuple`3")
+    struct TUPLE_3[T1,T2,T3]: System.Equatable[Ghul.TUPLE_3[T1,T2,T3]],System.Comparable[Ghul.TUPLE_3[T1,T2,T3]],System.IValueTupleInternal,System.Runtime.CompilerServices.ITuple is
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("Equals")
+        equals(other: Ghul.TUPLE_3[T1,T2,T3]) -> bool;
+
+        @IL.name("CompareTo")
+        compare_to(other: Ghul.TUPLE_3[T1,T2,T3]) -> int;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name(".ctor")
+        init(item1: T1, item2: T2, item3: T3);
+        @IL.name("Item1")
+        _0: T1 public;
+        @IL.name("Item2")
+        _1: T2 public;
+        @IL.name("Item3")
+        _2: T3 public;
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.ValueTuple`4")
+    struct TUPLE_4[T1,T2,T3,T4]: System.Equatable[Ghul.TUPLE_4[T1,T2,T3,T4]],System.Comparable[Ghul.TUPLE_4[T1,T2,T3,T4]],System.IValueTupleInternal,System.Runtime.CompilerServices.ITuple is
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("Equals")
+        equals(other: Ghul.TUPLE_4[T1,T2,T3,T4]) -> bool;
+
+        @IL.name("CompareTo")
+        compare_to(other: Ghul.TUPLE_4[T1,T2,T3,T4]) -> int;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name(".ctor")
+        init(item1: T1, item2: T2, item3: T3, item4: T4);
+        @IL.name("Item1")
+        _0: T1 public;
+        @IL.name("Item2")
+        _1: T2 public;
+        @IL.name("Item3")
+        _2: T3 public;
+        @IL.name("Item4")
+        _3: T4 public;
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.ValueTuple`5")
+    struct TUPLE_5[T1,T2,T3,T4,T5]: System.Equatable[Ghul.TUPLE_5[T1,T2,T3,T4,T5]],System.Comparable[Ghul.TUPLE_5[T1,T2,T3,T4,T5]],System.IValueTupleInternal,System.Runtime.CompilerServices.ITuple is
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("Equals")
+        equals(other: Ghul.TUPLE_5[T1,T2,T3,T4,T5]) -> bool;
+
+        @IL.name("CompareTo")
+        compare_to(other: Ghul.TUPLE_5[T1,T2,T3,T4,T5]) -> int;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name(".ctor")
+        init(item1: T1, item2: T2, item3: T3, item4: T4, item5: T5);
+        @IL.name("Item1")
+        _0: T1 public;
+        @IL.name("Item2")
+        _1: T2 public;
+        @IL.name("Item3")
+        _2: T3 public;
+        @IL.name("Item4")
+        _3: T4 public;
+        @IL.name("Item5")
+        _4: T5 public;
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.ValueTuple`6")
+    struct TUPLE_6[T1,T2,T3,T4,T5,T6]: System.Equatable[Ghul.TUPLE_6[T1,T2,T3,T4,T5,T6]],System.Comparable[Ghul.TUPLE_6[T1,T2,T3,T4,T5,T6]],System.IValueTupleInternal,System.Runtime.CompilerServices.ITuple is
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("Equals")
+        equals(other: Ghul.TUPLE_6[T1,T2,T3,T4,T5,T6]) -> bool;
+
+        @IL.name("CompareTo")
+        compare_to(other: Ghul.TUPLE_6[T1,T2,T3,T4,T5,T6]) -> int;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name(".ctor")
+        init(item1: T1, item2: T2, item3: T3, item4: T4, item5: T5, item6: T6);
+        @IL.name("Item1")
+        _0: T1 public;
+        @IL.name("Item2")
+        _1: T2 public;
+        @IL.name("Item3")
+        _2: T3 public;
+        @IL.name("Item4")
+        _3: T4 public;
+        @IL.name("Item5")
+        _4: T5 public;
+        @IL.name("Item6")
+        _5: T6 public;
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.ValueTuple`7")
+    struct TUPLE_7[T1,T2,T3,T4,T5,T6,T7]: System.Equatable[Ghul.TUPLE_7[T1,T2,T3,T4,T5,T6,T7]],System.Comparable[Ghul.TUPLE_7[T1,T2,T3,T4,T5,T6,T7]],System.IValueTupleInternal,System.Runtime.CompilerServices.ITuple is
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("Equals")
+        equals(other: Ghul.TUPLE_7[T1,T2,T3,T4,T5,T6,T7]) -> bool;
+
+        @IL.name("CompareTo")
+        compare_to(other: Ghul.TUPLE_7[T1,T2,T3,T4,T5,T6,T7]) -> int;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name(".ctor")
+        init(item1: T1, item2: T2, item3: T3, item4: T4, item5: T5, item6: T6, item7: T7);
+        @IL.name("Item1")
+        _0: T1 public;
+        @IL.name("Item2")
+        _1: T2 public;
+        @IL.name("Item3")
+        _2: T3 public;
+        @IL.name("Item4")
+        _3: T4 public;
+        @IL.name("Item5")
+        _4: T5 public;
+        @IL.name("Item6")
+        _5: T6 public;
+        @IL.name("Item7")
+        _6: T7 public;
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.ValueTuple`8")
+    struct TUPLE_8[T1,T2,T3,T4,T5,T6,T7,TRest]: System.Equatable[Ghul.TUPLE_8[T1,T2,T3,T4,T5,T6,T7,TRest]],System.Comparable[Ghul.TUPLE_8[T1,T2,T3,T4,T5,T6,T7,TRest]],System.IValueTupleInternal,System.Runtime.CompilerServices.ITuple is
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("Equals")
+        equals(other: Ghul.TUPLE_8[T1,T2,T3,T4,T5,T6,T7,TRest]) -> bool;
+
+        @IL.name("CompareTo")
+        compare_to(other: Ghul.TUPLE_8[T1,T2,T3,T4,T5,T6,T7,TRest]) -> int;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name(".ctor")
+        init(item1: T1, item2: T2, item3: T3, item4: T4, item5: T5, item6: T6, item7: T7, rest: TRest);
+        @IL.name("Item1")
+        _0: T1 public;
+        @IL.name("Item2")
+        _1: T2 public;
+        @IL.name("Item3")
+        _2: T3 public;
+        @IL.name("Item4")
+        _3: T4 public;
+        @IL.name("Item5")
+        _4: T5 public;
+        @IL.name("Item6")
+        _5: T6 public;
+        @IL.name("Item7")
+        _6: T7 public;
+        @IL.name("Rest")
+        _rest: TRest public;
     si
 si

--- a/lib/dotnet/stubs/microsoft.win32.safehandles.ghul
+++ b/lib/dotnet/stubs/microsoft.win32.safehandles.ghul
@@ -1,0 +1,10 @@
+namespace Microsoft.Win32.SafeHandles is
+    @IL.stub()
+    @IL.name("class [mscorlib]Microsoft.Win32.SafeHandles.SafeFileHandle")
+    class SafeFileHandle: Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid,System.IDisposable is
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid")
+    class SafeHandleZeroOrMinusOneIsInvalid: System.Runtime.InteropServices.SafeHandle,System.IDisposable is
+    si
+si

--- a/lib/dotnet/stubs/system.configuration.assemblies.ghul
+++ b/lib/dotnet/stubs/system.configuration.assemblies.ghul
@@ -1,0 +1,6 @@
+namespace System.Configuration.Assemblies is
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Configuration.Assemblies.AssemblyHashAlgorithm")
+    struct AssemblyHashAlgorithm is
+    si
+si

--- a/lib/dotnet/stubs/system.ghul
+++ b/lib/dotnet/stubs/system.ghul
@@ -1,5 +1,45 @@
 namespace System is
     @IL.stub()
+    @IL.built_in_type("object")
+    class Object is
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        // @IL.name("Equals")
+        // equals(obj_a: System.Object, obj_b: System.Object) -> bool static;
+
+        @IL.name("ReferenceEquals")
+        reference_equals(obj_a: System.Object, obj_b: System.Object) -> bool static;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name(".ctor")
+        init();
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.ValueType")
+    class ValueType is
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+    si
+    @IL.stub()
     @IL.name("class [mscorlib]System.String")
     class String: System.Object,System.IConvertible,Collections.Iterable[char],System.Comparable[System.String],System.Equatable[System.String],System.ICloneable is
         @IL.name("Replace")
@@ -176,31 +216,98 @@ namespace System is
         @IL.name("LastIndexOf")
         last_index_of(value: System.String, start_index: int, count: int, comparison_type: System.StringComparison) -> int;
 
-        @IL.name("ToString")
-        to_string() -> System.String;
+        @IL.name("Compare")
+        compare(str_a: System.String, str_b: System.String) -> int static;
 
-        @IL.name("ToString")
-        to_string(provider: System.IFormatProvider) -> System.String;
+        @IL.name("Compare")
+        compare(str_a: System.String, str_b: System.String, ignore_case: bool) -> int static;
 
-        @IL.name.read("GetEnumerator")
-        iterator: System.CharEnumerator;
-        @IL.name("EnumerateRunes")
-        enumerate_runes() -> System.Text.StringRuneEnumerator;
+        @IL.name("Compare")
+        compare(str_a: System.String, str_b: System.String, comparison_type: System.StringComparison) -> int static;
 
-        @IL.name("GetTypeCode")
-        get_type_code() -> System.TypeCode;
+        @IL.name("Compare")
+        compare(str_a: System.String, str_b: System.String, culture: System.Globalization.CultureInfo, options: System.Globalization.CompareOptions) -> int static;
 
-        @IL.name("IsNormalized")
-        is_normalized() -> bool;
+        @IL.name("Compare")
+        compare(str_a: System.String, str_b: System.String, ignore_case: bool, culture: System.Globalization.CultureInfo) -> int static;
 
-        @IL.name("IsNormalized")
-        is_normalized(normalization_form: System.Text.NormalizationForm) -> bool;
+        @IL.name("Compare")
+        compare(str_a: System.String, index_a: int, str_b: System.String, index_b: int, length: int) -> int static;
 
-        @IL.name("Normalize")
-        normalize() -> System.String;
+        @IL.name("Compare")
+        compare(str_a: System.String, index_a: int, str_b: System.String, index_b: int, length: int, ignore_case: bool) -> int static;
 
-        @IL.name("Normalize")
-        normalize(normalization_form: System.Text.NormalizationForm) -> System.String;
+        @IL.name("Compare")
+        compare(str_a: System.String, index_a: int, str_b: System.String, index_b: int, length: int, ignore_case: bool, culture: System.Globalization.CultureInfo) -> int static;
+
+        @IL.name("Compare")
+        compare(str_a: System.String, index_a: int, str_b: System.String, index_b: int, length: int, culture: System.Globalization.CultureInfo, options: System.Globalization.CompareOptions) -> int static;
+
+        @IL.name("Compare")
+        compare(str_a: System.String, index_a: int, str_b: System.String, index_b: int, length: int, comparison_type: System.StringComparison) -> int static;
+
+        @IL.name("CompareOrdinal")
+        compare_ordinal(str_a: System.String, str_b: System.String) -> int static;
+
+        @IL.name("CompareOrdinal")
+        compare_ordinal(str_a: System.String, index_a: int, str_b: System.String, index_b: int, length: int) -> int static;
+
+        @IL.name("CompareTo")
+        compare_to(value: System.Object) -> int;
+
+        @IL.name("CompareTo")
+        compare_to(str_b: System.String) -> int;
+
+        @IL.name("EndsWith")
+        ends_with(value: System.String) -> bool;
+
+        @IL.name("EndsWith")
+        ends_with(value: System.String, comparison_type: System.StringComparison) -> bool;
+
+        @IL.name("EndsWith")
+        ends_with(value: System.String, ignore_case: bool, culture: System.Globalization.CultureInfo) -> bool;
+
+        @IL.name("EndsWith")
+        ends_with(value: char) -> bool;
+
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("Equals")
+        equals(value: System.String) -> bool;
+
+        @IL.name("Equals")
+        equals(value: System.String, comparison_type: System.StringComparison) -> bool;
+
+        @IL.name("Equals")
+        equals(a: System.String, b: System.String) -> bool static;
+
+        @IL.name("Equals")
+        equals(a: System.String, b: System.String, comparison_type: System.StringComparison) -> bool static;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("GetHashCode")
+        get_hash_code(comparison_type: System.StringComparison) -> int;
+
+        @IL.name("GetHashCode")
+        get_hash_code(value: System.ReadOnlySpan[char]) -> int static;
+
+        @IL.name("GetHashCode")
+        get_hash_code(value: System.ReadOnlySpan[char], comparison_type: System.StringComparison) -> int static;
+
+        @IL.name("StartsWith")
+        starts_with(value: System.String) -> bool;
+
+        @IL.name("StartsWith")
+        starts_with(value: System.String, comparison_type: System.StringComparison) -> bool;
+
+        @IL.name("StartsWith")
+        starts_with(value: System.String, ignore_case: bool, culture: System.Globalization.CultureInfo) -> bool;
+
+        @IL.name("StartsWith")
+        starts_with(value: char) -> bool;
 
         @IL.name("Concat")
         concat(arg0: System.Object) -> System.String static;
@@ -322,99 +429,6 @@ namespace System is
         @IL.name("IsInterned")
         is_interned(str: System.String) -> System.String static;
 
-        @IL.name("Compare")
-        compare(str_a: System.String, str_b: System.String) -> int static;
-
-        @IL.name("Compare")
-        compare(str_a: System.String, str_b: System.String, ignore_case: bool) -> int static;
-
-        @IL.name("Compare")
-        compare(str_a: System.String, str_b: System.String, comparison_type: System.StringComparison) -> int static;
-
-        @IL.name("Compare")
-        compare(str_a: System.String, str_b: System.String, culture: System.Globalization.CultureInfo, options: System.Globalization.CompareOptions) -> int static;
-
-        @IL.name("Compare")
-        compare(str_a: System.String, str_b: System.String, ignore_case: bool, culture: System.Globalization.CultureInfo) -> int static;
-
-        @IL.name("Compare")
-        compare(str_a: System.String, index_a: int, str_b: System.String, index_b: int, length: int) -> int static;
-
-        @IL.name("Compare")
-        compare(str_a: System.String, index_a: int, str_b: System.String, index_b: int, length: int, ignore_case: bool) -> int static;
-
-        @IL.name("Compare")
-        compare(str_a: System.String, index_a: int, str_b: System.String, index_b: int, length: int, ignore_case: bool, culture: System.Globalization.CultureInfo) -> int static;
-
-        @IL.name("Compare")
-        compare(str_a: System.String, index_a: int, str_b: System.String, index_b: int, length: int, culture: System.Globalization.CultureInfo, options: System.Globalization.CompareOptions) -> int static;
-
-        @IL.name("Compare")
-        compare(str_a: System.String, index_a: int, str_b: System.String, index_b: int, length: int, comparison_type: System.StringComparison) -> int static;
-
-        @IL.name("CompareOrdinal")
-        compare_ordinal(str_a: System.String, str_b: System.String) -> int static;
-
-        @IL.name("CompareOrdinal")
-        compare_ordinal(str_a: System.String, index_a: int, str_b: System.String, index_b: int, length: int) -> int static;
-
-        @IL.name("CompareTo")
-        compare_to(value: System.Object) -> int;
-
-        @IL.name("CompareTo")
-        compare_to(str_b: System.String) -> int;
-
-        @IL.name("EndsWith")
-        ends_with(value: System.String) -> bool;
-
-        @IL.name("EndsWith")
-        ends_with(value: System.String, comparison_type: System.StringComparison) -> bool;
-
-        @IL.name("EndsWith")
-        ends_with(value: System.String, ignore_case: bool, culture: System.Globalization.CultureInfo) -> bool;
-
-        @IL.name("EndsWith")
-        ends_with(value: char) -> bool;
-
-        @IL.name("Equals")
-        equals(obj: System.Object) -> bool;
-
-        @IL.name("Equals")
-        equals(value: System.String) -> bool;
-
-        @IL.name("Equals")
-        equals(value: System.String, comparison_type: System.StringComparison) -> bool;
-
-        @IL.name("Equals")
-        equals(a: System.String, b: System.String) -> bool static;
-
-        @IL.name("Equals")
-        equals(a: System.String, b: System.String, comparison_type: System.StringComparison) -> bool static;
-
-        @IL.name("GetHashCode")
-        get_hash_code() -> int;
-
-        @IL.name("GetHashCode")
-        get_hash_code(comparison_type: System.StringComparison) -> int;
-
-        @IL.name("GetHashCode")
-        get_hash_code(value: System.ReadOnlySpan[char]) -> int static;
-
-        @IL.name("GetHashCode")
-        get_hash_code(value: System.ReadOnlySpan[char], comparison_type: System.StringComparison) -> int static;
-
-        @IL.name("StartsWith")
-        starts_with(value: System.String) -> bool;
-
-        @IL.name("StartsWith")
-        starts_with(value: System.String, comparison_type: System.StringComparison) -> bool;
-
-        @IL.name("StartsWith")
-        starts_with(value: System.String, ignore_case: bool, culture: System.Globalization.CultureInfo) -> bool;
-
-        @IL.name("StartsWith")
-        starts_with(value: char) -> bool;
-
         // create[TState](length: int, state: TState, action: System.Buffers.SpanAction[char,TState]) -> System.String static;
 
         @IL.name("Clone")
@@ -423,8 +437,8 @@ namespace System is
         @IL.name("Copy")
         copy(str: System.String) -> System.String static;
 
-        // @IL.name("CopyTo")
-        // copy_to(source_index: int, destination: char[], destination_index: int, count: int);
+        @IL.name("CopyTo")
+        copy_to(source_index: int, destination: char[], destination_index: int, count: int);
 
         @IL.name("ToCharArray")
         to_char_array() -> char[];
@@ -440,6 +454,32 @@ namespace System is
 
         @IL.name("GetPinnableReference")
         get_pinnable_reference() -> char ref;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("ToString")
+        to_string(provider: System.IFormatProvider) -> System.String;
+
+        @IL.name.read("GetEnumerator")
+        iterator: System.CharEnumerator;
+        @IL.name("EnumerateRunes")
+        enumerate_runes() -> System.Text.StringRuneEnumerator;
+
+        @IL.name("GetTypeCode")
+        get_type_code() -> System.TypeCode;
+
+        @IL.name("IsNormalized")
+        is_normalized() -> bool;
+
+        @IL.name("IsNormalized")
+        is_normalized(normalization_form: System.Text.NormalizationForm) -> bool;
+
+        @IL.name("Normalize")
+        normalize() -> System.String;
+
+        @IL.name("Normalize")
+        normalize(normalization_form: System.Text.NormalizationForm) -> System.String;
 
         @IL.name("GetType")
         get_type() -> System.Type;
@@ -465,6 +505,9 @@ namespace System is
         // named indexer: Chars
         @IL.name.read("get_Length") 
         length: int;
+
+        @IL.name("Empty")
+        _empty: System.String public;
     si
     @IL.stub()
     @IL.name("class [mscorlib]System.Exception")
@@ -521,6 +564,9 @@ namespace System is
     @IL.stub()
     @IL.name("class [mscorlib]System.Console")
     class Console: System.Object is
+        @IL.name("WriteLine")
+        write_line(value: System.String) static;
+
         @IL.name("WriteLine")
         write_line(format: System.String, arg0: System.Object) static;
 
@@ -601,9 +647,6 @@ namespace System is
 
         @IL.name("SetWindowSize")
         set_window_size(width: int, height: int) static;
-
-        @IL.name("GetCursorPosition")
-        get_cursor_position() -> System.ValueTuple[int,int] static;
 
         @IL.name("Beep")
         beep() static;
@@ -694,9 +737,6 @@ namespace System is
 
         @IL.name("WriteLine")
         write_line(value: System.Object) static;
-
-        @IL.name("WriteLine")
-        write_line(value: System.String) static;
 
         @IL.name("GetType")
         get_type() -> System.Type;
@@ -963,6 +1003,682 @@ namespace System is
 
     si
     @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Guid")
+    struct Guid: System.IFormattable,System.Comparable[System.Guid],System.Equatable[System.Guid] is
+        @IL.name("Parse")
+        parse(input: System.String) -> System.Guid static;
+
+        @IL.name("Parse")
+        parse(input: System.ReadOnlySpan[char]) -> System.Guid static;
+
+        @IL.name("TryParse")
+        try_parse(input: System.String, result: System.Guid ref) -> bool static;
+
+        @IL.name("TryParse")
+        try_parse(input: System.ReadOnlySpan[char], result: System.Guid ref) -> bool static;
+
+        @IL.name("ParseExact")
+        parse_exact(input: System.String, format: System.String) -> System.Guid static;
+
+        @IL.name("ParseExact")
+        parse_exact(input: System.ReadOnlySpan[char], format: System.ReadOnlySpan[char]) -> System.Guid static;
+
+        @IL.name("TryParseExact")
+        try_parse_exact(input: System.String, format: System.String, result: System.Guid ref) -> bool static;
+
+        @IL.name("TryParseExact")
+        try_parse_exact(input: System.ReadOnlySpan[char], format: System.ReadOnlySpan[char], result: System.Guid ref) -> bool static;
+
+        @IL.name("ToByteArray")
+        to_byte_array() -> ubyte[];
+
+        @IL.name("TryWriteBytes")
+        try_write_bytes(destination: System.Span[ubyte]) -> bool;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("Equals")
+        equals(o: System.Object) -> bool;
+
+        @IL.name("Equals")
+        equals(g: System.Guid) -> bool;
+
+        @IL.name("CompareTo")
+        compare_to(value: System.Object) -> int;
+
+        @IL.name("CompareTo")
+        compare_to(value: System.Guid) -> int;
+
+        @IL.name("ToString")
+        to_string(format: System.String) -> System.String;
+
+        @IL.name("ToString")
+        to_string(format: System.String, provider: System.IFormatProvider) -> System.String;
+
+        @IL.name("TryFormat")
+        try_format(destination: System.Span[char], chars_written: int ref, format: System.ReadOnlySpan[char]) -> bool;
+
+        @IL.name("NewGuid")
+        new_guid() -> System.Guid static;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name(".ctor")
+        init(b: ubyte[]);
+        @IL.name(".ctor")
+        init(b: System.ReadOnlySpan[ubyte]);
+        @IL.name(".ctor")
+        init(a: uint, b: ushort, c: ushort, d: ubyte, e: ubyte, f: ubyte, g: ubyte, h: ubyte, i: ubyte, j: ubyte, k: ubyte);
+        @IL.name(".ctor")
+        init(a: int, b: short, c: short, d: ubyte[]);
+        @IL.name(".ctor")
+        init(a: int, b: short, c: short, d: ubyte, e: ubyte, f: ubyte, g: ubyte, h: ubyte, i: ubyte, j: ubyte, k: ubyte);
+        @IL.name(".ctor")
+        init(g: System.String);
+        @IL.name("Empty")
+        _empty: System.Guid public;
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Type")
+    class Type: System.Reflection.MemberInfo,System.Reflection.ICustomAttributeProvider,System.Reflection.IReflect is
+        @IL.name("GetField")
+        get_field(name: System.String) -> System.Reflection.FieldInfo;
+
+        @IL.name("GetField")
+        get_field(name: System.String, binding_attr: System.Reflection.BindingFlags) -> System.Reflection.FieldInfo;
+
+        @IL.name("GetFields")
+        get_fields() -> System.Reflection.FieldInfo[];
+
+        @IL.name("GetFields")
+        get_fields(binding_attr: System.Reflection.BindingFlags) -> System.Reflection.FieldInfo[];
+
+        @IL.name("GetMember")
+        get_member(name: System.String) -> System.Reflection.MemberInfo[];
+
+        @IL.name("GetMember")
+        get_member(name: System.String, binding_attr: System.Reflection.BindingFlags) -> System.Reflection.MemberInfo[];
+
+        @IL.name("GetMember")
+        get_member(name: System.String, type: System.Reflection.MemberTypes, binding_attr: System.Reflection.BindingFlags) -> System.Reflection.MemberInfo[];
+
+        @IL.name("GetMembers")
+        get_members() -> System.Reflection.MemberInfo[];
+
+        @IL.name("GetMembers")
+        get_members(binding_attr: System.Reflection.BindingFlags) -> System.Reflection.MemberInfo[];
+
+        @IL.name("GetMethod")
+        get_method(name: System.String) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetMethod")
+        get_method(name: System.String, binding_attr: System.Reflection.BindingFlags) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetMethod")
+        get_method(name: System.String, types: System.Type[]) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetMethod")
+        get_method(name: System.String, types: System.Type[], modifiers: System.Reflection.ParameterModifier[]) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetMethod")
+        get_method(name: System.String, binding_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, types: System.Type[], modifiers: System.Reflection.ParameterModifier[]) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetMethod")
+        get_method(name: System.String, binding_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, call_convention: System.Reflection.CallingConventions, types: System.Type[], modifiers: System.Reflection.ParameterModifier[]) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetMethod")
+        get_method(name: System.String, generic_parameter_count: int, types: System.Type[]) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetMethod")
+        get_method(name: System.String, generic_parameter_count: int, types: System.Type[], modifiers: System.Reflection.ParameterModifier[]) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetMethod")
+        get_method(name: System.String, generic_parameter_count: int, binding_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, types: System.Type[], modifiers: System.Reflection.ParameterModifier[]) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetMethod")
+        get_method(name: System.String, generic_parameter_count: int, binding_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, call_convention: System.Reflection.CallingConventions, types: System.Type[], modifiers: System.Reflection.ParameterModifier[]) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetMethods")
+        get_methods() -> System.Reflection.MethodInfo[];
+
+        @IL.name("GetMethods")
+        get_methods(binding_attr: System.Reflection.BindingFlags) -> System.Reflection.MethodInfo[];
+
+        @IL.name("GetNestedType")
+        get_nested_type(name: System.String) -> System.Type;
+
+        @IL.name("GetNestedType")
+        get_nested_type(name: System.String, binding_attr: System.Reflection.BindingFlags) -> System.Type;
+
+        @IL.name("GetNestedTypes")
+        get_nested_types() -> System.Type[];
+
+        @IL.name("GetNestedTypes")
+        get_nested_types(binding_attr: System.Reflection.BindingFlags) -> System.Type[];
+
+        @IL.name("GetProperty")
+        get_property(name: System.String) -> System.Reflection.PropertyInfo;
+
+        @IL.name("GetProperty")
+        get_property(name: System.String, binding_attr: System.Reflection.BindingFlags) -> System.Reflection.PropertyInfo;
+
+        @IL.name("GetProperty")
+        get_property(name: System.String, return_type: System.Type) -> System.Reflection.PropertyInfo;
+
+        @IL.name("GetProperty")
+        get_property(name: System.String, types: System.Type[]) -> System.Reflection.PropertyInfo;
+
+        @IL.name("GetProperty")
+        get_property(name: System.String, return_type: System.Type, types: System.Type[]) -> System.Reflection.PropertyInfo;
+
+        @IL.name("GetProperty")
+        get_property(name: System.String, return_type: System.Type, types: System.Type[], modifiers: System.Reflection.ParameterModifier[]) -> System.Reflection.PropertyInfo;
+
+        @IL.name("GetProperty")
+        get_property(name: System.String, binding_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, return_type: System.Type, types: System.Type[], modifiers: System.Reflection.ParameterModifier[]) -> System.Reflection.PropertyInfo;
+
+        @IL.name("GetProperties")
+        get_properties() -> System.Reflection.PropertyInfo[];
+
+        @IL.name("GetProperties")
+        get_properties(binding_attr: System.Reflection.BindingFlags) -> System.Reflection.PropertyInfo[];
+
+        @IL.name("GetDefaultMembers")
+        get_default_members() -> System.Reflection.MemberInfo[];
+
+        @IL.name("GetTypeHandle")
+        get_type_handle(o: System.Object) -> System.RuntimeTypeHandle static;
+
+        @IL.name("GetTypeArray")
+        get_type_array(args: System.Object[]) -> System.Type[] static;
+
+        @IL.name("GetTypeCode")
+        get_type_code(type: System.Type) -> System.TypeCode static;
+
+        @IL.name("GetTypeFromCLSID")
+        get_type_from_c_l_s_i_d(clsid: System.Guid) -> System.Type static;
+
+        @IL.name("GetTypeFromCLSID")
+        get_type_from_c_l_s_i_d(clsid: System.Guid, throw_on_error: bool) -> System.Type static;
+
+        @IL.name("GetTypeFromCLSID")
+        get_type_from_c_l_s_i_d(clsid: System.Guid, server: System.String) -> System.Type static;
+
+        @IL.name("GetTypeFromProgID")
+        get_type_from_prog_i_d(prog_i_d: System.String) -> System.Type static;
+
+        @IL.name("GetTypeFromProgID")
+        get_type_from_prog_i_d(prog_i_d: System.String, throw_on_error: bool) -> System.Type static;
+
+        @IL.name("GetTypeFromProgID")
+        get_type_from_prog_i_d(prog_i_d: System.String, server: System.String) -> System.Type static;
+
+        @IL.name("InvokeMember")
+        invoke_member(name: System.String, invoke_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, target: System.Object, args: System.Object[]) -> System.Object;
+
+        @IL.name("InvokeMember")
+        invoke_member(name: System.String, invoke_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, target: System.Object, args: System.Object[], culture: System.Globalization.CultureInfo) -> System.Object;
+
+        @IL.name("InvokeMember")
+        invoke_member(name: System.String, invoke_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, target: System.Object, args: System.Object[], modifiers: System.Reflection.ParameterModifier[], culture: System.Globalization.CultureInfo, named_parameters: System.String[]) -> System.Object;
+
+        @IL.name("GetInterface")
+        get_interface(name: System.String) -> System.Type;
+
+        @IL.name("GetInterface")
+        get_interface(name: System.String, ignore_case: bool) -> System.Type;
+
+        @IL.name("GetInterfaces")
+        get_interfaces() -> System.Type[];
+
+        @IL.name("GetInterfaceMap")
+        get_interface_map(interface_type: System.Type) -> System.Reflection.InterfaceMapping;
+
+        @IL.name("IsInstanceOfType")
+        is_instance_of_type(o: System.Object) -> bool;
+
+        @IL.name("IsEquivalentTo")
+        is_equivalent_to(other: System.Type) -> bool;
+
+        @IL.name("GetEnumUnderlyingType")
+        get_enum_underlying_type() -> System.Type;
+
+        @IL.name("GetEnumValues")
+        get_enum_values() -> System.Array;
+
+        @IL.name("MakeArrayType")
+        make_array_type() -> System.Type;
+
+        @IL.name("MakeArrayType")
+        make_array_type(rank: int) -> System.Type;
+
+        @IL.name("MakeByRefType")
+        make_by_ref_type() -> System.Type;
+
+        @IL.name("MakeGenericType")
+        make_generic_type(type_arguments: System.Type[]) -> System.Type;
+
+        @IL.name("MakePointerType")
+        make_pointer_type() -> System.Type;
+
+        @IL.name("MakeGenericSignatureType")
+        make_generic_signature_type(generic_type_definition: System.Type, type_arguments: System.Type[]) -> System.Type static;
+
+        @IL.name("MakeGenericMethodParameter")
+        make_generic_method_parameter(position: int) -> System.Type static;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("Equals")
+        equals(o: System.Object) -> bool;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("Equals")
+        equals(o: System.Type) -> bool;
+
+        @IL.name("ReflectionOnlyGetType")
+        reflection_only_get_type(type_name: System.String, throw_if_not_found: bool, ignore_case: bool) -> System.Type static;
+
+        @IL.name("IsEnumDefined")
+        is_enum_defined(value: System.Object) -> bool;
+
+        @IL.name("GetEnumName")
+        get_enum_name(value: System.Object) -> System.String;
+
+        @IL.name("GetEnumNames")
+        get_enum_names() -> System.String[];
+
+        @IL.name("FindInterfaces")
+        find_interfaces(filter: System.Reflection.TypeFilter, filter_criteria: System.Object) -> System.Type[];
+
+        @IL.name("FindMembers")
+        find_members(member_type: System.Reflection.MemberTypes, binding_attr: System.Reflection.BindingFlags, filter: System.Reflection.MemberFilter, filter_criteria: System.Object) -> System.Reflection.MemberInfo[];
+
+        @IL.name("IsSubclassOf")
+        is_subclass_of(c: System.Type) -> bool;
+
+        @IL.name("IsAssignableFrom")
+        is_assignable_from(c: System.Type) -> bool;
+
+        @IL.name("GetType")
+        get_type(type_name: System.String, throw_on_error: bool, ignore_case: bool) -> System.Type static;
+
+        @IL.name("GetType")
+        get_type(type_name: System.String, throw_on_error: bool) -> System.Type static;
+
+        @IL.name("GetType")
+        get_type(type_name: System.String) -> System.Type static;
+
+        @IL.name("GetType")
+        get_type(type_name: System.String, assembly_resolver: Ghul.FUNCTION_1[System.Reflection.AssemblyName,System.Reflection.Assembly], type_resolver: Ghul.FUNCTION_3[System.Reflection.Assembly,System.String,bool,System.Type]) -> System.Type static;
+
+        @IL.name("GetType")
+        get_type(type_name: System.String, assembly_resolver: Ghul.FUNCTION_1[System.Reflection.AssemblyName,System.Reflection.Assembly], type_resolver: Ghul.FUNCTION_3[System.Reflection.Assembly,System.String,bool,System.Type], throw_on_error: bool) -> System.Type static;
+
+        @IL.name("GetType")
+        get_type(type_name: System.String, assembly_resolver: Ghul.FUNCTION_1[System.Reflection.AssemblyName,System.Reflection.Assembly], type_resolver: Ghul.FUNCTION_3[System.Reflection.Assembly,System.String,bool,System.Type], throw_on_error: bool, ignore_case: bool) -> System.Type static;
+
+        @IL.name("GetTypeFromProgID")
+        get_type_from_prog_i_d(prog_i_d: System.String, server: System.String, throw_on_error: bool) -> System.Type static;
+
+        @IL.name("GetTypeFromCLSID")
+        get_type_from_c_l_s_i_d(clsid: System.Guid, server: System.String, throw_on_error: bool) -> System.Type static;
+
+        @IL.name("GetTypeFromHandle")
+        get_type_from_handle(handle: System.RuntimeTypeHandle) -> System.Type static;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name("GetElementType")
+        get_element_type() -> System.Type;
+
+        @IL.name("GetArrayRank")
+        get_array_rank() -> int;
+
+        @IL.name("GetGenericTypeDefinition")
+        get_generic_type_definition() -> System.Type;
+
+        @IL.name("GetGenericArguments")
+        get_generic_arguments() -> System.Type[];
+
+        @IL.name("GetGenericParameterConstraints")
+        get_generic_parameter_constraints() -> System.Type[];
+
+        @IL.name("GetConstructor")
+        get_constructor(types: System.Type[]) -> System.Reflection.ConstructorInfo;
+
+        @IL.name("GetConstructor")
+        get_constructor(binding_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, types: System.Type[], modifiers: System.Reflection.ParameterModifier[]) -> System.Reflection.ConstructorInfo;
+
+        @IL.name("GetConstructor")
+        get_constructor(binding_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, call_convention: System.Reflection.CallingConventions, types: System.Type[], modifiers: System.Reflection.ParameterModifier[]) -> System.Reflection.ConstructorInfo;
+
+        @IL.name("GetConstructors")
+        get_constructors() -> System.Reflection.ConstructorInfo[];
+
+        @IL.name("GetConstructors")
+        get_constructors(binding_attr: System.Reflection.BindingFlags) -> System.Reflection.ConstructorInfo[];
+
+        @IL.name("GetEvent")
+        get_event(name: System.String) -> System.Reflection.EventInfo;
+
+        @IL.name("GetEvent")
+        get_event(name: System.String, binding_attr: System.Reflection.BindingFlags) -> System.Reflection.EventInfo;
+
+        @IL.name("GetEvents")
+        get_events() -> System.Reflection.EventInfo[];
+
+        @IL.name("GetEvents")
+        get_events(binding_attr: System.Reflection.BindingFlags) -> System.Reflection.EventInfo[];
+
+        @IL.name("HasSameMetadataDefinitionAs")
+        has_same_metadata_definition_as(other: System.Reflection.MemberInfo) -> bool;
+
+        @IL.name("IsDefined")
+        is_defined(attribute_type: System.Type, inherit: bool) -> bool;
+
+        @IL.name("GetCustomAttributes")
+        get_custom_attributes(inherit: bool) -> System.Object[];
+
+        @IL.name("GetCustomAttributes")
+        get_custom_attributes(attribute_type: System.Type, inherit: bool) -> System.Object[];
+
+        @IL.name("GetCustomAttributesData")
+        get_custom_attributes_data() -> Collections.MutableList[System.Reflection.CustomAttributeData];
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name.read("get_IsInterface") 
+        is_interface: bool;
+
+        @IL.name.read("get_MemberType") 
+        member_type: System.Reflection.MemberTypes;
+
+        @IL.name.read("get_Namespace") 
+        namespace_: System.String;
+
+        @IL.name.read("get_AssemblyQualifiedName") 
+        assembly_qualified_name: System.String;
+
+        @IL.name.read("get_FullName") 
+        full_name: System.String;
+
+        @IL.name.read("get_Assembly") 
+        assembly: System.Reflection.Assembly;
+
+        @IL.name.read("get_Module") 
+        module: System.Reflection.Module;
+
+        @IL.name.read("get_IsNested") 
+        is_nested: bool;
+
+        @IL.name.read("get_DeclaringType") 
+        declaring_type: System.Type;
+
+        @IL.name.read("get_DeclaringMethod") 
+        declaring_method: System.Reflection.MethodBase;
+
+        @IL.name.read("get_ReflectedType") 
+        reflected_type: System.Type;
+
+        @IL.name.read("get_UnderlyingSystemType") 
+        underlying_system_type: System.Type;
+
+        @IL.name.read("get_IsTypeDefinition") 
+        is_type_definition: bool;
+
+        @IL.name.read("get_IsArray") 
+        is_array: bool;
+
+        @IL.name.read("get_IsByRef") 
+        is_by_ref: bool;
+
+        @IL.name.read("get_IsPointer") 
+        is_pointer: bool;
+
+        @IL.name.read("get_IsConstructedGenericType") 
+        is_constructed_generic_type: bool;
+
+        @IL.name.read("get_IsGenericParameter") 
+        is_generic_parameter: bool;
+
+        @IL.name.read("get_IsGenericTypeParameter") 
+        is_generic_type_parameter: bool;
+
+        @IL.name.read("get_IsGenericMethodParameter") 
+        is_generic_method_parameter: bool;
+
+        @IL.name.read("get_IsGenericType") 
+        is_generic_type: bool;
+
+        @IL.name.read("get_IsGenericTypeDefinition") 
+        is_generic_type_definition: bool;
+
+        @IL.name.read("get_IsSZArray") 
+        is_s_z_array: bool;
+
+        @IL.name.read("get_IsVariableBoundArray") 
+        is_variable_bound_array: bool;
+
+        @IL.name.read("get_IsByRefLike") 
+        is_by_ref_like: bool;
+
+        @IL.name.read("get_HasElementType") 
+        has_element_type: bool;
+
+        @IL.name.read("get_GenericTypeArguments") 
+        generic_type_arguments: System.Type[];
+
+        @IL.name.read("get_GenericParameterPosition") 
+        generic_parameter_position: int;
+
+        @IL.name.read("get_GenericParameterAttributes") 
+        generic_parameter_attributes: System.Reflection.GenericParameterAttributes;
+
+        @IL.name.read("get_Attributes") 
+        attributes: System.Reflection.TypeAttributes;
+
+        @IL.name.read("get_IsAbstract") 
+        is_abstract: bool;
+
+        @IL.name.read("get_IsImport") 
+        is_import: bool;
+
+        @IL.name.read("get_IsSealed") 
+        is_sealed: bool;
+
+        @IL.name.read("get_IsSpecialName") 
+        is_special_name: bool;
+
+        @IL.name.read("get_IsClass") 
+        is_class: bool;
+
+        @IL.name.read("get_IsNestedAssembly") 
+        is_nested_assembly: bool;
+
+        @IL.name.read("get_IsNestedFamANDAssem") 
+        is_nested_fam_a_n_d_assem: bool;
+
+        @IL.name.read("get_IsNestedFamily") 
+        is_nested_family: bool;
+
+        @IL.name.read("get_IsNestedFamORAssem") 
+        is_nested_fam_o_r_assem: bool;
+
+        @IL.name.read("get_IsNestedPrivate") 
+        is_nested_private: bool;
+
+        @IL.name.read("get_IsNestedPublic") 
+        is_nested_public: bool;
+
+        @IL.name.read("get_IsNotPublic") 
+        is_not_public: bool;
+
+        @IL.name.read("get_IsPublic") 
+        is_public: bool;
+
+        @IL.name.read("get_IsAutoLayout") 
+        is_auto_layout: bool;
+
+        @IL.name.read("get_IsExplicitLayout") 
+        is_explicit_layout: bool;
+
+        @IL.name.read("get_IsLayoutSequential") 
+        is_layout_sequential: bool;
+
+        @IL.name.read("get_IsAnsiClass") 
+        is_ansi_class: bool;
+
+        @IL.name.read("get_IsAutoClass") 
+        is_auto_class: bool;
+
+        @IL.name.read("get_IsUnicodeClass") 
+        is_unicode_class: bool;
+
+        @IL.name.read("get_IsCOMObject") 
+        is_c_o_m_object: bool;
+
+        @IL.name.read("get_IsContextful") 
+        is_contextful: bool;
+
+        @IL.name.read("get_IsEnum") 
+        is_enum: bool;
+
+        @IL.name.read("get_IsMarshalByRef") 
+        is_marshal_by_ref: bool;
+
+        @IL.name.read("get_IsPrimitive") 
+        is_primitive: bool;
+
+        @IL.name.read("get_IsValueType") 
+        is_value_type: bool;
+
+        @IL.name.read("get_IsSignatureType") 
+        is_signature_type: bool;
+
+        @IL.name.read("get_IsSecurityCritical") 
+        is_security_critical: bool;
+
+        @IL.name.read("get_IsSecuritySafeCritical") 
+        is_security_safe_critical: bool;
+
+        @IL.name.read("get_IsSecurityTransparent") 
+        is_security_transparent: bool;
+
+        @IL.name.read("get_StructLayoutAttribute") 
+        struct_layout_attribute: System.Runtime.InteropServices.StructLayoutAttribute;
+
+        @IL.name.read("get_TypeInitializer") 
+        type_initializer: System.Reflection.ConstructorInfo;
+
+        @IL.name.read("get_TypeHandle") 
+        type_handle: System.RuntimeTypeHandle;
+
+        @IL.name.read("get_GUID") 
+        guid: System.Guid;
+
+        @IL.name.read("get_BaseType") 
+        base_type: System.Type;
+
+        @IL.name.read("get_DefaultBinder") 
+        default_binder: System.Reflection.Binder static;
+
+        @IL.name.read("get_IsSerializable") 
+        is_serializable: bool;
+
+        @IL.name.read("get_ContainsGenericParameters") 
+        contains_generic_parameters: bool;
+
+        @IL.name.read("get_IsVisible") 
+        is_visible: bool;
+
+        @IL.name.read("get_Name") 
+        name: System.String;
+
+        @IL.name.read("get_CustomAttributes") 
+        custom_attributes: Collections.Iterable[System.Reflection.CustomAttributeData];
+
+        @IL.name.read("get_IsCollectible") 
+        is_collectible: bool;
+
+        @IL.name.read("get_MetadataToken") 
+        metadata_token: int;
+
+        @IL.name("Delimiter")
+        _delimiter: char public;
+        @IL.name("EmptyTypes")
+        _empty_types: System.Type[] public;
+        @IL.name("Missing")
+        _missing: System.Object public;
+        @IL.name("FilterAttribute")
+        _filter_attribute: System.Reflection.MemberFilter public;
+        @IL.name("FilterName")
+        _filter_name: System.Reflection.MemberFilter public;
+        @IL.name("FilterNameIgnoreCase")
+        _filter_name_ignore_case: System.Reflection.MemberFilter public;
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.ModuleHandle")
+    struct ModuleHandle is
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("Equals")
+        equals(handle: System.ModuleHandle) -> bool;
+
+        @IL.name("GetRuntimeTypeHandleFromMetadataToken")
+        get_runtime_type_handle_from_metadata_token(type_token: int) -> System.RuntimeTypeHandle;
+
+        @IL.name("ResolveTypeHandle")
+        resolve_type_handle(type_token: int) -> System.RuntimeTypeHandle;
+
+        @IL.name("ResolveTypeHandle")
+        resolve_type_handle(type_token: int, type_instantiation_context: System.RuntimeTypeHandle[], method_instantiation_context: System.RuntimeTypeHandle[]) -> System.RuntimeTypeHandle;
+
+        @IL.name("GetRuntimeMethodHandleFromMetadataToken")
+        get_runtime_method_handle_from_metadata_token(method_token: int) -> System.RuntimeMethodHandle;
+
+        @IL.name("ResolveMethodHandle")
+        resolve_method_handle(method_token: int) -> System.RuntimeMethodHandle;
+
+        @IL.name("ResolveMethodHandle")
+        resolve_method_handle(method_token: int, type_instantiation_context: System.RuntimeTypeHandle[], method_instantiation_context: System.RuntimeTypeHandle[]) -> System.RuntimeMethodHandle;
+
+        @IL.name("GetRuntimeFieldHandleFromMetadataToken")
+        get_runtime_field_handle_from_metadata_token(field_token: int) -> System.RuntimeFieldHandle;
+
+        @IL.name("ResolveFieldHandle")
+        resolve_field_handle(field_token: int) -> System.RuntimeFieldHandle;
+
+        @IL.name("ResolveFieldHandle")
+        resolve_field_handle(field_token: int, type_instantiation_context: System.RuntimeTypeHandle[], method_instantiation_context: System.RuntimeTypeHandle[]) -> System.RuntimeFieldHandle;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name.read("get_MDStreamVersion") 
+        mdstream_version: int;
+
+        @IL.name("EmptyHandle")
+        _empty_handle: System.ModuleHandle public;
+    si
+    @IL.stub()
     @IL.name("class [mscorlib]System.MulticastDelegate")
     class MulticastDelegate: System.Delegate,System.ICloneable,System.Runtime.Serialization.ISerializable is
     si
@@ -974,32 +1690,6 @@ namespace System is
     @IL.name("class [mscorlib]System.AsyncCallback")
     class AsyncCallback: System.MulticastDelegate,System.ICloneable,System.Runtime.Serialization.ISerializable is
     si
-
-    @IL.stub()
-    @IL.built_in_type("object")
-    class Object is
-        // address: Object ptr => null;
-        ClassName: String => null;
-
-        @IL.name(".ctor")
-        init();
-
-        @IL.name("Clone")
-        clone() -> Object;
-
-        @IL.name("ToString")
-        toString() -> String;
-
-        @IL.name("ToString")
-        to_string() -> String;
-
-        @IL.name("GetHashCode")
-        hash() -> int;
-
-        // FIXME: just to silence some false positive errors when compiling compiler itself:
-        opCompare(other: Object) -> int;
-    si
-
     @IL.stub()
     @IL.name("class [mscorlib]System.IAsyncResult")
     trait IAsyncResult is
@@ -1009,8 +1699,8 @@ namespace System is
     class Delegate: System.Object,System.ICloneable,System.Runtime.Serialization.ISerializable is
     si
 @IL.stub()
-@IL.name("class [mscorlib]System.Type")
-class Type: System.Reflection.MemberInfo,System.Reflection.ICustomAttributeProvider,System.Reflection.IReflect is
+@IL.name("class [mscorlib]System.IValueTupleInternal")
+trait IValueTupleInternal: System.Runtime.CompilerServices.ITuple is
 si
 @IL.stub()
 @IL.name("class [mscorlib]System.IConvertible")
@@ -1025,6 +1715,10 @@ si
 struct StringComparison is
 si
 @IL.stub()
+@IL.name("valuetype [mscorlib]System.ReadOnlySpan`1")
+struct ReadOnlySpan[T] is
+si
+@IL.stub()
 @IL.name("class [mscorlib]System.IFormatProvider")
 trait IFormatProvider is
 si
@@ -1037,10 +1731,6 @@ si
 struct TypeCode is
 si
 @IL.stub()
-@IL.name("valuetype [mscorlib]System.ReadOnlySpan`1")
-struct ReadOnlySpan[T] is
-si
-@IL.stub()
 @IL.name("valuetype [mscorlib]System.Span`1")
 struct Span[T] is
 si
@@ -1049,16 +1739,12 @@ si
 struct Single: System.IConvertible,System.IFormattable,System.Comparable[System.Single],System.Equatable[System.Single] is
 si
 @IL.stub()
-@IL.name("class [mscorlib]System.IFormattable")
-trait IFormattable is
-si
-@IL.stub()
 @IL.name("valuetype [mscorlib]System.Double")
 struct Double: System.IConvertible,System.IFormattable,System.Comparable[System.Double],System.Equatable[System.Double] is
 si
 @IL.stub()
 @IL.name("valuetype [mscorlib]System.Decimal")
-struct Decimal: System.IFormattable,System.IConvertible,System.Comparable[System.Decimal],System.Equatable[System.Decimal],System.Runtime.Serialization.ISerializable,System.Runtime.Serialization.IDeserializationCallback is
+struct Decimal: System.IFormattable,System.IConvertible,System.Comparable[System.Decimal],System.Equatable[System.Decimal],System.Runtime.Serialization.IDeserializationCallback is
 si
 @IL.stub()
 @IL.name("valuetype [mscorlib]System.ReadOnlyMemory`1")
@@ -1069,16 +1755,8 @@ si
 struct ConsoleKeyInfo is
 si
 @IL.stub()
-@IL.name("valuetype [mscorlib]System.ValueTuple`2")
-struct ValueTuple[T1,T2]: System.Equatable[System.ValueTuple[T1,T2]],System.Comparable[System.ValueTuple[T1,T2]],System.Runtime.CompilerServices.ITuple is
-si
-@IL.stub()
 @IL.name("valuetype [mscorlib]System.ConsoleColor")
 struct ConsoleColor is
-si
-@IL.stub()
-@IL.name("class [mscorlib]System.IAsyncDisposable")
-trait IAsyncDisposable is
 si
 @IL.stub()
 @IL.name("class [mscorlib]System.MarshalByRefObject")
@@ -1099,5 +1777,57 @@ si
 @IL.stub()
 @IL.name("class [mscorlib]System.Comparison`1")
 class Comparison[T]: System.MulticastDelegate,System.ICloneable,System.Runtime.Serialization.ISerializable is
+si
+@IL.stub()
+@IL.name("class [mscorlib]System.IFormattable")
+trait IFormattable is
+si
+@IL.stub()
+@IL.name("class [mscorlib]System.Version")
+class Version: System.Object,System.ICloneable,System.Comparable[System.Version],System.Equatable[System.Version] is
+si
+@IL.stub()
+@IL.name("valuetype [mscorlib]System.RuntimeTypeHandle")
+struct RuntimeTypeHandle: System.Runtime.Serialization.ISerializable is
+si
+@IL.stub()
+@IL.name("class [mscorlib]System.Array")
+class Array: System.Object,System.ICloneable is
+si
+@IL.stub()
+@IL.name("class [mscorlib]System.Attribute")
+class Attribute: System.Object is
+si
+@IL.stub()
+@IL.name("valuetype [mscorlib]System.RuntimeMethodHandle")
+struct RuntimeMethodHandle: System.Runtime.Serialization.ISerializable is
+si
+@IL.stub()
+@IL.name("valuetype [mscorlib]System.RuntimeFieldHandle")
+struct RuntimeFieldHandle: System.Runtime.Serialization.ISerializable is
+si
+@IL.stub()
+@IL.name("valuetype [mscorlib]System.TypedReference")
+struct TypedReference is
+si
+@IL.stub()
+@IL.name("class [mscorlib]System.IAsyncDisposable")
+trait IAsyncDisposable is
+si
+@IL.stub()
+@IL.name("valuetype [mscorlib]System.Memory`1")
+struct Memory[T]: System.Equatable[System.Memory[T]] is
+si
+@IL.stub()
+@IL.name("valuetype [mscorlib]System.TimeSpan")
+struct TimeSpan: System.Comparable[System.TimeSpan],System.Equatable[System.TimeSpan],System.IFormattable is
+si
+@IL.stub()
+@IL.name("valuetype [mscorlib]System.Nullable`1")
+struct Nullable[T] is
+si
+@IL.stub()
+@IL.name("class [mscorlib]System.AggregateException")
+class AggregateException: System.Exception,System.Runtime.Serialization.ISerializable is
 si
 si

--- a/lib/dotnet/stubs/system.io.ghul
+++ b/lib/dotnet/stubs/system.io.ghul
@@ -1,5 +1,188 @@
 namespace System.IO is
     @IL.stub()
+    @IL.name("class [mscorlib]System.IO.FileStream")
+    class FileStream: System.IO.Stream,System.IDisposable,System.IAsyncDisposable is
+        @IL.name("Lock")
+        lock(position: long, length: long);
+
+        @IL.name("Unlock")
+        unlock(position: long, length: long);
+
+        @IL.name("FlushAsync")
+        flush_async(cancellation_token: System.Threading.CancellationToken) -> System.Threading.Tasks.Task_0;
+
+        @IL.name("Read")
+        read(array: ubyte[], offset: int, count: int) -> int;
+
+        @IL.name("Read")
+        read(buffer: System.Span[ubyte]) -> int;
+
+        @IL.name("ReadAsync")
+        read_async(buffer: ubyte[], offset: int, count: int, cancellation_token: System.Threading.CancellationToken) -> System.Threading.Tasks.Task[int];
+
+        @IL.name("ReadAsync")
+        read_async(buffer: System.Memory[ubyte], cancellation_token: System.Threading.CancellationToken) -> System.Threading.Tasks.ValueTask[int];
+
+        @IL.name("Write")
+        write(array: ubyte[], offset: int, count: int);
+
+        @IL.name("Write")
+        write(buffer: System.ReadOnlySpan[ubyte]);
+
+        @IL.name("WriteAsync")
+        write_async(buffer: ubyte[], offset: int, count: int, cancellation_token: System.Threading.CancellationToken) -> System.Threading.Tasks.Task_0;
+
+        @IL.name("WriteAsync")
+        write_async(buffer: System.ReadOnlyMemory[ubyte], cancellation_token: System.Threading.CancellationToken) -> System.Threading.Tasks.ValueTask_0;
+
+        @IL.name("Flush")
+        flush();
+
+        @IL.name("Flush")
+        flush(flush_to_disk: bool);
+
+        @IL.name("SetLength")
+        set_length(value: long);
+
+        @IL.name("ReadByte")
+        read_byte() -> int;
+
+        @IL.name("WriteByte")
+        write_byte(value: ubyte);
+
+        @IL.name("BeginRead")
+        begin_read(array: ubyte[], offset: int, num_bytes: int, callback: System.AsyncCallback, state: System.Object) -> System.IAsyncResult;
+
+        @IL.name("BeginWrite")
+        begin_write(array: ubyte[], offset: int, num_bytes: int, callback: System.AsyncCallback, state: System.Object) -> System.IAsyncResult;
+
+        @IL.name("EndRead")
+        end_read(async_result: System.IAsyncResult) -> int;
+
+        @IL.name("EndWrite")
+        end_write(async_result: System.IAsyncResult);
+
+        @IL.name("DisposeAsync")
+        dispose_async() -> System.Threading.Tasks.ValueTask_0;
+
+        @IL.name("CopyToAsync")
+        copy_to_async(destination: System.IO.Stream, buffer_size: int, cancellation_token: System.Threading.CancellationToken) -> System.Threading.Tasks.Task_0;
+
+        @IL.name("Seek")
+        seek(offset: long, origin: System.IO.SeekOrigin) -> long;
+
+        @IL.name("CopyToAsync")
+        copy_to_async(destination: System.IO.Stream) -> System.Threading.Tasks.Task_0;
+
+        @IL.name("CopyToAsync")
+        copy_to_async(destination: System.IO.Stream, buffer_size: int) -> System.Threading.Tasks.Task_0;
+
+        @IL.name("CopyToAsync")
+        copy_to_async(destination: System.IO.Stream, cancellation_token: System.Threading.CancellationToken) -> System.Threading.Tasks.Task_0;
+
+        @IL.name("CopyTo")
+        copy_to(destination: System.IO.Stream);
+
+        @IL.name("CopyTo")
+        copy_to(destination: System.IO.Stream, buffer_size: int);
+
+        @IL.name("Close")
+        close();
+
+        @IL.name("Dispose")
+        dispose();
+
+        @IL.name("FlushAsync")
+        flush_async() -> System.Threading.Tasks.Task_0;
+
+        @IL.name("ReadAsync")
+        read_async(buffer: ubyte[], offset: int, count: int) -> System.Threading.Tasks.Task[int];
+
+        @IL.name("WriteAsync")
+        write_async(buffer: ubyte[], offset: int, count: int) -> System.Threading.Tasks.Task_0;
+
+        @IL.name("GetLifetimeService")
+        get_lifetime_service() -> System.Object;
+
+        @IL.name("InitializeLifetimeService")
+        initialize_lifetime_service() -> System.Object;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name(".ctor")
+        init(handle: word, access: System.IO.FileAccess);
+        @IL.name(".ctor")
+        init(handle: word, access: System.IO.FileAccess, owns_handle: bool);
+        @IL.name(".ctor")
+        init(handle: word, access: System.IO.FileAccess, owns_handle: bool, buffer_size: int);
+        @IL.name(".ctor")
+        init(handle: word, access: System.IO.FileAccess, owns_handle: bool, buffer_size: int, is_async: bool);
+        @IL.name(".ctor")
+        init(handle: Microsoft.Win32.SafeHandles.SafeFileHandle, access: System.IO.FileAccess);
+        @IL.name(".ctor")
+        init(handle: Microsoft.Win32.SafeHandles.SafeFileHandle, access: System.IO.FileAccess, buffer_size: int);
+        @IL.name(".ctor")
+        init(handle: Microsoft.Win32.SafeHandles.SafeFileHandle, access: System.IO.FileAccess, buffer_size: int, is_async: bool);
+        @IL.name(".ctor")
+        init(path: System.String, mode: System.IO.FileMode);
+        @IL.name(".ctor")
+        init(path: System.String, mode: System.IO.FileMode, access: System.IO.FileAccess);
+        @IL.name(".ctor")
+        init(path: System.String, mode: System.IO.FileMode, access: System.IO.FileAccess, share: System.IO.FileShare);
+        @IL.name(".ctor")
+        init(path: System.String, mode: System.IO.FileMode, access: System.IO.FileAccess, share: System.IO.FileShare, buffer_size: int);
+        @IL.name(".ctor")
+        init(path: System.String, mode: System.IO.FileMode, access: System.IO.FileAccess, share: System.IO.FileShare, buffer_size: int, use_async: bool);
+        @IL.name(".ctor")
+        init(path: System.String, mode: System.IO.FileMode, access: System.IO.FileAccess, share: System.IO.FileShare, buffer_size: int, options: System.IO.FileOptions);
+        @IL.name.read("get_Handle") 
+        handle: word;
+
+        @IL.name.read("get_CanRead") 
+        can_read: bool;
+
+        @IL.name.read("get_CanWrite") 
+        can_write: bool;
+
+        @IL.name.read("get_SafeFileHandle") 
+        safe_file_handle: Microsoft.Win32.SafeHandles.SafeFileHandle;
+
+        @IL.name.read("get_Name") 
+        name: System.String;
+
+        @IL.name.read("get_IsAsync") 
+        is_async: bool;
+
+        @IL.name.read("get_Length") 
+        length: long;
+
+        @IL.name.read("get_Position") @IL.name.assign("set_Position") 
+        position: long;
+
+        @IL.name.read("get_CanSeek") 
+        can_seek: bool;
+
+        @IL.name.read("get_CanTimeout") 
+        can_timeout: bool;
+
+        @IL.name.read("get_ReadTimeout") @IL.name.assign("set_ReadTimeout") 
+        read_timeout: int;
+
+        @IL.name.read("get_WriteTimeout") @IL.name.assign("set_WriteTimeout") 
+        write_timeout: int;
+
+    si
+    @IL.stub()
     @IL.name("class [mscorlib]System.IO.Stream")
     class Stream: System.MarshalByRefObject,System.IDisposable,System.IAsyncDisposable is
     si
@@ -10,5 +193,25 @@ namespace System.IO is
     @IL.stub()
     @IL.name("class [mscorlib]System.IO.TextWriter")
     class TextWriter: System.MarshalByRefObject,System.IDisposable,System.IAsyncDisposable is
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.IO.SeekOrigin")
+    struct SeekOrigin is
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.IO.FileAccess")
+    struct FileAccess is
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.IO.FileMode")
+    struct FileMode is
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.IO.FileShare")
+    struct FileShare is
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.IO.FileOptions")
+    struct FileOptions is
     si
 si

--- a/lib/dotnet/stubs/system.reflection.ghul
+++ b/lib/dotnet/stubs/system.reflection.ghul
@@ -1,22 +1,1985 @@
 namespace System.Reflection is
     @IL.stub()
-    @IL.name("class [mscorlib]System.Reflection.IReflect")
-    trait IReflect is
+    @IL.name("class [mscorlib]System.Reflection.Assembly")
+    class Assembly: System.Object,System.Reflection.ICustomAttributeProvider,System.Runtime.Serialization.ISerializable is
+        @IL.name("Load")
+        load(assembly_string: System.String) -> System.Reflection.Assembly static;
+
+        @IL.name("LoadWithPartialName")
+        load_with_partial_name(partial_name: System.String) -> System.Reflection.Assembly static;
+
+        @IL.name("Load")
+        load(assembly_ref: System.Reflection.AssemblyName) -> System.Reflection.Assembly static;
+
+        @IL.name("GetExecutingAssembly")
+        get_executing_assembly() -> System.Reflection.Assembly static;
+
+        @IL.name("GetCallingAssembly")
+        get_calling_assembly() -> System.Reflection.Assembly static;
+
+        @IL.name("GetEntryAssembly")
+        get_entry_assembly() -> System.Reflection.Assembly static;
+
+        @IL.name("GetTypes")
+        get_types() -> System.Type[];
+
+        @IL.name("GetExportedTypes")
+        get_exported_types() -> System.Type[];
+
+        @IL.name("GetForwardedTypes")
+        get_forwarded_types() -> System.Type[];
+
+        @IL.name("GetManifestResourceInfo")
+        get_manifest_resource_info(resource_name: System.String) -> System.Reflection.ManifestResourceInfo;
+
+        @IL.name("GetManifestResourceNames")
+        get_manifest_resource_names() -> System.String[];
+
+        @IL.name("GetManifestResourceStream")
+        get_manifest_resource_stream(name: System.String) -> System.IO.Stream;
+
+        @IL.name("GetManifestResourceStream")
+        get_manifest_resource_stream(type: System.Type, name: System.String) -> System.IO.Stream;
+
+        @IL.name("GetName")
+        get_name() -> System.Reflection.AssemblyName;
+
+        @IL.name("GetName")
+        get_name(copied_name: bool) -> System.Reflection.AssemblyName;
+
+        @IL.name("GetType")
+        get_type(name: System.String) -> System.Type;
+
+        @IL.name("GetType")
+        get_type(name: System.String, throw_on_error: bool) -> System.Type;
+
+        @IL.name("GetType")
+        get_type(name: System.String, throw_on_error: bool, ignore_case: bool) -> System.Type;
+
+        @IL.name("IsDefined")
+        is_defined(attribute_type: System.Type, inherit: bool) -> bool;
+
+        @IL.name("GetCustomAttributesData")
+        get_custom_attributes_data() -> Collections.MutableList[System.Reflection.CustomAttributeData];
+
+        @IL.name("GetCustomAttributes")
+        get_custom_attributes(inherit: bool) -> System.Object[];
+
+        @IL.name("GetCustomAttributes")
+        get_custom_attributes(attribute_type: System.Type, inherit: bool) -> System.Object[];
+
+        @IL.name("CreateInstance")
+        create_instance(type_name: System.String) -> System.Object;
+
+        @IL.name("CreateInstance")
+        create_instance(type_name: System.String, ignore_case: bool) -> System.Object;
+
+        @IL.name("CreateInstance")
+        create_instance(type_name: System.String, ignore_case: bool, binding_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, args: System.Object[], culture: System.Globalization.CultureInfo, activation_attributes: System.Object[]) -> System.Object;
+
+        @IL.name("GetModule")
+        get_module(name: System.String) -> System.Reflection.Module;
+
+        @IL.name("GetModules")
+        get_modules() -> System.Reflection.Module[];
+
+        @IL.name("GetModules")
+        get_modules(get_resource_modules: bool) -> System.Reflection.Module[];
+
+        @IL.name("GetLoadedModules")
+        get_loaded_modules() -> System.Reflection.Module[];
+
+        @IL.name("GetLoadedModules")
+        get_loaded_modules(get_resource_modules: bool) -> System.Reflection.Module[];
+
+        @IL.name("GetReferencedAssemblies")
+        get_referenced_assemblies() -> System.Reflection.AssemblyName[];
+
+        @IL.name("GetSatelliteAssembly")
+        get_satellite_assembly(culture: System.Globalization.CultureInfo) -> System.Reflection.Assembly;
+
+        @IL.name("GetSatelliteAssembly")
+        get_satellite_assembly(culture: System.Globalization.CultureInfo, version: System.Version) -> System.Reflection.Assembly;
+
+        @IL.name("GetFile")
+        get_file(name: System.String) -> System.IO.FileStream;
+
+        @IL.name("GetFiles")
+        get_files() -> System.IO.FileStream[];
+
+        @IL.name("GetFiles")
+        get_files(get_resource_modules: bool) -> System.IO.FileStream[];
+
+        @IL.name("GetObjectData")
+        get_object_data(info: System.Runtime.Serialization.SerializationInfo, context: System.Runtime.Serialization.StreamingContext);
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("Equals")
+        equals(o: System.Object) -> bool;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("CreateQualifiedName")
+        create_qualified_name(assembly_name: System.String, type_name: System.String) -> System.String static;
+
+        @IL.name("GetAssembly")
+        get_assembly(type: System.Type) -> System.Reflection.Assembly static;
+
+        @IL.name("Load")
+        load(raw_assembly: ubyte[]) -> System.Reflection.Assembly static;
+
+        @IL.name("Load")
+        load(raw_assembly: ubyte[], raw_symbol_store: ubyte[]) -> System.Reflection.Assembly static;
+
+        @IL.name("LoadFile")
+        load_file(path: System.String) -> System.Reflection.Assembly static;
+
+        @IL.name("LoadFrom")
+        load_from(assembly_file: System.String) -> System.Reflection.Assembly static;
+
+        @IL.name("LoadFrom")
+        load_from(assembly_file: System.String, hash_value: ubyte[], hash_algorithm: System.Configuration.Assemblies.AssemblyHashAlgorithm) -> System.Reflection.Assembly static;
+
+        @IL.name("UnsafeLoadFrom")
+        unsafe_load_from(assembly_file: System.String) -> System.Reflection.Assembly static;
+
+        @IL.name("LoadModule")
+        load_module(module_name: System.String, raw_module: ubyte[]) -> System.Reflection.Module;
+
+        @IL.name("LoadModule")
+        load_module(module_name: System.String, raw_module: ubyte[], raw_symbol_store: ubyte[]) -> System.Reflection.Module;
+
+        @IL.name("ReflectionOnlyLoad")
+        reflection_only_load(raw_assembly: ubyte[]) -> System.Reflection.Assembly static;
+
+        @IL.name("ReflectionOnlyLoad")
+        reflection_only_load(assembly_string: System.String) -> System.Reflection.Assembly static;
+
+        @IL.name("ReflectionOnlyLoadFrom")
+        reflection_only_load_from(assembly_file: System.String) -> System.Reflection.Assembly static;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name.read("get_DefinedTypes") 
+        defined_types: Collections.Iterable[System.Reflection.TypeInfo];
+
+        @IL.name.read("get_ExportedTypes") 
+        exported_types: Collections.Iterable[System.Type];
+
+        @IL.name.read("get_CodeBase") 
+        code_base: System.String;
+
+        @IL.name.read("get_EntryPoint") 
+        entry_point: System.Reflection.MethodInfo;
+
+        @IL.name.read("get_FullName") 
+        full_name: System.String;
+
+        @IL.name.read("get_ImageRuntimeVersion") 
+        image_runtime_version: System.String;
+
+        @IL.name.read("get_IsDynamic") 
+        is_dynamic: bool;
+
+        @IL.name.read("get_Location") 
+        location: System.String;
+
+        @IL.name.read("get_ReflectionOnly") 
+        reflection_only: bool;
+
+        @IL.name.read("get_IsCollectible") 
+        is_collectible: bool;
+
+        @IL.name.read("get_IsFullyTrusted") 
+        is_fully_trusted: bool;
+
+        @IL.name.read("get_CustomAttributes") 
+        custom_attributes: Collections.Iterable[System.Reflection.CustomAttributeData];
+
+        @IL.name.read("get_EscapedCodeBase") 
+        escaped_code_base: System.String;
+
+        @IL.name.read("get_ManifestModule") 
+        manifest_module: System.Reflection.Module;
+
+        @IL.name.read("get_Modules") 
+        modules: Collections.Iterable[System.Reflection.Module];
+
+        @IL.name.read("get_GlobalAssemblyCache") 
+        global_assembly_cache: bool;
+
+        @IL.name.read("get_HostContext") 
+        host_context: long;
+
+        @IL.name.read("get_SecurityRuleSet") 
+        security_rule_set: System.Security.SecurityRuleSet;
+
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Reflection.Module")
+    class Module: System.Object,System.Reflection.ICustomAttributeProvider,System.Runtime.Serialization.ISerializable is
+        @IL.name("GetPEKind")
+        get_p_e_kind(pe_kind: System.Reflection.PortableExecutableKinds ref, machine: System.Reflection.ImageFileMachine ref);
+
+        @IL.name("IsResource")
+        is_resource() -> bool;
+
+        @IL.name("IsDefined")
+        is_defined(attribute_type: System.Type, inherit: bool) -> bool;
+
+        @IL.name("GetCustomAttributesData")
+        get_custom_attributes_data() -> Collections.MutableList[System.Reflection.CustomAttributeData];
+
+        @IL.name("GetCustomAttributes")
+        get_custom_attributes(inherit: bool) -> System.Object[];
+
+        @IL.name("GetCustomAttributes")
+        get_custom_attributes(attribute_type: System.Type, inherit: bool) -> System.Object[];
+
+        @IL.name("GetMethod")
+        get_method(name: System.String) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetMethod")
+        get_method(name: System.String, types: System.Type[]) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetMethod")
+        get_method(name: System.String, binding_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, call_convention: System.Reflection.CallingConventions, types: System.Type[], modifiers: System.Reflection.ParameterModifier[]) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetMethods")
+        get_methods() -> System.Reflection.MethodInfo[];
+
+        @IL.name("GetMethods")
+        get_methods(binding_flags: System.Reflection.BindingFlags) -> System.Reflection.MethodInfo[];
+
+        @IL.name("GetField")
+        get_field(name: System.String) -> System.Reflection.FieldInfo;
+
+        @IL.name("GetField")
+        get_field(name: System.String, binding_attr: System.Reflection.BindingFlags) -> System.Reflection.FieldInfo;
+
+        @IL.name("GetFields")
+        get_fields() -> System.Reflection.FieldInfo[];
+
+        @IL.name("GetFields")
+        get_fields(binding_flags: System.Reflection.BindingFlags) -> System.Reflection.FieldInfo[];
+
+        @IL.name("GetTypes")
+        get_types() -> System.Type[];
+
+        @IL.name("GetType")
+        get_type(class_name: System.String) -> System.Type;
+
+        @IL.name("GetType")
+        get_type(class_name: System.String, ignore_case: bool) -> System.Type;
+
+        @IL.name("GetType")
+        get_type(class_name: System.String, throw_on_error: bool, ignore_case: bool) -> System.Type;
+
+        @IL.name("FindTypes")
+        find_types(filter: System.Reflection.TypeFilter, filter_criteria: System.Object) -> System.Type[];
+
+        @IL.name("ResolveField")
+        resolve_field(metadata_token: int) -> System.Reflection.FieldInfo;
+
+        @IL.name("ResolveField")
+        resolve_field(metadata_token: int, generic_type_arguments: System.Type[], generic_method_arguments: System.Type[]) -> System.Reflection.FieldInfo;
+
+        @IL.name("ResolveMember")
+        resolve_member(metadata_token: int) -> System.Reflection.MemberInfo;
+
+        @IL.name("ResolveMember")
+        resolve_member(metadata_token: int, generic_type_arguments: System.Type[], generic_method_arguments: System.Type[]) -> System.Reflection.MemberInfo;
+
+        @IL.name("ResolveMethod")
+        resolve_method(metadata_token: int) -> System.Reflection.MethodBase;
+
+        @IL.name("ResolveMethod")
+        resolve_method(metadata_token: int, generic_type_arguments: System.Type[], generic_method_arguments: System.Type[]) -> System.Reflection.MethodBase;
+
+        @IL.name("ResolveSignature")
+        resolve_signature(metadata_token: int) -> ubyte[];
+
+        @IL.name("ResolveString")
+        resolve_string(metadata_token: int) -> System.String;
+
+        @IL.name("ResolveType")
+        resolve_type(metadata_token: int) -> System.Type;
+
+        @IL.name("ResolveType")
+        resolve_type(metadata_token: int, generic_type_arguments: System.Type[], generic_method_arguments: System.Type[]) -> System.Type;
+
+        @IL.name("GetObjectData")
+        get_object_data(info: System.Runtime.Serialization.SerializationInfo, context: System.Runtime.Serialization.StreamingContext);
+
+        @IL.name("Equals")
+        equals(o: System.Object) -> bool;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name.read("get_Assembly") 
+        assembly: System.Reflection.Assembly;
+
+        @IL.name.read("get_FullyQualifiedName") 
+        fully_qualified_name: System.String;
+
+        @IL.name.read("get_Name") 
+        name: System.String;
+
+        @IL.name.read("get_MDStreamVersion") 
+        mdstream_version: int;
+
+        @IL.name.read("get_ModuleVersionId") 
+        module_version_id: System.Guid;
+
+        @IL.name.read("get_ScopeName") 
+        scope_name: System.String;
+
+        @IL.name.read("get_ModuleHandle") 
+        module_handle: System.ModuleHandle;
+
+        @IL.name.read("get_CustomAttributes") 
+        custom_attributes: Collections.Iterable[System.Reflection.CustomAttributeData];
+
+        @IL.name.read("get_MetadataToken") 
+        metadata_token: int;
+
+        @IL.name("FilterTypeName")
+        _filter_type_name: System.Reflection.TypeFilter public;
+        @IL.name("FilterTypeNameIgnoreCase")
+        _filter_type_name_ignore_case: System.Reflection.TypeFilter public;
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Reflection.MemberInfo")
+    class MemberInfo: System.Object,System.Reflection.ICustomAttributeProvider is
+        @IL.name("HasSameMetadataDefinitionAs")
+        has_same_metadata_definition_as(other: System.Reflection.MemberInfo) -> bool;
+
+        @IL.name("IsDefined")
+        is_defined(attribute_type: System.Type, inherit: bool) -> bool;
+
+        @IL.name("GetCustomAttributes")
+        get_custom_attributes(inherit: bool) -> System.Object[];
+
+        @IL.name("GetCustomAttributes")
+        get_custom_attributes(attribute_type: System.Type, inherit: bool) -> System.Object[];
+
+        @IL.name("GetCustomAttributesData")
+        get_custom_attributes_data() -> Collections.MutableList[System.Reflection.CustomAttributeData];
+
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name.read("get_MemberType") 
+        member_type: System.Reflection.MemberTypes;
+
+        @IL.name.read("get_Name") 
+        name: System.String;
+
+        @IL.name.read("get_DeclaringType") 
+        declaring_type: System.Type;
+
+        @IL.name.read("get_ReflectedType") 
+        reflected_type: System.Type;
+
+        @IL.name.read("get_Module") 
+        module: System.Reflection.Module;
+
+        @IL.name.read("get_CustomAttributes") 
+        custom_attributes: Collections.Iterable[System.Reflection.CustomAttributeData];
+
+        @IL.name.read("get_IsCollectible") 
+        is_collectible: bool;
+
+        @IL.name.read("get_MetadataToken") 
+        metadata_token: int;
+
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Reflection.MethodInfo")
+    class MethodInfo: System.Reflection.MethodBase,System.Reflection.ICustomAttributeProvider is
+        @IL.name("GetGenericArguments")
+        get_generic_arguments() -> System.Type[];
+
+        @IL.name("GetGenericMethodDefinition")
+        get_generic_method_definition() -> System.Reflection.MethodInfo;
+
+        @IL.name("MakeGenericMethod")
+        make_generic_method(type_arguments: System.Type[]) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetBaseDefinition")
+        get_base_definition() -> System.Reflection.MethodInfo;
+
+        @IL.name("CreateDelegate")
+        create_delegate(delegate_type: System.Type) -> System.Delegate;
+
+        @IL.name("CreateDelegate")
+        create_delegate(delegate_type: System.Type, target: System.Object) -> System.Delegate;
+
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("GetParameters")
+        get_parameters() -> System.Reflection.ParameterInfo[];
+
+        @IL.name("GetMethodImplementationFlags")
+        get_method_implementation_flags() -> System.Reflection.MethodImplAttributes;
+
+        @IL.name("GetMethodBody")
+        get_method_body() -> System.Reflection.MethodBody;
+
+        @IL.name("Invoke")
+        invoke(obj: System.Object, parameters: System.Object[]) -> System.Object;
+
+        @IL.name("Invoke")
+        invoke(obj: System.Object, invoke_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, parameters: System.Object[], culture: System.Globalization.CultureInfo) -> System.Object;
+
+        @IL.name("HasSameMetadataDefinitionAs")
+        has_same_metadata_definition_as(other: System.Reflection.MemberInfo) -> bool;
+
+        @IL.name("IsDefined")
+        is_defined(attribute_type: System.Type, inherit: bool) -> bool;
+
+        @IL.name("GetCustomAttributes")
+        get_custom_attributes(inherit: bool) -> System.Object[];
+
+        @IL.name("GetCustomAttributes")
+        get_custom_attributes(attribute_type: System.Type, inherit: bool) -> System.Object[];
+
+        @IL.name("GetCustomAttributesData")
+        get_custom_attributes_data() -> Collections.MutableList[System.Reflection.CustomAttributeData];
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name.read("get_MemberType") 
+        member_type: System.Reflection.MemberTypes;
+
+        @IL.name.read("get_ReturnParameter") 
+        return_parameter: System.Reflection.ParameterInfo;
+
+        @IL.name.read("get_ReturnType") 
+        return_type: System.Type;
+
+        @IL.name.read("get_ReturnTypeCustomAttributes") 
+        return_type_custom_attributes: System.Reflection.ICustomAttributeProvider;
+
+        @IL.name.read("get_Attributes") 
+        attributes: System.Reflection.MethodAttributes;
+
+        @IL.name.read("get_MethodImplementationFlags") 
+        method_implementation_flags: System.Reflection.MethodImplAttributes;
+
+        @IL.name.read("get_CallingConvention") 
+        calling_convention: System.Reflection.CallingConventions;
+
+        @IL.name.read("get_IsAbstract") 
+        is_abstract: bool;
+
+        @IL.name.read("get_IsConstructor") 
+        is_constructor: bool;
+
+        @IL.name.read("get_IsFinal") 
+        is_final: bool;
+
+        @IL.name.read("get_IsHideBySig") 
+        is_hide_by_sig: bool;
+
+        @IL.name.read("get_IsSpecialName") 
+        is_special_name: bool;
+
+        @IL.name.read("get_IsStatic") 
+        is_static: bool;
+
+        @IL.name.read("get_IsVirtual") 
+        is_virtual: bool;
+
+        @IL.name.read("get_IsAssembly") 
+        is_assembly: bool;
+
+        @IL.name.read("get_IsFamily") 
+        is_family: bool;
+
+        @IL.name.read("get_IsFamilyAndAssembly") 
+        is_family_and_assembly: bool;
+
+        @IL.name.read("get_IsFamilyOrAssembly") 
+        is_family_or_assembly: bool;
+
+        @IL.name.read("get_IsPrivate") 
+        is_private: bool;
+
+        @IL.name.read("get_IsPublic") 
+        is_public: bool;
+
+        @IL.name.read("get_IsConstructedGenericMethod") 
+        is_constructed_generic_method: bool;
+
+        @IL.name.read("get_IsGenericMethod") 
+        is_generic_method: bool;
+
+        @IL.name.read("get_IsGenericMethodDefinition") 
+        is_generic_method_definition: bool;
+
+        @IL.name.read("get_ContainsGenericParameters") 
+        contains_generic_parameters: bool;
+
+        @IL.name.read("get_MethodHandle") 
+        method_handle: System.RuntimeMethodHandle;
+
+        @IL.name.read("get_IsSecurityCritical") 
+        is_security_critical: bool;
+
+        @IL.name.read("get_IsSecuritySafeCritical") 
+        is_security_safe_critical: bool;
+
+        @IL.name.read("get_IsSecurityTransparent") 
+        is_security_transparent: bool;
+
+        @IL.name.read("get_Name") 
+        name: System.String;
+
+        @IL.name.read("get_DeclaringType") 
+        declaring_type: System.Type;
+
+        @IL.name.read("get_ReflectedType") 
+        reflected_type: System.Type;
+
+        @IL.name.read("get_Module") 
+        module: System.Reflection.Module;
+
+        @IL.name.read("get_CustomAttributes") 
+        custom_attributes: Collections.Iterable[System.Reflection.CustomAttributeData];
+
+        @IL.name.read("get_IsCollectible") 
+        is_collectible: bool;
+
+        @IL.name.read("get_MetadataToken") 
+        metadata_token: int;
+
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Reflection.PropertyInfo")
+    class PropertyInfo: System.Reflection.MemberInfo,System.Reflection.ICustomAttributeProvider is
+        @IL.name("GetIndexParameters")
+        get_index_parameters() -> System.Reflection.ParameterInfo[];
+
+        @IL.name("GetAccessors")
+        get_accessors() -> System.Reflection.MethodInfo[];
+
+        @IL.name("GetAccessors")
+        get_accessors(non_public: bool) -> System.Reflection.MethodInfo[];
+
+        @IL.name("GetGetMethod")
+        get_get_method() -> System.Reflection.MethodInfo;
+
+        @IL.name("GetGetMethod")
+        get_get_method(non_public: bool) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetSetMethod")
+        get_set_method() -> System.Reflection.MethodInfo;
+
+        @IL.name("GetSetMethod")
+        get_set_method(non_public: bool) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetOptionalCustomModifiers")
+        get_optional_custom_modifiers() -> System.Type[];
+
+        @IL.name("GetRequiredCustomModifiers")
+        get_required_custom_modifiers() -> System.Type[];
+
+        @IL.name("GetValue")
+        get_value(obj: System.Object) -> System.Object;
+
+        @IL.name("GetValue")
+        get_value(obj: System.Object, index: System.Object[]) -> System.Object;
+
+        @IL.name("GetValue")
+        get_value(obj: System.Object, invoke_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, index: System.Object[], culture: System.Globalization.CultureInfo) -> System.Object;
+
+        @IL.name("GetConstantValue")
+        get_constant_value() -> System.Object;
+
+        @IL.name("GetRawConstantValue")
+        get_raw_constant_value() -> System.Object;
+
+        @IL.name("SetValue")
+        set_value(obj: System.Object, value: System.Object);
+
+        @IL.name("SetValue")
+        set_value(obj: System.Object, value: System.Object, index: System.Object[]);
+
+        @IL.name("SetValue")
+        set_value(obj: System.Object, value: System.Object, invoke_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, index: System.Object[], culture: System.Globalization.CultureInfo);
+
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("HasSameMetadataDefinitionAs")
+        has_same_metadata_definition_as(other: System.Reflection.MemberInfo) -> bool;
+
+        @IL.name("IsDefined")
+        is_defined(attribute_type: System.Type, inherit: bool) -> bool;
+
+        @IL.name("GetCustomAttributes")
+        get_custom_attributes(inherit: bool) -> System.Object[];
+
+        @IL.name("GetCustomAttributes")
+        get_custom_attributes(attribute_type: System.Type, inherit: bool) -> System.Object[];
+
+        @IL.name("GetCustomAttributesData")
+        get_custom_attributes_data() -> Collections.MutableList[System.Reflection.CustomAttributeData];
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name.read("get_MemberType") 
+        member_type: System.Reflection.MemberTypes;
+
+        @IL.name.read("get_PropertyType") 
+        property_type: System.Type;
+
+        @IL.name.read("get_Attributes") 
+        attributes: System.Reflection.PropertyAttributes;
+
+        @IL.name.read("get_IsSpecialName") 
+        is_special_name: bool;
+
+        @IL.name.read("get_CanRead") 
+        can_read: bool;
+
+        @IL.name.read("get_CanWrite") 
+        can_write: bool;
+
+        @IL.name.read("get_GetMethod") 
+        get_method: System.Reflection.MethodInfo;
+
+        @IL.name.read("get_SetMethod") 
+        set_method: System.Reflection.MethodInfo;
+
+        @IL.name.read("get_Name") 
+        name: System.String;
+
+        @IL.name.read("get_DeclaringType") 
+        declaring_type: System.Type;
+
+        @IL.name.read("get_ReflectedType") 
+        reflected_type: System.Type;
+
+        @IL.name.read("get_Module") 
+        module: System.Reflection.Module;
+
+        @IL.name.read("get_CustomAttributes") 
+        custom_attributes: Collections.Iterable[System.Reflection.CustomAttributeData];
+
+        @IL.name.read("get_IsCollectible") 
+        is_collectible: bool;
+
+        @IL.name.read("get_MetadataToken") 
+        metadata_token: int;
+
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Reflection.TypeInfo")
+    class TypeInfo: System.Type,System.Reflection.ICustomAttributeProvider,System.Reflection.IReflect,System.Reflection.IReflectableType is
+        @IL.name("AsType")
+        as_type() -> System.Type;
+
+        @IL.name("GetDeclaredEvent")
+        get_declared_event(name: System.String) -> System.Reflection.EventInfo;
+
+        @IL.name("GetDeclaredField")
+        get_declared_field(name: System.String) -> System.Reflection.FieldInfo;
+
+        @IL.name("GetDeclaredMethod")
+        get_declared_method(name: System.String) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetDeclaredNestedType")
+        get_declared_nested_type(name: System.String) -> System.Reflection.TypeInfo;
+
+        @IL.name("GetDeclaredProperty")
+        get_declared_property(name: System.String) -> System.Reflection.PropertyInfo;
+
+        @IL.name("GetDeclaredMethods")
+        get_declared_methods(name: System.String) -> Collections.Iterable[System.Reflection.MethodInfo];
+
+        @IL.name("IsAssignableFrom")
+        is_assignable_from(type_info: System.Reflection.TypeInfo) -> bool;
+
+        @IL.name("GetField")
+        get_field(name: System.String) -> System.Reflection.FieldInfo;
+
+        @IL.name("GetField")
+        get_field(name: System.String, binding_attr: System.Reflection.BindingFlags) -> System.Reflection.FieldInfo;
+
+        @IL.name("GetFields")
+        get_fields() -> System.Reflection.FieldInfo[];
+
+        @IL.name("GetFields")
+        get_fields(binding_attr: System.Reflection.BindingFlags) -> System.Reflection.FieldInfo[];
+
+        @IL.name("GetMember")
+        get_member(name: System.String) -> System.Reflection.MemberInfo[];
+
+        @IL.name("GetMember")
+        get_member(name: System.String, binding_attr: System.Reflection.BindingFlags) -> System.Reflection.MemberInfo[];
+
+        @IL.name("GetMember")
+        get_member(name: System.String, type: System.Reflection.MemberTypes, binding_attr: System.Reflection.BindingFlags) -> System.Reflection.MemberInfo[];
+
+        @IL.name("GetMembers")
+        get_members() -> System.Reflection.MemberInfo[];
+
+        @IL.name("GetMembers")
+        get_members(binding_attr: System.Reflection.BindingFlags) -> System.Reflection.MemberInfo[];
+
+        @IL.name("GetMethod")
+        get_method(name: System.String) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetMethod")
+        get_method(name: System.String, binding_attr: System.Reflection.BindingFlags) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetMethod")
+        get_method(name: System.String, types: System.Type[]) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetMethod")
+        get_method(name: System.String, types: System.Type[], modifiers: System.Reflection.ParameterModifier[]) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetMethod")
+        get_method(name: System.String, binding_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, types: System.Type[], modifiers: System.Reflection.ParameterModifier[]) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetMethod")
+        get_method(name: System.String, binding_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, call_convention: System.Reflection.CallingConventions, types: System.Type[], modifiers: System.Reflection.ParameterModifier[]) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetMethod")
+        get_method(name: System.String, generic_parameter_count: int, types: System.Type[]) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetMethod")
+        get_method(name: System.String, generic_parameter_count: int, types: System.Type[], modifiers: System.Reflection.ParameterModifier[]) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetMethod")
+        get_method(name: System.String, generic_parameter_count: int, binding_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, types: System.Type[], modifiers: System.Reflection.ParameterModifier[]) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetMethod")
+        get_method(name: System.String, generic_parameter_count: int, binding_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, call_convention: System.Reflection.CallingConventions, types: System.Type[], modifiers: System.Reflection.ParameterModifier[]) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetMethods")
+        get_methods() -> System.Reflection.MethodInfo[];
+
+        @IL.name("GetMethods")
+        get_methods(binding_attr: System.Reflection.BindingFlags) -> System.Reflection.MethodInfo[];
+
+        @IL.name("GetNestedType")
+        get_nested_type(name: System.String) -> System.Type;
+
+        @IL.name("GetNestedType")
+        get_nested_type(name: System.String, binding_attr: System.Reflection.BindingFlags) -> System.Type;
+
+        @IL.name("GetNestedTypes")
+        get_nested_types() -> System.Type[];
+
+        @IL.name("GetNestedTypes")
+        get_nested_types(binding_attr: System.Reflection.BindingFlags) -> System.Type[];
+
+        @IL.name("GetProperty")
+        get_property(name: System.String) -> System.Reflection.PropertyInfo;
+
+        @IL.name("GetProperty")
+        get_property(name: System.String, binding_attr: System.Reflection.BindingFlags) -> System.Reflection.PropertyInfo;
+
+        @IL.name("GetProperty")
+        get_property(name: System.String, return_type: System.Type) -> System.Reflection.PropertyInfo;
+
+        @IL.name("GetProperty")
+        get_property(name: System.String, types: System.Type[]) -> System.Reflection.PropertyInfo;
+
+        @IL.name("GetProperty")
+        get_property(name: System.String, return_type: System.Type, types: System.Type[]) -> System.Reflection.PropertyInfo;
+
+        @IL.name("GetProperty")
+        get_property(name: System.String, return_type: System.Type, types: System.Type[], modifiers: System.Reflection.ParameterModifier[]) -> System.Reflection.PropertyInfo;
+
+        @IL.name("GetProperty")
+        get_property(name: System.String, binding_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, return_type: System.Type, types: System.Type[], modifiers: System.Reflection.ParameterModifier[]) -> System.Reflection.PropertyInfo;
+
+        @IL.name("GetProperties")
+        get_properties() -> System.Reflection.PropertyInfo[];
+
+        @IL.name("GetProperties")
+        get_properties(binding_attr: System.Reflection.BindingFlags) -> System.Reflection.PropertyInfo[];
+
+        @IL.name("GetDefaultMembers")
+        get_default_members() -> System.Reflection.MemberInfo[];
+
+        @IL.name("InvokeMember")
+        invoke_member(name: System.String, invoke_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, target: System.Object, args: System.Object[]) -> System.Object;
+
+        @IL.name("InvokeMember")
+        invoke_member(name: System.String, invoke_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, target: System.Object, args: System.Object[], culture: System.Globalization.CultureInfo) -> System.Object;
+
+        @IL.name("InvokeMember")
+        invoke_member(name: System.String, invoke_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, target: System.Object, args: System.Object[], modifiers: System.Reflection.ParameterModifier[], culture: System.Globalization.CultureInfo, named_parameters: System.String[]) -> System.Object;
+
+        @IL.name("GetInterface")
+        get_interface(name: System.String) -> System.Type;
+
+        @IL.name("GetInterface")
+        get_interface(name: System.String, ignore_case: bool) -> System.Type;
+
+        @IL.name("GetInterfaces")
+        get_interfaces() -> System.Type[];
+
+        @IL.name("GetInterfaceMap")
+        get_interface_map(interface_type: System.Type) -> System.Reflection.InterfaceMapping;
+
+        @IL.name("IsInstanceOfType")
+        is_instance_of_type(o: System.Object) -> bool;
+
+        @IL.name("IsEquivalentTo")
+        is_equivalent_to(other: System.Type) -> bool;
+
+        @IL.name("GetEnumUnderlyingType")
+        get_enum_underlying_type() -> System.Type;
+
+        @IL.name("GetEnumValues")
+        get_enum_values() -> System.Array;
+
+        @IL.name("MakeArrayType")
+        make_array_type() -> System.Type;
+
+        @IL.name("MakeArrayType")
+        make_array_type(rank: int) -> System.Type;
+
+        @IL.name("MakeByRefType")
+        make_by_ref_type() -> System.Type;
+
+        @IL.name("MakeGenericType")
+        make_generic_type(type_arguments: System.Type[]) -> System.Type;
+
+        @IL.name("MakePointerType")
+        make_pointer_type() -> System.Type;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("Equals")
+        equals(o: System.Object) -> bool;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("Equals")
+        equals(o: System.Type) -> bool;
+
+        @IL.name("IsEnumDefined")
+        is_enum_defined(value: System.Object) -> bool;
+
+        @IL.name("GetEnumName")
+        get_enum_name(value: System.Object) -> System.String;
+
+        @IL.name("GetEnumNames")
+        get_enum_names() -> System.String[];
+
+        @IL.name("FindInterfaces")
+        find_interfaces(filter: System.Reflection.TypeFilter, filter_criteria: System.Object) -> System.Type[];
+
+        @IL.name("FindMembers")
+        find_members(member_type: System.Reflection.MemberTypes, binding_attr: System.Reflection.BindingFlags, filter: System.Reflection.MemberFilter, filter_criteria: System.Object) -> System.Reflection.MemberInfo[];
+
+        @IL.name("IsSubclassOf")
+        is_subclass_of(c: System.Type) -> bool;
+
+        @IL.name("IsAssignableFrom")
+        is_assignable_from(c: System.Type) -> bool;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name("GetElementType")
+        get_element_type() -> System.Type;
+
+        @IL.name("GetArrayRank")
+        get_array_rank() -> int;
+
+        @IL.name("GetGenericTypeDefinition")
+        get_generic_type_definition() -> System.Type;
+
+        @IL.name("GetGenericArguments")
+        get_generic_arguments() -> System.Type[];
+
+        @IL.name("GetGenericParameterConstraints")
+        get_generic_parameter_constraints() -> System.Type[];
+
+        @IL.name("GetConstructor")
+        get_constructor(types: System.Type[]) -> System.Reflection.ConstructorInfo;
+
+        @IL.name("GetConstructor")
+        get_constructor(binding_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, types: System.Type[], modifiers: System.Reflection.ParameterModifier[]) -> System.Reflection.ConstructorInfo;
+
+        @IL.name("GetConstructor")
+        get_constructor(binding_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, call_convention: System.Reflection.CallingConventions, types: System.Type[], modifiers: System.Reflection.ParameterModifier[]) -> System.Reflection.ConstructorInfo;
+
+        @IL.name("GetConstructors")
+        get_constructors() -> System.Reflection.ConstructorInfo[];
+
+        @IL.name("GetConstructors")
+        get_constructors(binding_attr: System.Reflection.BindingFlags) -> System.Reflection.ConstructorInfo[];
+
+        @IL.name("GetEvent")
+        get_event(name: System.String) -> System.Reflection.EventInfo;
+
+        @IL.name("GetEvent")
+        get_event(name: System.String, binding_attr: System.Reflection.BindingFlags) -> System.Reflection.EventInfo;
+
+        @IL.name("GetEvents")
+        get_events() -> System.Reflection.EventInfo[];
+
+        @IL.name("GetEvents")
+        get_events(binding_attr: System.Reflection.BindingFlags) -> System.Reflection.EventInfo[];
+
+        @IL.name("HasSameMetadataDefinitionAs")
+        has_same_metadata_definition_as(other: System.Reflection.MemberInfo) -> bool;
+
+        @IL.name("IsDefined")
+        is_defined(attribute_type: System.Type, inherit: bool) -> bool;
+
+        @IL.name("GetCustomAttributes")
+        get_custom_attributes(inherit: bool) -> System.Object[];
+
+        @IL.name("GetCustomAttributes")
+        get_custom_attributes(attribute_type: System.Type, inherit: bool) -> System.Object[];
+
+        @IL.name("GetCustomAttributesData")
+        get_custom_attributes_data() -> Collections.MutableList[System.Reflection.CustomAttributeData];
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name.read("get_GenericTypeParameters") 
+        generic_type_parameters: System.Type[];
+
+        @IL.name.read("get_DeclaredConstructors") 
+        declared_constructors: Collections.Iterable[System.Reflection.ConstructorInfo];
+
+        @IL.name.read("get_DeclaredEvents") 
+        declared_events: Collections.Iterable[System.Reflection.EventInfo];
+
+        @IL.name.read("get_DeclaredFields") 
+        declared_fields: Collections.Iterable[System.Reflection.FieldInfo];
+
+        @IL.name.read("get_DeclaredMembers") 
+        declared_members: Collections.Iterable[System.Reflection.MemberInfo];
+
+        @IL.name.read("get_DeclaredMethods") 
+        declared_methods: Collections.Iterable[System.Reflection.MethodInfo];
+
+        @IL.name.read("get_DeclaredNestedTypes") 
+        declared_nested_types: Collections.Iterable[System.Reflection.TypeInfo];
+
+        @IL.name.read("get_DeclaredProperties") 
+        declared_properties: Collections.Iterable[System.Reflection.PropertyInfo];
+
+        @IL.name.read("get_ImplementedInterfaces") 
+        implemented_interfaces: Collections.Iterable[System.Type];
+
+        @IL.name.read("get_IsInterface") 
+        is_interface: bool;
+
+        @IL.name.read("get_MemberType") 
+        member_type: System.Reflection.MemberTypes;
+
+        @IL.name.read("get_Namespace") 
+        namespace_: System.String;
+
+        @IL.name.read("get_AssemblyQualifiedName") 
+        assembly_qualified_name: System.String;
+
+        @IL.name.read("get_FullName") 
+        full_name: System.String;
+
+        @IL.name.read("get_Assembly") 
+        assembly: System.Reflection.Assembly;
+
+        @IL.name.read("get_Module") 
+        module: System.Reflection.Module;
+
+        @IL.name.read("get_IsNested") 
+        is_nested: bool;
+
+        @IL.name.read("get_DeclaringType") 
+        declaring_type: System.Type;
+
+        @IL.name.read("get_DeclaringMethod") 
+        declaring_method: System.Reflection.MethodBase;
+
+        @IL.name.read("get_ReflectedType") 
+        reflected_type: System.Type;
+
+        @IL.name.read("get_UnderlyingSystemType") 
+        underlying_system_type: System.Type;
+
+        @IL.name.read("get_IsTypeDefinition") 
+        is_type_definition: bool;
+
+        @IL.name.read("get_IsArray") 
+        is_array: bool;
+
+        @IL.name.read("get_IsByRef") 
+        is_by_ref: bool;
+
+        @IL.name.read("get_IsPointer") 
+        is_pointer: bool;
+
+        @IL.name.read("get_IsConstructedGenericType") 
+        is_constructed_generic_type: bool;
+
+        @IL.name.read("get_IsGenericParameter") 
+        is_generic_parameter: bool;
+
+        @IL.name.read("get_IsGenericTypeParameter") 
+        is_generic_type_parameter: bool;
+
+        @IL.name.read("get_IsGenericMethodParameter") 
+        is_generic_method_parameter: bool;
+
+        @IL.name.read("get_IsGenericType") 
+        is_generic_type: bool;
+
+        @IL.name.read("get_IsGenericTypeDefinition") 
+        is_generic_type_definition: bool;
+
+        @IL.name.read("get_IsSZArray") 
+        is_s_z_array: bool;
+
+        @IL.name.read("get_IsVariableBoundArray") 
+        is_variable_bound_array: bool;
+
+        @IL.name.read("get_IsByRefLike") 
+        is_by_ref_like: bool;
+
+        @IL.name.read("get_HasElementType") 
+        has_element_type: bool;
+
+        @IL.name.read("get_GenericTypeArguments") 
+        generic_type_arguments: System.Type[];
+
+        @IL.name.read("get_GenericParameterPosition") 
+        generic_parameter_position: int;
+
+        @IL.name.read("get_GenericParameterAttributes") 
+        generic_parameter_attributes: System.Reflection.GenericParameterAttributes;
+
+        @IL.name.read("get_Attributes") 
+        attributes: System.Reflection.TypeAttributes;
+
+        @IL.name.read("get_IsAbstract") 
+        is_abstract: bool;
+
+        @IL.name.read("get_IsImport") 
+        is_import: bool;
+
+        @IL.name.read("get_IsSealed") 
+        is_sealed: bool;
+
+        @IL.name.read("get_IsSpecialName") 
+        is_special_name: bool;
+
+        @IL.name.read("get_IsClass") 
+        is_class: bool;
+
+        @IL.name.read("get_IsNestedAssembly") 
+        is_nested_assembly: bool;
+
+        @IL.name.read("get_IsNestedFamANDAssem") 
+        is_nested_fam_a_n_d_assem: bool;
+
+        @IL.name.read("get_IsNestedFamily") 
+        is_nested_family: bool;
+
+        @IL.name.read("get_IsNestedFamORAssem") 
+        is_nested_fam_o_r_assem: bool;
+
+        @IL.name.read("get_IsNestedPrivate") 
+        is_nested_private: bool;
+
+        @IL.name.read("get_IsNestedPublic") 
+        is_nested_public: bool;
+
+        @IL.name.read("get_IsNotPublic") 
+        is_not_public: bool;
+
+        @IL.name.read("get_IsPublic") 
+        is_public: bool;
+
+        @IL.name.read("get_IsAutoLayout") 
+        is_auto_layout: bool;
+
+        @IL.name.read("get_IsExplicitLayout") 
+        is_explicit_layout: bool;
+
+        @IL.name.read("get_IsLayoutSequential") 
+        is_layout_sequential: bool;
+
+        @IL.name.read("get_IsAnsiClass") 
+        is_ansi_class: bool;
+
+        @IL.name.read("get_IsAutoClass") 
+        is_auto_class: bool;
+
+        @IL.name.read("get_IsUnicodeClass") 
+        is_unicode_class: bool;
+
+        @IL.name.read("get_IsCOMObject") 
+        is_c_o_m_object: bool;
+
+        @IL.name.read("get_IsContextful") 
+        is_contextful: bool;
+
+        @IL.name.read("get_IsEnum") 
+        is_enum: bool;
+
+        @IL.name.read("get_IsMarshalByRef") 
+        is_marshal_by_ref: bool;
+
+        @IL.name.read("get_IsPrimitive") 
+        is_primitive: bool;
+
+        @IL.name.read("get_IsValueType") 
+        is_value_type: bool;
+
+        @IL.name.read("get_IsSignatureType") 
+        is_signature_type: bool;
+
+        @IL.name.read("get_IsSecurityCritical") 
+        is_security_critical: bool;
+
+        @IL.name.read("get_IsSecuritySafeCritical") 
+        is_security_safe_critical: bool;
+
+        @IL.name.read("get_IsSecurityTransparent") 
+        is_security_transparent: bool;
+
+        @IL.name.read("get_StructLayoutAttribute") 
+        struct_layout_attribute: System.Runtime.InteropServices.StructLayoutAttribute;
+
+        @IL.name.read("get_TypeInitializer") 
+        type_initializer: System.Reflection.ConstructorInfo;
+
+        @IL.name.read("get_TypeHandle") 
+        type_handle: System.RuntimeTypeHandle;
+
+        @IL.name.read("get_GUID") 
+        guid: System.Guid;
+
+        @IL.name.read("get_BaseType") 
+        base_type: System.Type;
+
+        @IL.name.read("get_IsSerializable") 
+        is_serializable: bool;
+
+        @IL.name.read("get_ContainsGenericParameters") 
+        contains_generic_parameters: bool;
+
+        @IL.name.read("get_IsVisible") 
+        is_visible: bool;
+
+        @IL.name.read("get_Name") 
+        name: System.String;
+
+        @IL.name.read("get_CustomAttributes") 
+        custom_attributes: Collections.Iterable[System.Reflection.CustomAttributeData];
+
+        @IL.name.read("get_IsCollectible") 
+        is_collectible: bool;
+
+        @IL.name.read("get_MetadataToken") 
+        metadata_token: int;
+
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Reflection.FieldInfo")
+    class FieldInfo: System.Reflection.MemberInfo,System.Reflection.ICustomAttributeProvider is
+        @IL.name("GetFieldFromHandle")
+        get_field_from_handle(handle: System.RuntimeFieldHandle) -> System.Reflection.FieldInfo static;
+
+        @IL.name("GetFieldFromHandle")
+        get_field_from_handle(handle: System.RuntimeFieldHandle, declaring_type: System.RuntimeTypeHandle) -> System.Reflection.FieldInfo static;
+
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("GetValue")
+        get_value(obj: System.Object) -> System.Object;
+
+        @IL.name("SetValue")
+        set_value(obj: System.Object, value: System.Object);
+
+        @IL.name("SetValue")
+        set_value(obj: System.Object, value: System.Object, invoke_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, culture: System.Globalization.CultureInfo);
+
+        @IL.name("SetValueDirect")
+        set_value_direct(obj: System.TypedReference, value: System.Object);
+
+        @IL.name("GetValueDirect")
+        get_value_direct(obj: System.TypedReference) -> System.Object;
+
+        @IL.name("GetRawConstantValue")
+        get_raw_constant_value() -> System.Object;
+
+        @IL.name("GetOptionalCustomModifiers")
+        get_optional_custom_modifiers() -> System.Type[];
+
+        @IL.name("GetRequiredCustomModifiers")
+        get_required_custom_modifiers() -> System.Type[];
+
+        @IL.name("HasSameMetadataDefinitionAs")
+        has_same_metadata_definition_as(other: System.Reflection.MemberInfo) -> bool;
+
+        @IL.name("IsDefined")
+        is_defined(attribute_type: System.Type, inherit: bool) -> bool;
+
+        @IL.name("GetCustomAttributes")
+        get_custom_attributes(inherit: bool) -> System.Object[];
+
+        @IL.name("GetCustomAttributes")
+        get_custom_attributes(attribute_type: System.Type, inherit: bool) -> System.Object[];
+
+        @IL.name("GetCustomAttributesData")
+        get_custom_attributes_data() -> Collections.MutableList[System.Reflection.CustomAttributeData];
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name.read("get_MemberType") 
+        member_type: System.Reflection.MemberTypes;
+
+        @IL.name.read("get_Attributes") 
+        attributes: System.Reflection.FieldAttributes;
+
+        @IL.name.read("get_FieldType") 
+        field_type: System.Type;
+
+        @IL.name.read("get_IsInitOnly") 
+        is_init_only: bool;
+
+        @IL.name.read("get_IsLiteral") 
+        is_literal: bool;
+
+        @IL.name.read("get_IsNotSerialized") 
+        is_not_serialized: bool;
+
+        @IL.name.read("get_IsPinvokeImpl") 
+        is_pinvoke_impl: bool;
+
+        @IL.name.read("get_IsSpecialName") 
+        is_special_name: bool;
+
+        @IL.name.read("get_IsStatic") 
+        is_static: bool;
+
+        @IL.name.read("get_IsAssembly") 
+        is_assembly: bool;
+
+        @IL.name.read("get_IsFamily") 
+        is_family: bool;
+
+        @IL.name.read("get_IsFamilyAndAssembly") 
+        is_family_and_assembly: bool;
+
+        @IL.name.read("get_IsFamilyOrAssembly") 
+        is_family_or_assembly: bool;
+
+        @IL.name.read("get_IsPrivate") 
+        is_private: bool;
+
+        @IL.name.read("get_IsPublic") 
+        is_public: bool;
+
+        @IL.name.read("get_IsSecurityCritical") 
+        is_security_critical: bool;
+
+        @IL.name.read("get_IsSecuritySafeCritical") 
+        is_security_safe_critical: bool;
+
+        @IL.name.read("get_IsSecurityTransparent") 
+        is_security_transparent: bool;
+
+        @IL.name.read("get_FieldHandle") 
+        field_handle: System.RuntimeFieldHandle;
+
+        @IL.name.read("get_Name") 
+        name: System.String;
+
+        @IL.name.read("get_DeclaringType") 
+        declaring_type: System.Type;
+
+        @IL.name.read("get_ReflectedType") 
+        reflected_type: System.Type;
+
+        @IL.name.read("get_Module") 
+        module: System.Reflection.Module;
+
+        @IL.name.read("get_CustomAttributes") 
+        custom_attributes: Collections.Iterable[System.Reflection.CustomAttributeData];
+
+        @IL.name.read("get_IsCollectible") 
+        is_collectible: bool;
+
+        @IL.name.read("get_MetadataToken") 
+        metadata_token: int;
+
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Reflection.ConstructorInfo")
+    class ConstructorInfo: System.Reflection.MethodBase,System.Reflection.ICustomAttributeProvider is
+        @IL.name("Invoke")
+        invoke(parameters: System.Object[]) -> System.Object;
+
+        @IL.name("Invoke")
+        invoke(invoke_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, parameters: System.Object[], culture: System.Globalization.CultureInfo) -> System.Object;
+
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("GetParameters")
+        get_parameters() -> System.Reflection.ParameterInfo[];
+
+        @IL.name("GetMethodImplementationFlags")
+        get_method_implementation_flags() -> System.Reflection.MethodImplAttributes;
+
+        @IL.name("GetMethodBody")
+        get_method_body() -> System.Reflection.MethodBody;
+
+        @IL.name("GetGenericArguments")
+        get_generic_arguments() -> System.Type[];
+
+        @IL.name("Invoke")
+        invoke(obj: System.Object, parameters: System.Object[]) -> System.Object;
+
+        @IL.name("Invoke")
+        invoke(obj: System.Object, invoke_attr: System.Reflection.BindingFlags, binder: System.Reflection.Binder, parameters: System.Object[], culture: System.Globalization.CultureInfo) -> System.Object;
+
+        @IL.name("HasSameMetadataDefinitionAs")
+        has_same_metadata_definition_as(other: System.Reflection.MemberInfo) -> bool;
+
+        @IL.name("IsDefined")
+        is_defined(attribute_type: System.Type, inherit: bool) -> bool;
+
+        @IL.name("GetCustomAttributes")
+        get_custom_attributes(inherit: bool) -> System.Object[];
+
+        @IL.name("GetCustomAttributes")
+        get_custom_attributes(attribute_type: System.Type, inherit: bool) -> System.Object[];
+
+        @IL.name("GetCustomAttributesData")
+        get_custom_attributes_data() -> Collections.MutableList[System.Reflection.CustomAttributeData];
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name.read("get_MemberType") 
+        member_type: System.Reflection.MemberTypes;
+
+        @IL.name.read("get_Attributes") 
+        attributes: System.Reflection.MethodAttributes;
+
+        @IL.name.read("get_MethodImplementationFlags") 
+        method_implementation_flags: System.Reflection.MethodImplAttributes;
+
+        @IL.name.read("get_CallingConvention") 
+        calling_convention: System.Reflection.CallingConventions;
+
+        @IL.name.read("get_IsAbstract") 
+        is_abstract: bool;
+
+        @IL.name.read("get_IsConstructor") 
+        is_constructor: bool;
+
+        @IL.name.read("get_IsFinal") 
+        is_final: bool;
+
+        @IL.name.read("get_IsHideBySig") 
+        is_hide_by_sig: bool;
+
+        @IL.name.read("get_IsSpecialName") 
+        is_special_name: bool;
+
+        @IL.name.read("get_IsStatic") 
+        is_static: bool;
+
+        @IL.name.read("get_IsVirtual") 
+        is_virtual: bool;
+
+        @IL.name.read("get_IsAssembly") 
+        is_assembly: bool;
+
+        @IL.name.read("get_IsFamily") 
+        is_family: bool;
+
+        @IL.name.read("get_IsFamilyAndAssembly") 
+        is_family_and_assembly: bool;
+
+        @IL.name.read("get_IsFamilyOrAssembly") 
+        is_family_or_assembly: bool;
+
+        @IL.name.read("get_IsPrivate") 
+        is_private: bool;
+
+        @IL.name.read("get_IsPublic") 
+        is_public: bool;
+
+        @IL.name.read("get_IsConstructedGenericMethod") 
+        is_constructed_generic_method: bool;
+
+        @IL.name.read("get_IsGenericMethod") 
+        is_generic_method: bool;
+
+        @IL.name.read("get_IsGenericMethodDefinition") 
+        is_generic_method_definition: bool;
+
+        @IL.name.read("get_ContainsGenericParameters") 
+        contains_generic_parameters: bool;
+
+        @IL.name.read("get_MethodHandle") 
+        method_handle: System.RuntimeMethodHandle;
+
+        @IL.name.read("get_IsSecurityCritical") 
+        is_security_critical: bool;
+
+        @IL.name.read("get_IsSecuritySafeCritical") 
+        is_security_safe_critical: bool;
+
+        @IL.name.read("get_IsSecurityTransparent") 
+        is_security_transparent: bool;
+
+        @IL.name.read("get_Name") 
+        name: System.String;
+
+        @IL.name.read("get_DeclaringType") 
+        declaring_type: System.Type;
+
+        @IL.name.read("get_ReflectedType") 
+        reflected_type: System.Type;
+
+        @IL.name.read("get_Module") 
+        module: System.Reflection.Module;
+
+        @IL.name.read("get_CustomAttributes") 
+        custom_attributes: Collections.Iterable[System.Reflection.CustomAttributeData];
+
+        @IL.name.read("get_IsCollectible") 
+        is_collectible: bool;
+
+        @IL.name.read("get_MetadataToken") 
+        metadata_token: int;
+
+        @IL.name("ConstructorName")
+        _constructor_name: System.String public;
+        @IL.name("TypeConstructorName")
+        _type_constructor_name: System.String public;
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Reflection.BindingFlags")
+    struct BindingFlags is
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("HasFlag")
+        has_flag(flag: System.Enum) -> bool;
+
+        @IL.name("CompareTo")
+        compare_to(target: System.Object) -> int;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("ToString")
+        to_string(format: System.String, provider: System.IFormatProvider) -> System.String;
+
+        @IL.name("ToString")
+        to_string(format: System.String) -> System.String;
+
+        @IL.name("ToString")
+        to_string(provider: System.IFormatProvider) -> System.String;
+
+        @IL.name("GetTypeCode")
+        get_type_code() -> System.TypeCode;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name("Default")
+        _default: System.Reflection.BindingFlags public;
+        @IL.name("IgnoreCase")
+        _ignore_case: System.Reflection.BindingFlags public;
+        @IL.name("DeclaredOnly")
+        _declared_only: System.Reflection.BindingFlags public;
+        @IL.name("Instance")
+        _instance: System.Reflection.BindingFlags public;
+        @IL.name("Static")
+        _static: System.Reflection.BindingFlags public;
+        @IL.name("Public")
+        _public: System.Reflection.BindingFlags public;
+        @IL.name("NonPublic")
+        _non_public: System.Reflection.BindingFlags public;
+        @IL.name("FlattenHierarchy")
+        _flatten_hierarchy: System.Reflection.BindingFlags public;
+        @IL.name("InvokeMethod")
+        _invoke_method: System.Reflection.BindingFlags public;
+        @IL.name("CreateInstance")
+        _create_instance: System.Reflection.BindingFlags public;
+        @IL.name("GetField")
+        _get_field: System.Reflection.BindingFlags public;
+        @IL.name("SetField")
+        _set_field: System.Reflection.BindingFlags public;
+        @IL.name("GetProperty")
+        _get_property: System.Reflection.BindingFlags public;
+        @IL.name("SetProperty")
+        _set_property: System.Reflection.BindingFlags public;
+        @IL.name("PutDispProperty")
+        _put_disp_property: System.Reflection.BindingFlags public;
+        @IL.name("PutRefDispProperty")
+        _put_ref_disp_property: System.Reflection.BindingFlags public;
+        @IL.name("ExactBinding")
+        _exact_binding: System.Reflection.BindingFlags public;
+        @IL.name("SuppressChangeType")
+        _suppress_change_type: System.Reflection.BindingFlags public;
+        @IL.name("OptionalParamBinding")
+        _optional_param_binding: System.Reflection.BindingFlags public;
+        @IL.name("IgnoreReturn")
+        _ignore_return: System.Reflection.BindingFlags public;
+        @IL.name("DoNotWrapExceptions")
+        _do_not_wrap_exceptions: System.Reflection.BindingFlags public;
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Reflection.Binder")
+    class Binder: System.Object is
+        @IL.name("BindToField")
+        bind_to_field(binding_attr: System.Reflection.BindingFlags, match: System.Reflection.FieldInfo[], value: System.Object, culture: System.Globalization.CultureInfo) -> System.Reflection.FieldInfo;
+
+        @IL.name("BindToMethod")
+        bind_to_method(binding_attr: System.Reflection.BindingFlags, match: System.Reflection.MethodBase[], args: System.Object[] ref, modifiers: System.Reflection.ParameterModifier[], culture: System.Globalization.CultureInfo, names: System.String[], state: System.Object ref) -> System.Reflection.MethodBase;
+
+        @IL.name("ChangeType")
+        change_type(value: System.Object, type: System.Type, culture: System.Globalization.CultureInfo) -> System.Object;
+
+        @IL.name("ReorderArgumentArray")
+        reorder_argument_array(args: System.Object[] ref, state: System.Object);
+
+        @IL.name("SelectMethod")
+        select_method(binding_attr: System.Reflection.BindingFlags, match: System.Reflection.MethodBase[], types: System.Type[], modifiers: System.Reflection.ParameterModifier[]) -> System.Reflection.MethodBase;
+
+        @IL.name("SelectProperty")
+        select_property(binding_attr: System.Reflection.BindingFlags, match: System.Reflection.PropertyInfo[], return_type: System.Type, indexes: System.Type[], modifiers: System.Reflection.ParameterModifier[]) -> System.Reflection.PropertyInfo;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Reflection.CallingConventions")
+    struct CallingConventions is
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("HasFlag")
+        has_flag(flag: System.Enum) -> bool;
+
+        @IL.name("CompareTo")
+        compare_to(target: System.Object) -> int;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("ToString")
+        to_string(format: System.String, provider: System.IFormatProvider) -> System.String;
+
+        @IL.name("ToString")
+        to_string(format: System.String) -> System.String;
+
+        @IL.name("ToString")
+        to_string(provider: System.IFormatProvider) -> System.String;
+
+        @IL.name("GetTypeCode")
+        get_type_code() -> System.TypeCode;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name("Standard")
+        _standard: System.Reflection.CallingConventions public;
+        @IL.name("VarArgs")
+        _var_args: System.Reflection.CallingConventions public;
+        @IL.name("Any")
+        _any: System.Reflection.CallingConventions public;
+        @IL.name("HasThis")
+        _has_this: System.Reflection.CallingConventions public;
+        @IL.name("ExplicitThis")
+        _explicit_this: System.Reflection.CallingConventions public;
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Reflection.EventInfo")
+    class EventInfo: System.Reflection.MemberInfo,System.Reflection.ICustomAttributeProvider is
+        @IL.name("GetOtherMethods")
+        get_other_methods() -> System.Reflection.MethodInfo[];
+
+        @IL.name("GetOtherMethods")
+        get_other_methods(non_public: bool) -> System.Reflection.MethodInfo[];
+
+        @IL.name("GetAddMethod")
+        get_add_method() -> System.Reflection.MethodInfo;
+
+        @IL.name("GetRemoveMethod")
+        get_remove_method() -> System.Reflection.MethodInfo;
+
+        @IL.name("GetRaiseMethod")
+        get_raise_method() -> System.Reflection.MethodInfo;
+
+        @IL.name("GetAddMethod")
+        get_add_method(non_public: bool) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetRemoveMethod")
+        get_remove_method(non_public: bool) -> System.Reflection.MethodInfo;
+
+        @IL.name("GetRaiseMethod")
+        get_raise_method(non_public: bool) -> System.Reflection.MethodInfo;
+
+        @IL.name("AddEventHandler")
+        add_event_handler(target: System.Object, handler: System.Delegate);
+
+        @IL.name("RemoveEventHandler")
+        remove_event_handler(target: System.Object, handler: System.Delegate);
+
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("HasSameMetadataDefinitionAs")
+        has_same_metadata_definition_as(other: System.Reflection.MemberInfo) -> bool;
+
+        @IL.name("IsDefined")
+        is_defined(attribute_type: System.Type, inherit: bool) -> bool;
+
+        @IL.name("GetCustomAttributes")
+        get_custom_attributes(inherit: bool) -> System.Object[];
+
+        @IL.name("GetCustomAttributes")
+        get_custom_attributes(attribute_type: System.Type, inherit: bool) -> System.Object[];
+
+        @IL.name("GetCustomAttributesData")
+        get_custom_attributes_data() -> Collections.MutableList[System.Reflection.CustomAttributeData];
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name.read("get_MemberType") 
+        member_type: System.Reflection.MemberTypes;
+
+        @IL.name.read("get_Attributes") 
+        attributes: System.Reflection.EventAttributes;
+
+        @IL.name.read("get_IsSpecialName") 
+        is_special_name: bool;
+
+        @IL.name.read("get_AddMethod") 
+        add_method: System.Reflection.MethodInfo;
+
+        @IL.name.read("get_RemoveMethod") 
+        remove_method: System.Reflection.MethodInfo;
+
+        @IL.name.read("get_RaiseMethod") 
+        raise_method: System.Reflection.MethodInfo;
+
+        @IL.name.read("get_IsMulticast") 
+        is_multicast: bool;
+
+        @IL.name.read("get_EventHandlerType") 
+        event_handler_type: System.Type;
+
+        @IL.name.read("get_Name") 
+        name: System.String;
+
+        @IL.name.read("get_DeclaringType") 
+        declaring_type: System.Type;
+
+        @IL.name.read("get_ReflectedType") 
+        reflected_type: System.Type;
+
+        @IL.name.read("get_Module") 
+        module: System.Reflection.Module;
+
+        @IL.name.read("get_CustomAttributes") 
+        custom_attributes: Collections.Iterable[System.Reflection.CustomAttributeData];
+
+        @IL.name.read("get_IsCollectible") 
+        is_collectible: bool;
+
+        @IL.name.read("get_MetadataToken") 
+        metadata_token: int;
+
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Reflection.MemberTypes")
+    struct MemberTypes is
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("HasFlag")
+        has_flag(flag: System.Enum) -> bool;
+
+        @IL.name("CompareTo")
+        compare_to(target: System.Object) -> int;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("ToString")
+        to_string(format: System.String, provider: System.IFormatProvider) -> System.String;
+
+        @IL.name("ToString")
+        to_string(format: System.String) -> System.String;
+
+        @IL.name("ToString")
+        to_string(provider: System.IFormatProvider) -> System.String;
+
+        @IL.name("GetTypeCode")
+        get_type_code() -> System.TypeCode;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name("Constructor")
+        _constructor: System.Reflection.MemberTypes public;
+        @IL.name("Event")
+        _event: System.Reflection.MemberTypes public;
+        @IL.name("Field")
+        _field: System.Reflection.MemberTypes public;
+        @IL.name("Method")
+        _method: System.Reflection.MemberTypes public;
+        @IL.name("Property")
+        _property: System.Reflection.MemberTypes public;
+        @IL.name("TypeInfo")
+        _type_info: System.Reflection.MemberTypes public;
+        @IL.name("Custom")
+        _custom: System.Reflection.MemberTypes public;
+        @IL.name("NestedType")
+        _nested_type: System.Reflection.MemberTypes public;
+        @IL.name("All")
+        _all: System.Reflection.MemberTypes public;
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Reflection.TypeFilter")
+    class TypeFilter: System.MulticastDelegate,System.ICloneable,System.Runtime.Serialization.ISerializable is
+        @IL.name("Invoke")
+        invoke(m: System.Type, filter_criteria: System.Object) -> bool;
+
+        @IL.name("BeginInvoke")
+        begin_invoke(m: System.Type, filter_criteria: System.Object, callback: System.AsyncCallback, object: System.Object) -> System.IAsyncResult;
+
+        @IL.name("EndInvoke")
+        end_invoke(result: System.IAsyncResult) -> bool;
+
+        @IL.name("GetObjectData")
+        get_object_data(info: System.Runtime.Serialization.SerializationInfo, context: System.Runtime.Serialization.StreamingContext);
+
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("GetInvocationList")
+        get_invocation_list() -> System.Delegate[];
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("Clone")
+        clone() -> System.Object;
+
+        @IL.name("DynamicInvoke")
+        dynamic_invoke(args: System.Object[]) -> System.Object;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name(".ctor")
+        init(object: System.Object, method: word);
+        @IL.name.read("get_Target") 
+        target: System.Object;
+
+        @IL.name.read("get_Method") 
+        method: System.Reflection.MethodInfo;
+
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Reflection.InterfaceMapping")
+    struct InterfaceMapping is
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name("TargetType")
+        _target_type: System.Type public;
+        @IL.name("InterfaceType")
+        _interface_type: System.Type public;
+        @IL.name("TargetMethods")
+        _target_methods: System.Reflection.MethodInfo[] public;
+        @IL.name("InterfaceMethods")
+        _interface_methods: System.Reflection.MethodInfo[] public;
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Reflection.MethodBase")
+    class MethodBase: System.Reflection.MemberInfo,System.Reflection.ICustomAttributeProvider is
     si
     @IL.stub()
     @IL.name("class [mscorlib]System.Reflection.ICustomAttributeProvider")
     trait ICustomAttributeProvider is
     si
     @IL.stub()
-    @IL.name("class [mscorlib]System.Reflection.MemberInfo")
-    class MemberInfo: System.Object,System.Reflection.ICustomAttributeProvider is
+    @IL.name("class [mscorlib]System.Reflection.AssemblyName")
+    class AssemblyName: System.Object,System.ICloneable,System.Runtime.Serialization.IDeserializationCallback,System.Runtime.Serialization.ISerializable is
     si
     @IL.stub()
-    @IL.name("class [mscorlib]System.Reflection.MethodInfo")
-    class MethodInfo: System.Reflection.MethodBase,System.Reflection.ICustomAttributeProvider is
+    @IL.name("class [mscorlib]System.Reflection.ManifestResourceInfo")
+    class ManifestResourceInfo: System.Object is
     si
     @IL.stub()
-    @IL.name("class [mscorlib]System.Reflection.MethodBase")
-    class MethodBase: System.Reflection.MemberInfo,System.Reflection.ICustomAttributeProvider is
+    @IL.name("class [mscorlib]System.Reflection.CustomAttributeData")
+    class CustomAttributeData: System.Object is
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Reflection.PortableExecutableKinds")
+    struct PortableExecutableKinds is
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Reflection.ImageFileMachine")
+    struct ImageFileMachine is
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Reflection.ParameterModifier")
+    struct ParameterModifier is
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Reflection.IReflect")
+    trait IReflect is
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Reflection.MemberFilter")
+    class MemberFilter: System.MulticastDelegate,System.ICloneable,System.Runtime.Serialization.ISerializable is
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Reflection.GenericParameterAttributes")
+    struct GenericParameterAttributes is
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Reflection.TypeAttributes")
+    struct TypeAttributes is
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Reflection.ParameterInfo")
+    class ParameterInfo: System.Object,System.Reflection.ICustomAttributeProvider,System.Runtime.Serialization.IObjectReference is
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Reflection.MethodImplAttributes")
+    struct MethodImplAttributes is
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Reflection.MethodBody")
+    class MethodBody: System.Object is
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Reflection.MethodAttributes")
+    struct MethodAttributes is
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Reflection.PropertyAttributes")
+    struct PropertyAttributes is
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Reflection.IReflectableType")
+    trait IReflectableType is
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Reflection.FieldAttributes")
+    struct FieldAttributes is
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Reflection.EventAttributes")
+    struct EventAttributes is
     si
 si

--- a/lib/dotnet/stubs/system.runtime.compilerservices.ghul
+++ b/lib/dotnet/stubs/system.runtime.compilerservices.ghul
@@ -3,4 +3,40 @@ namespace System.Runtime.CompilerServices is
     @IL.name("class [mscorlib]System.Runtime.CompilerServices.ITuple")
     trait ITuple is
     si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter")
+    struct TaskAwaiter: System.Runtime.CompilerServices.ICriticalNotifyCompletion,System.Runtime.CompilerServices.INotifyCompletion,System.Runtime.CompilerServices.ITaskAwaiter is
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Runtime.CompilerServices.ITaskAwaiter")
+    trait ITaskAwaiter is
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Runtime.CompilerServices.INotifyCompletion")
+    trait INotifyCompletion is
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Runtime.CompilerServices.ICriticalNotifyCompletion")
+    trait ICriticalNotifyCompletion: System.Runtime.CompilerServices.INotifyCompletion is
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable")
+    struct ConfiguredTaskAwaitable is
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Runtime.CompilerServices.YieldAwaitable")
+    struct YieldAwaitable is
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Runtime.CompilerServices.ValueTaskAwaiter")
+    struct ValueTaskAwaiter: System.Runtime.CompilerServices.ICriticalNotifyCompletion,System.Runtime.CompilerServices.INotifyCompletion,System.Runtime.CompilerServices.IStateMachineBoxAwareAwaiter is
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Runtime.CompilerServices.IStateMachineBoxAwareAwaiter")
+    trait IStateMachineBoxAwareAwaiter is
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable")
+    struct ConfiguredValueTaskAwaitable is
+    si
 si

--- a/lib/dotnet/stubs/system.runtime.constrainedexecution.ghul
+++ b/lib/dotnet/stubs/system.runtime.constrainedexecution.ghul
@@ -1,0 +1,6 @@
+namespace System.Runtime.ConstrainedExecution is
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Runtime.ConstrainedExecution.CriticalFinalizerObject")
+    class CriticalFinalizerObject: System.Object is
+    si
+si

--- a/lib/dotnet/stubs/system.runtime.interopservices.ghul
+++ b/lib/dotnet/stubs/system.runtime.interopservices.ghul
@@ -1,0 +1,46 @@
+namespace System.Runtime.InteropServices is
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Runtime.InteropServices.SafeHandle")
+    class SafeHandle: System.Runtime.ConstrainedExecution.CriticalFinalizerObject,System.IDisposable is
+        @IL.name("DangerousGetHandle")
+        dangerous_get_handle() -> word;
+
+        @IL.name("Close")
+        close();
+
+        @IL.name("Dispose")
+        dispose();
+
+        @IL.name("SetHandleAsInvalid")
+        set_handle_as_invalid();
+
+        @IL.name("DangerousAddRef")
+        dangerous_add_ref(success: bool ref);
+
+        @IL.name("DangerousRelease")
+        dangerous_release();
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name.read("get_IsClosed") 
+        is_closed: bool;
+
+        @IL.name.read("get_IsInvalid") 
+        is_invalid: bool;
+
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Runtime.InteropServices.StructLayoutAttribute")
+    class StructLayoutAttribute: System.Attribute is
+    si
+si

--- a/lib/dotnet/stubs/system.runtime.serialization.ghul
+++ b/lib/dotnet/stubs/system.runtime.serialization.ghul
@@ -15,4 +15,8 @@ namespace System.Runtime.Serialization is
 @IL.name("class [mscorlib]System.Runtime.Serialization.IDeserializationCallback")
 trait IDeserializationCallback is
 si
+@IL.stub()
+@IL.name("class [mscorlib]System.Runtime.Serialization.IObjectReference")
+trait IObjectReference is
+si
 si

--- a/lib/dotnet/stubs/system.security.ghul
+++ b/lib/dotnet/stubs/system.security.ghul
@@ -1,0 +1,6 @@
+namespace System.Security is
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Security.SecurityRuleSet")
+    struct SecurityRuleSet is
+    si
+si

--- a/lib/dotnet/stubs/system.text.ghul
+++ b/lib/dotnet/stubs/system.text.ghul
@@ -3,9 +3,6 @@ namespace System.Text is
     @IL.name("class [mscorlib]System.Text.StringBuilder")
     class StringBuilder: System.Object,System.Runtime.Serialization.ISerializable is
         @IL.name("Insert")
-        insert(index: int, value: uint) -> System.Text.StringBuilder;
-
-        @IL.name("Insert")
         insert(index: int, value: ulong) -> System.Text.StringBuilder;
 
         @IL.name("Insert")
@@ -216,6 +213,9 @@ namespace System.Text is
         @IL.name("Insert")
         insert(index: int, value: ushort) -> System.Text.StringBuilder;
 
+        @IL.name("Insert")
+        insert(index: int, value: uint) -> System.Text.StringBuilder;
+
         @IL.name("GetType")
         get_type() -> System.Type;
 
@@ -260,8 +260,8 @@ namespace System.Text is
     @IL.name("valuetype [mscorlib]System.Text.NormalizationForm")
     struct NormalizationForm is
     si
-    @IL.stub()
-    @IL.name("class [mscorlib]System.Text.Encoding")
-    class Encoding: System.Object,System.ICloneable is
-    si
+@IL.stub()
+@IL.name("class [mscorlib]System.Text.Encoding")
+class Encoding: System.Object,System.ICloneable is
+si
 si

--- a/lib/dotnet/stubs/system.threading.ghul
+++ b/lib/dotnet/stubs/system.threading.ghul
@@ -1,0 +1,6 @@
+namespace System.Threading is
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Threading.CancellationToken")
+    struct CancellationToken is
+    si
+si

--- a/lib/dotnet/stubs/system.threading.tasks.ghul
+++ b/lib/dotnet/stubs/system.threading.tasks.ghul
@@ -1,0 +1,328 @@
+namespace System.Threading.Tasks is
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Threading.Tasks.Task")
+    class Task_0: System.Object,System.IAsyncResult,System.IDisposable is
+        @IL.name("WaitAny")
+        wait_any(tasks: System.Threading.Tasks.Task_0[]) -> int static;
+
+        @IL.name("WaitAny")
+        wait_any(tasks: System.Threading.Tasks.Task_0[], timeout: System.TimeSpan) -> int static;
+
+        @IL.name("WaitAny")
+        wait_any(tasks: System.Threading.Tasks.Task_0[], cancellation_token: System.Threading.CancellationToken) -> int static;
+
+        @IL.name("WaitAny")
+        wait_any(tasks: System.Threading.Tasks.Task_0[], milliseconds_timeout: int) -> int static;
+
+        @IL.name("WaitAny")
+        wait_any(tasks: System.Threading.Tasks.Task_0[], milliseconds_timeout: int, cancellation_token: System.Threading.CancellationToken) -> int static;
+
+        // from_result[TResult](result: TResult) -> System.Threading.Tasks.Task[TResult] static;
+
+        @IL.name("FromException")
+        from_exception(exception: System.Exception) -> System.Threading.Tasks.Task_0 static;
+
+        // from_exception[TResult](exception: System.Exception) -> System.Threading.Tasks.Task[TResult] static;
+
+        @IL.name("FromCanceled")
+        from_canceled(cancellation_token: System.Threading.CancellationToken) -> System.Threading.Tasks.Task_0 static;
+
+        // from_canceled[TResult](cancellation_token: System.Threading.CancellationToken) -> System.Threading.Tasks.Task[TResult] static;
+
+        @IL.name("Run")
+        run(action: Ghul.ACTION_0) -> System.Threading.Tasks.Task_0 static;
+
+        @IL.name("Run")
+        run(action: Ghul.ACTION_0, cancellation_token: System.Threading.CancellationToken) -> System.Threading.Tasks.Task_0 static;
+
+        // run[TResult](function: Ghul.FUNCTION_0[TResult]) -> System.Threading.Tasks.Task[TResult] static;
+
+        // run[TResult](function: Ghul.FUNCTION_0[TResult], cancellation_token: System.Threading.CancellationToken) -> System.Threading.Tasks.Task[TResult] static;
+
+        @IL.name("Run")
+        run(function: Ghul.FUNCTION_0[System.Threading.Tasks.Task_0]) -> System.Threading.Tasks.Task_0 static;
+
+        @IL.name("Run")
+        run(function: Ghul.FUNCTION_0[System.Threading.Tasks.Task_0], cancellation_token: System.Threading.CancellationToken) -> System.Threading.Tasks.Task_0 static;
+
+        // run[TResult](function: Ghul.FUNCTION_0[System.Threading.Tasks.Task[TResult]]) -> System.Threading.Tasks.Task[TResult] static;
+
+        // run[TResult](function: Ghul.FUNCTION_0[System.Threading.Tasks.Task[TResult]], cancellation_token: System.Threading.CancellationToken) -> System.Threading.Tasks.Task[TResult] static;
+
+        @IL.name("Delay")
+        delay(delay: System.TimeSpan) -> System.Threading.Tasks.Task_0 static;
+
+        @IL.name("Delay")
+        delay(delay: System.TimeSpan, cancellation_token: System.Threading.CancellationToken) -> System.Threading.Tasks.Task_0 static;
+
+        @IL.name("Delay")
+        delay(milliseconds_delay: int) -> System.Threading.Tasks.Task_0 static;
+
+        @IL.name("Delay")
+        delay(milliseconds_delay: int, cancellation_token: System.Threading.CancellationToken) -> System.Threading.Tasks.Task_0 static;
+
+        @IL.name("WhenAll")
+        when_all(tasks: Collections.Iterable[System.Threading.Tasks.Task_0]) -> System.Threading.Tasks.Task_0 static;
+
+        @IL.name("WhenAll")
+        when_all(tasks: System.Threading.Tasks.Task_0[]) -> System.Threading.Tasks.Task_0 static;
+
+        // when_all[TResult](tasks: Collections.Iterable[System.Threading.Tasks.Task[TResult]]) -> System.Threading.Tasks.Task[TResult[]] static;
+
+        // when_all[TResult](tasks: System.Threading.Tasks.Task[TResult][]) -> System.Threading.Tasks.Task[TResult[]] static;
+
+        @IL.name("WhenAny")
+        when_any(tasks: System.Threading.Tasks.Task_0[]) -> System.Threading.Tasks.Task[System.Threading.Tasks.Task_0] static;
+
+        @IL.name("WhenAny")
+        when_any(tasks: Collections.Iterable[System.Threading.Tasks.Task_0]) -> System.Threading.Tasks.Task[System.Threading.Tasks.Task_0] static;
+
+        // when_any[TResult](tasks: System.Threading.Tasks.Task[TResult][]) -> System.Threading.Tasks.Task[System.Threading.Tasks.Task[TResult]] static;
+
+        // when_any[TResult](tasks: Collections.Iterable[System.Threading.Tasks.Task[TResult]]) -> System.Threading.Tasks.Task[System.Threading.Tasks.Task[TResult]] static;
+
+        @IL.name("GetAwaiter")
+        get_awaiter() -> System.Runtime.CompilerServices.TaskAwaiter;
+
+        @IL.name("ConfigureAwait")
+        configure_await(continue_on_captured_context: bool) -> System.Runtime.CompilerServices.ConfiguredTaskAwaitable;
+
+        @IL.name("Yield")
+        yield() -> System.Runtime.CompilerServices.YieldAwaitable static;
+
+        @IL.name("Wait")
+        wait();
+
+        @IL.name("Wait")
+        wait(timeout: System.TimeSpan) -> bool;
+
+        @IL.name("Wait")
+        wait(cancellation_token: System.Threading.CancellationToken);
+
+        @IL.name("Wait")
+        wait(milliseconds_timeout: int) -> bool;
+
+        @IL.name("Wait")
+        wait(milliseconds_timeout: int, cancellation_token: System.Threading.CancellationToken) -> bool;
+
+        @IL.name("ContinueWith")
+        continue_with(continuation_action: Ghul.ACTION_1[System.Threading.Tasks.Task_0]) -> System.Threading.Tasks.Task_0;
+
+        @IL.name("ContinueWith")
+        continue_with(continuation_action: Ghul.ACTION_1[System.Threading.Tasks.Task_0], cancellation_token: System.Threading.CancellationToken) -> System.Threading.Tasks.Task_0;
+
+        @IL.name("ContinueWith")
+        continue_with(continuation_action: Ghul.ACTION_1[System.Threading.Tasks.Task_0], scheduler: System.Threading.Tasks.TaskScheduler) -> System.Threading.Tasks.Task_0;
+
+        @IL.name("ContinueWith")
+        continue_with(continuation_action: Ghul.ACTION_1[System.Threading.Tasks.Task_0], continuation_options: System.Threading.Tasks.TaskContinuationOptions) -> System.Threading.Tasks.Task_0;
+
+        @IL.name("ContinueWith")
+        continue_with(continuation_action: Ghul.ACTION_1[System.Threading.Tasks.Task_0], cancellation_token: System.Threading.CancellationToken, continuation_options: System.Threading.Tasks.TaskContinuationOptions, scheduler: System.Threading.Tasks.TaskScheduler) -> System.Threading.Tasks.Task_0;
+
+        @IL.name("ContinueWith")
+        continue_with(continuation_action: Ghul.ACTION_2[System.Threading.Tasks.Task_0,System.Object], state: System.Object) -> System.Threading.Tasks.Task_0;
+
+        @IL.name("ContinueWith")
+        continue_with(continuation_action: Ghul.ACTION_2[System.Threading.Tasks.Task_0,System.Object], state: System.Object, cancellation_token: System.Threading.CancellationToken) -> System.Threading.Tasks.Task_0;
+
+        @IL.name("ContinueWith")
+        continue_with(continuation_action: Ghul.ACTION_2[System.Threading.Tasks.Task_0,System.Object], state: System.Object, scheduler: System.Threading.Tasks.TaskScheduler) -> System.Threading.Tasks.Task_0;
+
+        @IL.name("ContinueWith")
+        continue_with(continuation_action: Ghul.ACTION_2[System.Threading.Tasks.Task_0,System.Object], state: System.Object, continuation_options: System.Threading.Tasks.TaskContinuationOptions) -> System.Threading.Tasks.Task_0;
+
+        @IL.name("ContinueWith")
+        continue_with(continuation_action: Ghul.ACTION_2[System.Threading.Tasks.Task_0,System.Object], state: System.Object, cancellation_token: System.Threading.CancellationToken, continuation_options: System.Threading.Tasks.TaskContinuationOptions, scheduler: System.Threading.Tasks.TaskScheduler) -> System.Threading.Tasks.Task_0;
+
+        // continue_with[TResult](continuation_function: Ghul.FUNCTION_1[System.Threading.Tasks.Task_0,TResult]) -> System.Threading.Tasks.Task[TResult];
+
+        // continue_with[TResult](continuation_function: Ghul.FUNCTION_1[System.Threading.Tasks.Task_0,TResult], cancellation_token: System.Threading.CancellationToken) -> System.Threading.Tasks.Task[TResult];
+
+        // continue_with[TResult](continuation_function: Ghul.FUNCTION_1[System.Threading.Tasks.Task_0,TResult], scheduler: System.Threading.Tasks.TaskScheduler) -> System.Threading.Tasks.Task[TResult];
+
+        // continue_with[TResult](continuation_function: Ghul.FUNCTION_1[System.Threading.Tasks.Task_0,TResult], continuation_options: System.Threading.Tasks.TaskContinuationOptions) -> System.Threading.Tasks.Task[TResult];
+
+        // continue_with[TResult](continuation_function: Ghul.FUNCTION_1[System.Threading.Tasks.Task_0,TResult], cancellation_token: System.Threading.CancellationToken, continuation_options: System.Threading.Tasks.TaskContinuationOptions, scheduler: System.Threading.Tasks.TaskScheduler) -> System.Threading.Tasks.Task[TResult];
+
+        // continue_with[TResult](continuation_function: Ghul.FUNCTION_2[System.Threading.Tasks.Task_0,System.Object,TResult], state: System.Object) -> System.Threading.Tasks.Task[TResult];
+
+        // continue_with[TResult](continuation_function: Ghul.FUNCTION_2[System.Threading.Tasks.Task_0,System.Object,TResult], state: System.Object, cancellation_token: System.Threading.CancellationToken) -> System.Threading.Tasks.Task[TResult];
+
+        // continue_with[TResult](continuation_function: Ghul.FUNCTION_2[System.Threading.Tasks.Task_0,System.Object,TResult], state: System.Object, scheduler: System.Threading.Tasks.TaskScheduler) -> System.Threading.Tasks.Task[TResult];
+
+        // continue_with[TResult](continuation_function: Ghul.FUNCTION_2[System.Threading.Tasks.Task_0,System.Object,TResult], state: System.Object, continuation_options: System.Threading.Tasks.TaskContinuationOptions) -> System.Threading.Tasks.Task[TResult];
+
+        // continue_with[TResult](continuation_function: Ghul.FUNCTION_2[System.Threading.Tasks.Task_0,System.Object,TResult], state: System.Object, cancellation_token: System.Threading.CancellationToken, continuation_options: System.Threading.Tasks.TaskContinuationOptions, scheduler: System.Threading.Tasks.TaskScheduler) -> System.Threading.Tasks.Task[TResult];
+
+        @IL.name("WaitAll")
+        wait_all(tasks: System.Threading.Tasks.Task_0[]) static;
+
+        @IL.name("WaitAll")
+        wait_all(tasks: System.Threading.Tasks.Task_0[], timeout: System.TimeSpan) -> bool static;
+
+        @IL.name("WaitAll")
+        wait_all(tasks: System.Threading.Tasks.Task_0[], milliseconds_timeout: int) -> bool static;
+
+        @IL.name("WaitAll")
+        wait_all(tasks: System.Threading.Tasks.Task_0[], cancellation_token: System.Threading.CancellationToken) static;
+
+        @IL.name("WaitAll")
+        wait_all(tasks: System.Threading.Tasks.Task_0[], milliseconds_timeout: int, cancellation_token: System.Threading.CancellationToken) -> bool static;
+
+        @IL.name("Start")
+        start();
+
+        @IL.name("Start")
+        start(scheduler: System.Threading.Tasks.TaskScheduler);
+
+        @IL.name("RunSynchronously")
+        run_synchronously();
+
+        @IL.name("RunSynchronously")
+        run_synchronously(scheduler: System.Threading.Tasks.TaskScheduler);
+
+        @IL.name("Dispose")
+        dispose();
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name(".ctor")
+        init(action: Ghul.ACTION_0);
+        @IL.name(".ctor")
+        init(action: Ghul.ACTION_0, cancellation_token: System.Threading.CancellationToken);
+        @IL.name(".ctor")
+        init(action: Ghul.ACTION_0, creation_options: System.Threading.Tasks.TaskCreationOptions);
+        @IL.name(".ctor")
+        init(action: Ghul.ACTION_0, cancellation_token: System.Threading.CancellationToken, creation_options: System.Threading.Tasks.TaskCreationOptions);
+        @IL.name(".ctor")
+        init(action: Ghul.ACTION_1[System.Object], state: System.Object);
+        @IL.name(".ctor")
+        init(action: Ghul.ACTION_1[System.Object], state: System.Object, cancellation_token: System.Threading.CancellationToken);
+        @IL.name(".ctor")
+        init(action: Ghul.ACTION_1[System.Object], state: System.Object, creation_options: System.Threading.Tasks.TaskCreationOptions);
+        @IL.name(".ctor")
+        init(action: Ghul.ACTION_1[System.Object], state: System.Object, cancellation_token: System.Threading.CancellationToken, creation_options: System.Threading.Tasks.TaskCreationOptions);
+        @IL.name.read("get_Id") 
+        id: int;
+
+        @IL.name.read("get_CurrentId") 
+        current_id: System.Nullable[int] static;
+
+        @IL.name.read("get_Exception") 
+        exception: System.AggregateException;
+
+        @IL.name.read("get_Status") 
+        status: System.Threading.Tasks.TaskStatus;
+
+        @IL.name.read("get_IsCanceled") 
+        is_canceled: bool;
+
+        @IL.name.read("get_IsCompleted") 
+        is_completed: bool;
+
+        @IL.name.read("get_IsCompletedSuccessfully") 
+        is_completed_successfully: bool;
+
+        @IL.name.read("get_CreationOptions") 
+        creation_options: System.Threading.Tasks.TaskCreationOptions;
+
+        @IL.name.read("get_AsyncState") 
+        async_state: System.Object;
+
+        @IL.name.read("get_Factory") 
+        factory: System.Threading.Tasks.TaskFactory static;
+
+        @IL.name.read("get_CompletedTask") 
+        completed_task: System.Threading.Tasks.Task_0 static;
+
+        @IL.name.read("get_IsFaulted") 
+        is_faulted: bool;
+
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Threading.Tasks.ValueTask")
+    struct ValueTask_0: System.Equatable[System.Threading.Tasks.ValueTask_0] is
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("Equals")
+        equals(other: System.Threading.Tasks.ValueTask_0) -> bool;
+
+        @IL.name("AsTask")
+        as_task() -> System.Threading.Tasks.Task_0;
+
+        @IL.name("Preserve")
+        preserve() -> System.Threading.Tasks.ValueTask_0;
+
+        @IL.name("GetAwaiter")
+        get_awaiter() -> System.Runtime.CompilerServices.ValueTaskAwaiter;
+
+        @IL.name("ConfigureAwait")
+        configure_await(continue_on_captured_context: bool) -> System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("GetType")
+        get_type() -> System.Type;
+
+        @IL.name(".ctor")
+        init(task: System.Threading.Tasks.Task_0);
+        @IL.name(".ctor")
+        init(source: System.Threading.Tasks.Sources.IValueTaskSource, token: short);
+        @IL.name.read("get_IsCompleted") 
+        is_completed: bool;
+
+        @IL.name.read("get_IsCompletedSuccessfully") 
+        is_completed_successfully: bool;
+
+        @IL.name.read("get_IsFaulted") 
+        is_faulted: bool;
+
+        @IL.name.read("get_IsCanceled") 
+        is_canceled: bool;
+
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Threading.Tasks.Task`1")
+    class Task[TResult]: System.Threading.Tasks.Task_0,System.IAsyncResult,System.IDisposable is
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Threading.Tasks.ValueTask`1")
+    struct ValueTask[TResult]: System.Equatable[System.Threading.Tasks.ValueTask[TResult]] is
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Threading.Tasks.TaskScheduler")
+    class TaskScheduler: System.Object is
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Threading.Tasks.TaskContinuationOptions")
+    struct TaskContinuationOptions is
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Threading.Tasks.TaskCreationOptions")
+    struct TaskCreationOptions is
+    si
+    @IL.stub()
+    @IL.name("valuetype [mscorlib]System.Threading.Tasks.TaskStatus")
+    struct TaskStatus is
+    si
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Threading.Tasks.TaskFactory")
+    class TaskFactory: System.Object is
+    si
+si

--- a/lib/dotnet/stubs/system.threading.tasks.sources.ghul
+++ b/lib/dotnet/stubs/system.threading.tasks.sources.ghul
@@ -1,0 +1,6 @@
+namespace System.Threading.Tasks.Sources is
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Threading.Tasks.Sources.IValueTaskSource")
+    trait IValueTaskSource is
+    si
+si

--- a/tests/cases/generic-function-type/test.ghul
+++ b/tests/cases/generic-function-type/test.ghul
@@ -37,11 +37,11 @@ namespace Test.Function is
             let qi = ti.get_tuple();
             check_tuple_int(qi);
 
-            let qi0 = qi.item_0;
+            let qi0 = qi._0;
             check_int(qi0);
-            let qi1 = qi.item_1;
+            let qi1 = qi._1;
             check_int(qi1);
-            let qi2 = qi.item_2;
+            let qi2 = qi._2;
             check_int(qi2);
         si
     si

--- a/tests/cases/integration-arithmetic-minimal/test.ghul
+++ b/tests/cases/integration-arithmetic-minimal/test.ghul
@@ -4,13 +4,13 @@ namespace Test is
             @IL.entrypoint()
 
             let x = 123;
-            System.Console.write_line(x.toString());
+            System.Console.write_line(x.to_string());
 
             let y = 456;
-            System.Console.write_line(y.toString());
+            System.Console.write_line(y.to_string());
 
             let z = x + y;
-            System.Console.write_line(z.toString());
+            System.Console.write_line(z.to_string());
         si
     si
 si


### PR DESCRIPTION
- Downgrade from .NET Core 5.0-pre to .NET Core 3.1
- Map ghul tuples to correct .NET ValueTuple<> types
- Add some of System.Reflection
- Add more of System.IO

See #409 