### PR TITLE
Fix errors when type checking compiler against .NET stubs

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -100,7 +100,7 @@ jobs:
       run: bash ./ghul.run -- -N
 
     - name: Type check
-      run: find src -name '*.ghul' | xargs ghul -L -G -p ./lib
+      run: find src -name '*.ghul' | xargs ghul -N -G -p ./lib
 
   build_tester:
     name: Build tester

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
       run: bash ./ghul.run -- -N
 
     - name: Type check
-      run: find src -name '*.ghul' | xargs ghul -L -G -p ./lib
+      run: find src -name '*.ghul' | xargs ghul -N -G -p ./lib
 
   build_tester:
     name: Build tester

--- a/build/type-check.sh
+++ b/build/type-check.sh
@@ -2,4 +2,5 @@
 
 echo "namespace Source is class BUILD is number: System.String static => \"local-`date +'%s'`\"; si si" >src/source/build.ghul
 
-find src -name '*.ghul' | xargs ./ghul -L -G -p ./lib
+# find src -name '*.ghul' | xargs ./ghul -L -G -p ./lib
+find src -name '*.ghul' | xargs ./ghul -N -G -p ./lib

--- a/lib/dotnet/ghul/ghul.ghul
+++ b/lib/dotnet/ghul/ghul.ghul
@@ -195,10 +195,9 @@ namespace Ghul is
     ::(from: int, to: int) -> INT_RANGE_INCLUSIVE innate range.inclusive;
 si
 
+@IF.legacy()
 @IL.stub()
 namespace System is
-
- 
     class StringBuffer: String is
         init();
         init(initial_capacity: int);
@@ -220,6 +219,7 @@ namespace System is
     si    
 si
 
+@IF.legacy()
 @IL.stub()
 namespace IO is
     use System;

--- a/lib/dotnet/stubs/system.ghul
+++ b/lib/dotnet/stubs/system.ghul
@@ -26,6 +26,107 @@ namespace System is
         @IL.name(".ctor")
         init();
     si
+
+    @IL.stub()
+    @IL.name("class [mscorlib]System.Enum")
+    class Enum: System.ValueType,System.IFormattable,System.IConvertible is
+        @IL.name("Equals")
+        equals(obj: System.Object) -> bool;
+
+        @IL.name("HasFlag")
+        has_flag(flag: System.Enum) -> bool;
+
+        @IL.name("GetName")
+        get_name(enum_type: System.Type2, value: System.Object) -> System.String static;
+
+        @IL.name("GetNames")
+        get_names(enum_type: System.Type2) -> System.String[] static;
+
+        @IL.name("GetUnderlyingType")
+        get_underlying_type(enum_type: System.Type2) -> System.Type2 static;
+
+        @IL.name("GetValues")
+        get_values(enum_type: System.Type2) -> System.Array static;
+
+        @IL.name("IsDefined")
+        is_defined(enum_type: System.Type2, value: System.Object) -> bool static;
+
+        @IL.name("CompareTo")
+        compare_to(target: System.Object) -> int;
+
+        @IL.name("Parse")
+        parse(enum_type: System.Type2, value: System.String) -> System.Object static;
+
+        @IL.name("Parse")
+        parse(enum_type: System.Type2, value: System.String, ignore_case: bool) -> System.Object static;
+
+        // parse[TEnum](value: System.String) -> TEnum static;
+
+        // parse[TEnum](value: System.String, ignore_case: bool) -> TEnum static;
+
+        @IL.name("TryParse")
+        try_parse(enum_type: System.Type2, value: System.String, result: System.Object ref) -> bool static;
+
+        @IL.name("TryParse")
+        try_parse(enum_type: System.Type2, value: System.String, ignore_case: bool, result: System.Object ref) -> bool static;
+
+        // try_parse[TEnum](value: System.String, result: TEnum ref) -> bool static;
+
+        // try_parse[TEnum](value: System.String, ignore_case: bool, result: TEnum ref) -> bool static;
+
+        @IL.name("ToObject")
+        to_object(enum_type: System.Type2, value: System.Object) -> System.Object static;
+
+        @IL.name("Format")
+        format(enum_type: System.Type2, value: System.Object, format: System.String) -> System.String static;
+
+        @IL.name("GetHashCode")
+        get_hash_code() -> int;
+
+        @IL.name("ToString")
+        to_string() -> System.String;
+
+        @IL.name("ToString")
+        to_string(format: System.String, provider: System.IFormatProvider) -> System.String;
+
+        @IL.name("ToString")
+        to_string(format: System.String) -> System.String;
+
+        @IL.name("ToString")
+        to_string(provider: System.IFormatProvider) -> System.String;
+
+        @IL.name("GetTypeCode")
+        get_type_code() -> System.TypeCode;
+
+        @IL.name("ToObject")
+        to_object(enum_type: System.Type2, value: byte) -> System.Object static;
+
+        @IL.name("ToObject")
+        to_object(enum_type: System.Type2, value: short) -> System.Object static;
+
+        @IL.name("ToObject")
+        to_object(enum_type: System.Type2, value: int) -> System.Object static;
+
+        @IL.name("ToObject")
+        to_object(enum_type: System.Type2, value: ubyte) -> System.Object static;
+
+        @IL.name("ToObject")
+        to_object(enum_type: System.Type2, value: ushort) -> System.Object static;
+
+        @IL.name("ToObject")
+        to_object(enum_type: System.Type2, value: uint) -> System.Object static;
+
+        @IL.name("ToObject")
+        to_object(enum_type: System.Type2, value: long) -> System.Object static;
+
+        @IL.name("ToObject")
+        to_object(enum_type: System.Type2, value: ulong) -> System.Object static;
+
+        @IL.name("GetType")
+        get_type() -> System.Type2;
+
+    si
+
     @IL.stub()
     @IL.name("class [mscorlib]System.ValueType")
     class ValueType is
@@ -48,6 +149,9 @@ namespace System is
     @IL.stub()
     @IL.name("class [mscorlib]System.String")
     class String: System.Object,System.IConvertible,Collections.Iterable[char],System.Comparable[System.String],System.Equatable[System.String],System.Cloneable is
+        @IL.name("get_Item")
+        get_at(index: int) -> char;
+
         @IL.name("Replace")
         replace(old_char: char, new_char: char) -> System.String;
 
@@ -757,7 +861,7 @@ namespace System is
         get_hash_code() -> int;
 
         @IL.name.read("get_In") 
-        in_: System.IO2.TextReader static;
+        input: System.IO2.TextReader static;
 
         @IL.name.read("get_InputEncoding") @IL.name.assign("set_InputEncoding") 
         input_encoding: System.Text.Encoding static;
@@ -769,7 +873,7 @@ namespace System is
         key_available: bool static;
 
         @IL.name.read("get_Out") 
-        out: System.IO2.TextWriter static;
+        output: System.IO2.TextWriter static;
 
         @IL.name.read("get_Error") 
         error: System.IO2.TextWriter static;

--- a/lib/legacy/ghul/ghul.ghul
+++ b/lib/legacy/ghul/ghul.ghul
@@ -1,3 +1,4 @@
+@IF.legacy()
 @IL.stub()
 namespace Ghul is
     @IL.built_in_type("void")

--- a/src/driver/analyser.ghul
+++ b/src/driver/analyser.ghul
@@ -501,14 +501,16 @@ namespace Driver is
             yrt
         si
 
+        @IF.legacy()
         format_thousands(value: long) -> String is
-            let result = new StringBuffer();
+            // FIXME: needs to be divided by 1000:
+            return "" + value;
+        si
 
-            result.append(value / 1000L);
-            result.append(',');
-            result.append(cast int(value % 1000L), 10, 3, '0');
-
-            return result;
+        @IF.dotnet()
+        format_thousands(value: long) -> String is
+            // FIXME: needs to be divided by 1000:
+            return value.to_string();
         si
     si
 
@@ -632,7 +634,7 @@ namespace Driver is
         si
 
         get_function_doc_for(function: Semantic.Symbol.Function) -> String is
-            let result = new StringBuffer();
+            let result = new System.Text.StringBuilder();
 
             result
                 .append(function.short_description);
@@ -643,7 +645,7 @@ namespace Driver is
                     .append(function.get_short_argument_description(i));
             od
 
-            return result;
+            return result.to_string();
         si
 
         find_signatures(path: String, target_line: int, target_column: int) -> Semantic.OVERLOAD_MATCHES_RESULT is
@@ -718,7 +720,7 @@ namespace Driver is
         si
 
         get_symbol_info_for(symbol: Semantic.Symbol.BASE) -> String is
-            let result = new StringBuffer();
+            let result = new System.Text.StringBuilder();
 
             let qualified_name = symbol.qualified_name;
 
@@ -739,7 +741,7 @@ namespace Driver is
                 .append('\t')
                 .append(qualifier);
 
-            return result;
+            return result.to_string();
         si
     si
 
@@ -802,7 +804,7 @@ namespace Driver is
         si
 
         format_location(location: LOCATION) -> String is
-            let result = new StringBuffer();
+            let result = new System.Text.StringBuilder();
 
             result
                 .append(location.file_name)
@@ -815,7 +817,7 @@ namespace Driver is
                 .append('\t')
                 .append(location.end_column);
 
-            return result;
+            return result.to_string();
         si
     si
 

--- a/src/driver/compiler.ghul
+++ b/src/driver/compiler.ghul
@@ -118,7 +118,7 @@ namespace Driver is
                     )
                 );
 
-            build(post_parse_passes, new Collections.ITERABLE_WRAPPER[Driver.WORK_ITEM]([result]));
+            build(post_parse_passes, new Collections.LIST[Driver.WORK_ITEM]([result]));
 
             return result;
         si
@@ -268,7 +268,7 @@ namespace Driver is
 
                 generated_source_files.add(work_item.legacy_object_file_name);
 
-                var writer = IO.File.openCreate(work_item.legacy_object_file_name);
+                var writer = Shim.FILE.open_create(work_item.legacy_object_file_name);
 
                 writer.write(printer.result);
 

--- a/src/driver/main.ghul
+++ b/src/driver/main.ghul
@@ -36,9 +36,9 @@ namespace Driver is
 
             try
                 if arguments.count <= 1 then
-                    System.Console.out.write_line("ghūl " + Source.BUILD.number);
+                    System.Console.output.write_line("ghūl " + Source.BUILD.number);
 
-                    System.Console.out.flush();
+                    System.Console.output.flush();
                     native.exit(0);
                 fi
     
@@ -77,7 +77,7 @@ namespace Driver is
 
             // FIXME: the runtime should be doing this - wrapping the L stderr + stdout IO.Writers should not prevent them getting flushed:
             System.Console.error.flush();
-            System.Console.out.flush();
+            System.Console.output.flush();
 
             native.exit(result);
         si
@@ -460,7 +460,7 @@ namespace Driver is
                 container.completer,
                 container.signature_help,
                 System.Console.input,
-                System.Console.out,
+                System.Console.output,
                 flags
             );
 

--- a/src/ir/boilerplate_generator.ghul
+++ b/src/ir/boilerplate_generator.ghul
@@ -19,7 +19,7 @@ namespace IR is
             let snippet = _snippets[name];
 
             if !snippet? then
-                snippet = IO.File.openRead(_paths.library_prefix + "dotnet/il/" + name + ".il").readAll();
+                snippet = Shim.FILE.read_all(_paths.library_prefix + "dotnet/il/" + name + ".il");
 
                 _snippets[name] = snippet;
             fi

--- a/src/ir/context.ghul
+++ b/src/ir/context.ghul
@@ -84,12 +84,12 @@ namespace IR is
     si
 
     class BUFFER_ASSEMBLER_OUTPUT: AssemblyOutput is
-        buffer: StringBuffer;
+        buffer: System.Text.StringBuilder;
 
         init(want_comments: bool) is
             super.init(want_comments);
 
-            buffer = new StringBuffer();
+            buffer = new System.Text.StringBuilder();
         si
 
         write(value: Object) is
@@ -193,7 +193,7 @@ namespace IR is
 
             _outputs.pop();
 
-            return result;
+            return result.to_string();
         si        
     si
 si

--- a/src/lexical/token.ghul
+++ b/src/lexical/token.ghul
@@ -1,4 +1,5 @@
 namespace Lexical is
+    @IF.legacy()
     class _dummy  is
         _dummy: System.Enum[TOKEN][];
     si

--- a/src/lexical/token_names.ghul
+++ b/src/lexical/token_names.ghul
@@ -139,23 +139,25 @@ namespace Lexical is
 
             sorted_tokens.sort();
             
-            var result = new StringBuffer();
+            var buffer = new System.Text.StringBuilder();
             var seen_any = false;
 
             for s in sorted_tokens do
                 if seen_any then
-                    result.append(", ");
+                    buffer.append(", ");
                 fi
-                result.append(s);
+                buffer.append(s);
                 seen_any = true;
             od
+
+            let result = buffer.to_string();
 
             var i = Shim.STR.last_index_of(result, ',');
 
             if i >= 0 then
                 var left = result.substring(0, i);
                 var right = result.substring(i + 2);
-                result = new StringBuffer().append(left).append(" or ").append(right);
+                result = left + " or " + right;
             fi
 
             return result;

--- a/src/semantic/graph/value/value.ghul
+++ b/src/semantic/graph/value/value.ghul
@@ -1014,7 +1014,7 @@ namespace Semantic.Graph.Value is
                     count = count + 1;
                 od
 
-                let call = new StringBuffer();
+                let call = new System.Text.StringBuilder();
 
                 call
                     .append("callvirt instance ");
@@ -1045,7 +1045,7 @@ namespace Semantic.Graph.Value is
 
                 call.append(")");
                 
-                context.write_line(call);
+                context.write_line(call.to_string());
             si
             
             toString() -> String =>

--- a/src/semantic/symbol/classy.ghul
+++ b/src/semantic/symbol/classy.ghul
@@ -21,7 +21,7 @@ namespace Semantic.Symbol is
         il_name_prefix: String => "";
 
         il_name: String is
-            let result = new System.StringBuffer(Shim.STR.length(name) + 5);
+            let result = new System.Text.StringBuilder(Shim.STR.length(name) + 5);
 
             result.append("'").append(name);
 
@@ -33,11 +33,11 @@ namespace Semantic.Symbol is
 
             result.append("'");
 
-            return result;
+            return result.to_string();
         si
 
         il_type_name: String is
-            let result = new System.StringBuffer();
+            let result = new System.Text.StringBuilder();
 
             if il_name_override? then
                 result.append(il_qualified_name);
@@ -64,7 +64,7 @@ namespace Semantic.Symbol is
                 result.append('>');
             fi
             
-            return result;
+            return result.to_string();
         si
 
         is_derived_from_iterable_trait: bool
@@ -74,7 +74,7 @@ namespace Semantic.Symbol is
             => find_ancestor(IoC.CONTAINER.instance.collections_symbol_lookup.get_unspecialized_iterator_type())?;
 
         get_il_def(preamble: String) -> String is
-            let result = new StringBuffer();
+            let result = new System.Text.StringBuilder();
 
             result
                 .append(preamble)
@@ -146,7 +146,7 @@ namespace Semantic.Symbol is
                 index = index + 1;
             od
 
-            return result;
+            return result.to_string();
         si
 
         init(location: LOCATION, owner: Scope, name: String, argument_names: Collections.LIST[String], enclosing_scope: Scope) is

--- a/src/semantic/symbol/function.ghul
+++ b/src/semantic/symbol/function.ghul
@@ -204,7 +204,7 @@ namespace Semantic.Symbol is
         si
 
         il_type_name: String is
-            let result = new StringBuffer();
+            let result = new System.Text.StringBuilder();
 
             assert(self?, "function il_type_name self is null");
 
@@ -258,11 +258,11 @@ namespace Semantic.Symbol is
 
             result.append(')');
 
-            return result;
+            return result.to_string();
         si
 
         argument_descriptions: String is
-            let result = new StringBuffer();
+            let result = new System.Text.StringBuilder();
 
             for i in 0..arguments.count do
                 if i > 0 then
@@ -271,11 +271,11 @@ namespace Semantic.Symbol is
                 result.append(get_argument_description(i));
             od
 
-            return result;
+            return result.to_string();
         si
 
         short_argument_descriptions: String is
-            let result = new StringBuffer();
+            let result = new System.Text.StringBuilder();
 
             for i in 0..arguments.count do
                 if i > 0 then
@@ -284,7 +284,7 @@ namespace Semantic.Symbol is
                 result.append(get_short_argument_description(i));
             od
 
-            return result;
+            return result.to_string();
         si
 
         override: Function public
@@ -299,7 +299,7 @@ namespace Semantic.Symbol is
         si
 
         get_il_def(preamble: String) -> String is
-            let result = new StringBuffer();
+            let result = new System.Text.StringBuilder();
             
             result
                 .append(preamble)
@@ -327,7 +327,7 @@ namespace Semantic.Symbol is
 
             result.append(") cil managed");
 
-            return result;    
+            return result.to_string();    
         si
         
         start_declaring_arguments() is
@@ -446,29 +446,29 @@ namespace Semantic.Symbol is
         si
 
         get_argument_description(index: int) -> String is
-            let result = new StringBuffer();
+            let result = new System.Text.StringBuilder();
 
             result
                 .append(argument_names[index])
                 .append(": ")
                 .append(arguments[index]);
 
-            return result;
+            return result.to_string();
         si
 
         get_short_argument_description(index: int) -> String is
-            let result = new StringBuffer();
+            let result = new System.Text.StringBuilder();
 
             result
                 .append(argument_names[index])
                 .append(": ")
                 .append(arguments[index].short_description);
 
-            return result;
+            return result.to_string();
         si
 
         toString() -> String is
-            let result = new StringBuffer();
+            let result = new System.Text.StringBuilder();
 
             try
                 result.append(qualified_name);
@@ -478,7 +478,7 @@ namespace Semantic.Symbol is
                 result.append(return_type);
 
                 // return qualified_name + " (" + short_argument_descriptions + ") -> " + return_type;
-                return result;
+                return result.to_string();
             catch ex: Exception
                 // System.Console.error.write_line("failed to convert function to string: " + name + ", got as far as: " + result);
                 // System.Console.error.write_line(ex);

--- a/src/semantic/symbol/generic.ghul
+++ b/src/semantic/symbol/generic.ghul
@@ -32,7 +32,7 @@ namespace Semantic.Symbol is
         qualified_name: String => symbol.qualified_name + "[" + arguments_string + "]";
 
         arguments_string: String is
-            let result = new StringBuffer();
+            let result = new System.Text.StringBuilder();
 
             let seen_any = false;
 
@@ -46,12 +46,13 @@ namespace Semantic.Symbol is
                 seen_any = true;
             od
 
-            return result;
+            return result.to_string();
         si
         
         description: String => qualified_name;
+
         short_description: String is
-            let result = new StringBuffer();
+            let result = new System.Text.StringBuilder();
 
             result
                 .append(name)
@@ -71,6 +72,8 @@ namespace Semantic.Symbol is
 
             result
                 .append(']');
+
+            return result.to_string();
         si
 
         symbol_kind: SYMBOL_KIND => symbol.symbol_kind;
@@ -78,7 +81,7 @@ namespace Semantic.Symbol is
         // is_workspace_visible: bool => true;
 
         il_type_name: String is
-            let result = new StringBuffer();
+            let result = new System.Text.StringBuilder();
 
             let qn = symbol.il_name_override;
 
@@ -120,7 +123,7 @@ namespace Semantic.Symbol is
 
             result.append('>');
 
-            return result;
+            return result.to_string();
         si
 
         il_def: String => "generic has no il_def: " + self;
@@ -197,7 +200,7 @@ namespace Semantic.Symbol is
         dump_ancestors(depth: int) is
             for i in 0..self.ancestors.count do
                 for j in 0..depth do
-                    IO.Std.err.write("  ");
+                    System.Console.error.write("  ");
                 od
                 
                 let a = get_ancestor(i);

--- a/src/semantic/symbol/namespace.ghul
+++ b/src/semantic/symbol/namespace.ghul
@@ -23,7 +23,7 @@ namespace Semantic.Symbol is
         il_qualified_name: String is
             let parts = Shim.STR.split(qualified_name.substring(1), '.');
 
-            let result = new StringBuffer(Shim.STR.length(qualified_name) + parts.count * 3);
+            let result = new System.Text.StringBuilder(Shim.STR.length(qualified_name) + parts.count * 3);
 
             let seen_any = false;
 
@@ -40,7 +40,7 @@ namespace Semantic.Symbol is
                 seen_any = true;
             od
 
-            return result;
+            return result.to_string();
         si
 
         // FIXME: the IL generation pass is not using the namespace symbol so does not see this:

--- a/src/semantic/symbol/symbol.ghul
+++ b/src/semantic/symbol/symbol.ghul
@@ -65,7 +65,7 @@ namespace Semantic.Symbol is
 
         owner: Scope public => _owner, = value is
             if _owner? && !value? then
-                System.Console.error.write_line("clear owner " + self + " from " + new System.Backtrace());                
+                System.Console.error.write_line("clear owner " + self);                
             fi
             
             _owner = value;

--- a/src/semantic/symbol_map.ghul
+++ b/src/semantic/symbol_map.ghul
@@ -1,6 +1,7 @@
 namespace Semantic is
     use System;
 
+    @IF.legacy()
     class SYMBOL_MAP: Collection.SortedMap[String,Symbol.BASE] is
         init() is
             super.init();
@@ -60,5 +61,57 @@ namespace Semantic is
 
             return n;
         si        
+    si
+
+    @IF.dotnet()
+    class SYMBOL_MAP: Collections.MutableMap[String,Symbol.BASE] is
+        _map: Collections.MAP[String,Symbol.BASE];
+
+        init() is
+            _map = new Collections.MAP[String,Symbol.BASE]();
+        si
+
+        [name: String]: Symbol.BASE => _map[name], = v is
+            _map[name] = v;
+        si
+
+        add(pair: Collections.Pair[String,Symbol.BASE]) is _map.add(pair); si
+        add(name: String, value: Symbol.BASE) is _map.add(name, value); si
+
+        contains(pair: Collections.Pair[String,Symbol.BASE]) -> bool => _map.contains(pair);
+        contains_key(name: String) -> bool => _map.contains_key(name);
+
+        remove(pair: Collections.Pair[String,Symbol.BASE]) -> bool => _map.remove(pair);
+
+        remove(name: String) is _map.remove(name); si
+
+        try_get_value(name: String, result: Symbol.BASE ref) -> bool => _map.try_get_value(name, result);
+
+        copy_to(result: Collections.Pair[String,Symbol.BASE][], index: int) is
+            _map.copy_to(result, index);
+        si
+                
+        clear() is _map.clear(); si
+
+        find_matches(
+            prefix: String,
+            matches: Collections.MAP[String,Semantic.Symbol.BASE])
+        is        
+        si
+
+        add_match(
+            name: String,
+            match: Semantic.Symbol.BASE,
+            matches: Collections.MAP[String,Semantic.Symbol.BASE]
+        ) static is
+            if !Shim.STR.starts_with(name, "__") && !matches.contains_key(name) then
+                matches[name] = match.collapse_group_if_single_member();
+            fi
+        si
+
+        // find_first_match(
+        //     prefix: String
+        // ) -> Collection.TreeNode[String,Semantic.Symbol.BASE] is
+        // si        
     si
 si

--- a/src/semantic/symbol_table.ghul
+++ b/src/semantic/symbol_table.ghul
@@ -118,7 +118,7 @@ namespace Semantic is
         enter_scope(node: Syntax.Tree.NODE) is
             var scope = _scopes[node];
             if scope == null then
-                _logger.error(node.location, "no scope found for " + node + "\n" + new System.Backtrace());
+                _logger.error(node.location, "no scope found for " + node);
                 return;
             fi
             enter_scope(scope);
@@ -153,7 +153,7 @@ namespace Semantic is
         si
 
         toString() -> String is
-            var result = new StringBuffer();
+            var result = new System.Text.StringBuilder();
 
             result.append("symbol table:\n");
 
@@ -165,7 +165,7 @@ namespace Semantic is
 
             result.append("\n");
 
-            return result;
+            return result.to_string();
         si
     si
 si

--- a/src/semantic/type/type.ghul
+++ b/src/semantic/type/type.ghul
@@ -232,7 +232,7 @@ namespace Semantic.Type is
             assert(symbol.name?, "symbol.name is null");
             assert(arguments?, "arguments is null");
 
-            let result = new StringBuffer();
+            let result = new System.Text.StringBuilder();
 
             result
                 .append(symbol.name)
@@ -256,7 +256,7 @@ namespace Semantic.Type is
 
             result.append(']');
 
-            return result;
+            return result.to_string();
         si
 
         init(
@@ -466,7 +466,7 @@ namespace Semantic.Type is
         si
 
         toString() -> String is
-            let result = new System.StringBuffer();
+            let result = new System.Text.StringBuilder();
 
             if arguments.count == 2 then
                 result
@@ -491,7 +491,7 @@ namespace Semantic.Type is
                 od
             fi
 
-            return result;
+            return result.to_string();
         si
     si
 

--- a/src/syntax/parser/context.ghul
+++ b/src/syntax/parser/context.ghul
@@ -118,10 +118,10 @@ namespace Syntax.Parser is
             
             do
                 if is_end_of_file then
-                    error(start::location, "%: expected %" % [message, Lexical.TOKEN_NAMES[current_token]]: Object );
+                    error(start::location, message + ": expected " + Lexical.TOKEN_NAMES[current_token]);
                     return;
                 elif tokens.contains(current_token) then
-                    error(start::location, "%: expected %" % [message, Lexical.TOKEN_NAMES[current_token]]: Object );
+                    error(start::location, message + ": expected " + Lexical.TOKEN_NAMES[current_token]);
                     next_token();
                     return;
                 else
@@ -138,7 +138,12 @@ namespace Syntax.Parser is
 
         expect_token(token: Lexical.TOKEN, message: String) -> bool is
             if current_token != token then
+                @IF.legacy()
                 error(location, "%: expected % but found %" % [message, Lexical.TOKEN_NAMES[token], current_token_name]: Object );
+
+                @IF.dotnet()
+                error(location, String.format("{0}: expected {1} but found {2}", [message, Lexical.TOKEN_NAMES[token], current_token_name]: Object));
+
                 return false;
             else
                 return true;
@@ -151,7 +156,12 @@ namespace Syntax.Parser is
 
         expect_token(tokens: Collections.LIST[Lexical.TOKEN], message: String) -> bool is
             if !tokens.contains(current_token) then
+                @IF.legacy()
                 error(location, "%: expected % but found %" % [message, Lexical.TOKEN_NAMES[tokens], current_token_name]: Object );
+
+                @IF.dotnet()
+                error(location, String.format("{0}: expected {1} but found {2}", [message, Lexical.TOKEN_NAMES[tokens], current_token_name]: Object));
+
                 return false;
             else
                 return true;

--- a/src/syntax/parser/definition/indexer.ghul
+++ b/src/syntax/parser/definition/indexer.ghul
@@ -73,14 +73,14 @@ namespace Syntax.Parser.Definition is
                     context.next_token();
                     progress = true;
                     setter_argument_name = identifier_parser.parse(context);
-                    expect_semicolon = ![Lexical.TOKEN.COMMA, Lexical.TOKEN.IS].contains(context.current.token);
+                    expect_semicolon = context.current.token != Lexical.TOKEN.COMMA && context.current.token != Lexical.TOKEN.IS;
                     assign_body = body_parser.parse(context);
                     if context.current.token == Lexical.TOKEN.COMMA then
                         context.next_token();
                     else
                         break;
                     fi
-                elif [Lexical.TOKEN.IS, Lexical.TOKEN.ARROW_FAT].contains(context.current.token) then
+                elif context.current.token == Lexical.TOKEN.IS || context.current.token == Lexical.TOKEN.ARROW_FAT then
                     expect_semicolon = context.current.token == Lexical.TOKEN.ARROW_FAT;
                     if read_body? then
                         context.error(context.location, "replacing read");

--- a/src/syntax/parser/definition/list.ghul
+++ b/src/syntax/parser/definition/list.ghul
@@ -28,7 +28,11 @@ namespace Syntax.Parser.Definition is
                 catch e: Exception
                     System.Console.error.write_line("" + (start..context.current.location) + ": caught exception parsing definition: " + e);
 
-                    while !context.is_end_of_file && !([Lexical.TOKEN.SI, Lexical.TOKEN.SEMICOLON].contains(context.current.token)) do
+                    while 
+                        !context.is_end_of_file &&
+                        context.current.token != Lexical.TOKEN.SI &&
+                        context.current.token != Lexical.TOKEN.SEMICOLON
+                    do
                         context.next_token();
                     od
 

--- a/src/syntax/parser/definition/property.ghul
+++ b/src/syntax/parser/definition/property.ghul
@@ -75,7 +75,7 @@ namespace Syntax.Parser.Definition is
 
                         break;
                     fi
-                elif [Lexical.TOKEN.IS, Lexical.TOKEN.ARROW_FAT].contains(context.current.token) then
+                elif context.current.token == Lexical.TOKEN.IS || context.current.token == Lexical.TOKEN.ARROW_FAT then
                     expect_semicolon = context.current.token == Lexical.TOKEN.ARROW_FAT;
 
                     if read_body? then

--- a/src/syntax/parser/expression/node.ghul
+++ b/src/syntax/parser/expression/node.ghul
@@ -103,7 +103,11 @@ namespace Syntax.Parser.Expression is
                     break;
                 fi
 
+                @IF.legacy()
                 let s = left_precedence.toString();
+
+                @IF.dotnet()
+                let s = left_precedence.to_string();
 
                 let apparent_op = context.current.string;
                 let real_op = _real_operation[apparent_op];

--- a/src/syntax/parser/expression/secondary.ghul
+++ b/src/syntax/parser/expression/secondary.ghul
@@ -58,7 +58,10 @@ namespace Syntax.Parser.Expression is
 
                     context.next_token();
 
-                    if [Lexical.TOKEN.IDENTIFIER, Lexical.TOKEN.OPERATOR].contains(context.current.token) then
+                    if 
+                        context.current.token == Lexical.TOKEN.IDENTIFIER ||
+                        context.current.token == Lexical.TOKEN.OPERATOR
+                    then
                         let member = identifier_parser.parse(context);
                         result = new Tree.Expression.MEMBER(start::member.location, result, member, completion_target_start::member.location);
                     else

--- a/src/syntax/parser/statement/node.ghul
+++ b/src/syntax/parser/statement/node.ghul
@@ -117,7 +117,10 @@ namespace Syntax.Parser.Statement is
                     var seen_default = false;
                     var match_list = new Collections.LIST[Tree.Statement.CASE_MATCH]();
 
-                    while [Lexical.TOKEN.WHEN,Lexical.TOKEN.DEFAULT].contains(context.current.token) do
+                    while 
+                        context.current.token == Lexical.TOKEN.WHEN ||
+                        context.current.token == Lexical.TOKEN.DEFAULT
+                    do
                         var match_start = context.location;
                         var match_expressions: Tree.Expression.LIST;
                         if context.current.token != Lexical.TOKEN.DEFAULT then

--- a/src/syntax/parser/type/node.ghul
+++ b/src/syntax/parser/type/node.ghul
@@ -25,7 +25,7 @@ namespace Syntax.Parser.TypeExpression is
                     var identifier = identifier_qualified_parser.parse(context);
 
                     if identifier.is_poisoned then
-                        if [Lexical.TOKEN.IN].contains(context.current.token) then
+                        if context.current.token == Lexical.TOKEN.IN then
                             System.Console.error.write_line("parse type node, skip");
                             context.next_token();
                         fi
@@ -148,7 +148,7 @@ namespace Syntax.Parser.TypeExpression is
         other_token(context: CONTEXT) -> Tree.TypeExpression.NODE is
             var should_skip_next_token = false;
 
-            if [Lexical.TOKEN.IN].contains(context.current.token) then
+            if context.current.token == Lexical.TOKEN.IN then
                 should_skip_next_token = true;
             fi
 

--- a/src/syntax/process/add_accessors_for_properties.ghul
+++ b/src/syntax/process/add_accessors_for_properties.ghul
@@ -21,7 +21,11 @@ namespace Syntax.Process is
         si
 
         pre(property: Definition.PROPERTY) -> bool is
-            if !property.name.name.startsWith('_') || property.read_body? || property.assign_body? then
+            if
+                !Shim.STR.starts_with(property.name.name, '_') ||
+                property.read_body? ||
+                property.assign_body?
+            then
                 let is_assignable = !property.read_body? || property.assign_argument?;
 
                 add_accessor_functions_for_property(property, is_assignable);
@@ -40,7 +44,7 @@ namespace Syntax.Process is
             property.is_auto_property =
                 !property.read_body? &&
                 !property.assign_body? &&
-                !property.name.name.startsWith('_') &&
+                !Shim.STR.starts_with(property.name.name, '_') &&
                 !property.modifiers.is_private;
 
             let backing_variable_name = "__backing_" + property.name.name;

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -582,7 +582,7 @@ namespace Syntax.Process is
                         type
                     );
 
-                _logger.error(new_.location, "no constructor found init(" + argument_types.get_inner() + ")");                
+                _logger.error(new_.location, "no constructor found init(" + new Shim.JOIN[Semantic.Type.BASE](argument_types) + ")");                
 
                 return;
             fi
@@ -1010,7 +1010,10 @@ namespace Syntax.Process is
 
             let string = integer.string;
 
-            if string.endsWith('L') || string.endsWith('l') then
+            if
+                Shim.STR.ends_with(string, 'L') ||
+                Shim.STR.ends_with(string, 'l')
+            then
                 string = string.substring(0, Shim.STR.length(string)-1);
                 type = _ghul_symbol_lookup.get_type("long");
             else
@@ -1037,7 +1040,7 @@ namespace Syntax.Process is
             if Shim.STR.length(string) < 1 || Shim.STR.length(string) > 1 then
                 _logger.error(character.location, "invalid character literal");
             else
-                c = cast int(string[0]);
+                c = cast int(Shim.STR.get_at(string, 0));
             fi
             
             character.value = new Semantic.Graph.Value.Literal.INTEGER(
@@ -1130,15 +1133,15 @@ namespace Syntax.Process is
             let function_type_arguments = function_generic_type.arguments;
 
             // FIXME: need to check for actual types here, and or presence of invoke method:
-            let is_action = function_generic_type.name.startsWith("ACTION_");
-            let is_function = function_generic_type.name.startsWith("FUNCTION_");
+            let is_action = Shim.STR.starts_with(function_generic_type.name, "ACTION_");
+            let is_function = Shim.STR.starts_with(function_generic_type.name, "FUNCTION_");
 
             if is_action then
                 if function_type_arguments.count != arguments.count then
                     _logger.error(
                         call.arguments.location, 
-                        "expected % arguments but % supplied" % [function_type_arguments.count, arguments.count]: Object);
-                    
+                        "expected " + function_type_arguments.count + " arguments but " + arguments.count + " supplied");
+                            
                     return;
                 fi
 
@@ -1146,7 +1149,7 @@ namespace Syntax.Process is
                 if function_type_arguments.count != arguments.count + 1 then
                     _logger.error(
                         call.arguments.location, 
-                        "expected % arguments but % supplied" % [function_type_arguments.count - 1, arguments.count]: Object);
+                        "expected " + (function_type_arguments.count - 1) + " arguments but " + arguments.count + " supplied");
                     
                     return;
                 fi
@@ -1164,7 +1167,7 @@ namespace Syntax.Process is
                 then
                     ok = false;
 
-                    _logger.error(call.arguments.expressions[i].location, "expected argument of type % but % supplied" % [function_type_arguments[i], argument_types[i]]: Object);
+                    _logger.error(call.arguments.expressions[i].location, "expected argument of type " + function_type_arguments[i] + " but " + argument_types[i] + " supplied");
                 fi
             od
 

--- a/src/syntax/process/declare_symbols.ghul
+++ b/src/syntax/process/declare_symbols.ghul
@@ -229,13 +229,17 @@ namespace Syntax.Process is
         pre(property: Definition.PROPERTY) -> bool is
             let is_static = property.modifiers.is_static;
 
-            if property.name.name.startsWith('_') && !property.read_body? && !property.assign_body? then
+            if 
+                Shim.STR.starts_with(property.name.name, '_') && 
+                !property.read_body? && 
+                !property.assign_body?
+            then
                 current_declaration_context.declare_variable(property.name.location, property.name.name, is_static, _symbol_definition_listener);
             else
                 let is_assignable = !property.read_body? || property.assign_argument?;
                 let is_private: bool;
 
-                if property.name.name.startsWith('_') then
+                if Shim.STR.starts_with(property.name.name, '_') then
                     is_private = !property.modifiers.is_public;
                 else
                     is_private = property.modifiers.is_private;

--- a/src/syntax/process/printer/base.ghul
+++ b/src/syntax/process/printer/base.ghul
@@ -10,7 +10,7 @@ namespace Syntax.Process.Printer is
         _indent_needed: bool;
         _want_locations: bool;
         _current_line: int;
-        _result: StringBuffer;
+        _result: System.Text.StringBuilder;
         
         init(want_locations: bool) is
             super.init();
@@ -18,12 +18,12 @@ namespace Syntax.Process.Printer is
             _want_locations = want_locations;
             _depth = 0;
             _indent = 2;
-            _result = new StringBuffer();
+            _result = new System.Text.StringBuilder();
             _current_line = 1;
         si
 
         result: String is
-            return _result;
+            return _result.to_string();
         si
 
         write_line(string: String) is
@@ -136,7 +136,7 @@ namespace Syntax.Process.Printer is
 
                 // yuck...
                 if isa Variable.NODE(d) then
-                    if !cast Variable.NODE(d).name.name.startsWith("__") then
+                    if !Shim.STR.starts_with(cast Variable.NODE(d).name.name, "__") then
                         write_line(";");
                     fi
                 fi
@@ -356,6 +356,7 @@ namespace Syntax.Process.Printer is
             write(literal.string);
         si
 
+        @IF.legacy()
         write_escape_char(c: char) is
             var ci = cast int(c);
             if ci < 32 then
@@ -363,6 +364,23 @@ namespace Syntax.Process.Printer is
                 var b = new StringBuffer(5);
                 b.append(ci & 0xFF, 8);
                 write(b);
+            elif ci == 34 then
+                write("\\");
+                write(cast char(34));
+            elif ci == 39 then
+                write("'");
+            elif ci == 92 then
+                write("\\\\");
+            else
+                write(c);
+            fi
+        si
+
+        @IF.dotnet()
+        write_escape_char(c: char) is
+            var ci = cast int(c);
+            if ci < 32 then
+                write("\\" + System.String.format("X", ci));
             elif ci == 34 then
                 write("\\");
                 write(cast char(34));
@@ -392,7 +410,7 @@ namespace Syntax.Process.Printer is
         visit(character: Expression.Literal.CHARACTER) is
             location(character);
             write("'");
-            write_escape_char(character.string[0]);
+            write_escape_char(Shim.STR.get_at(character.string, 0));
             write("'");
         si
 

--- a/src/syntax/process/printer/legacy.ghul
+++ b/src/syntax/process/printer/legacy.ghul
@@ -41,9 +41,9 @@ namespace Syntax.Process.Printer is
         si
 
         write_name(name: String) is
-            var c = name[0];
+            var c = Shim.STR.get_at(name,0);
 
-            if (c>='a'&&c<='z') || (c>='A'&&c<='Z') || c=='_' then
+            if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' then
                 write(name);
             else
                 write("operator");
@@ -60,7 +60,7 @@ namespace Syntax.Process.Printer is
         si
 
         visit(variable: Variable.NODE) is
-            if variable.name.name.startsWith("__") then
+            if Shim.STR.starts_with(variable.name.name, "__") then
                 return;
             fi
             
@@ -226,7 +226,7 @@ namespace Syntax.Process.Printer is
         si
 
         visit(function: Definition.FUNCTION) is
-            if function.name.name.startsWith("__") then
+            if Shim.STR.starts_with(function.name.name, "__") then
                 return;
             fi
 
@@ -256,7 +256,7 @@ namespace Syntax.Process.Printer is
                 modifiers.access_modifier.accept(self);
                 write(' ');
             elif 
-                name!=null && name.name.startsWith('_')
+                name != null && Shim.STR.starts_with(name.name, '_')
             then
                 write("private ");
             fi

--- a/src/syntax/process/visitor.ghul
+++ b/src/syntax/process/visitor.ghul
@@ -10,7 +10,7 @@ namespace Syntax is
 
         throwNotImplemented(name: String, node: NODE) is
             throw new NotImplementedException(
-                "Visitor % does not define a visit method for % % and/or this node does not accept this visitor" % [self, name, node.ClassName]: Object 
+                "Visitor " + self + " does not define a visit method for " + name + " " + Shim.OBJ.type_name(node) + " and/or this node does not accept this visitor"
             );
         si
 

--- a/src/syntax/tree/modifier/node.ghul
+++ b/src/syntax/tree/modifier/node.ghul
@@ -9,7 +9,7 @@ namespace Syntax.Tree.Modifier is
         si
 
         name: String is
-            throw new NotImplementedException("% does not implement name" % [self]: Object );
+            throw new NotImplementedException("" + self + " does not implement name");
         si
 
         accept(visitor: Visitor) is

--- a/src/syntax/tree/node.ghul
+++ b/src/syntax/tree/node.ghul
@@ -41,7 +41,12 @@ namespace Syntax.Tree is
         si
 
         clone() -> NODE is
+            @IF.legacy()
             let result = cast NODE(super.clone());   
+
+            @IF.dotnet()
+            let result = cast NODE(memberwise_clone());   
+
             result._id = next_id;         
 
             return result;

--- a/src/syntax/tree/type/built_in.ghul
+++ b/src/syntax/tree/type/built_in.ghul
@@ -9,7 +9,7 @@ namespace Syntax.Tree.TypeExpression is
         si
 
         name: String is
-            throw new NotImplementedException("% does not implement name" % [self]: Object );
+            throw new NotImplementedException("" + self + " does not implement name");
         si
 
         accept(visitor: Visitor) is

--- a/src/system/directory.ghul
+++ b/src/system/directory.ghul
@@ -1,10 +1,10 @@
 namespace IO is
     use System;
-    use Generic;
+    use Collections;
 
     @IF.legacy()
-    class DIRECTORY: Object, Iterable[String] is
-        files: Iterable[String];
+    class DIRECTORY: Object, Generic.Iterable[String] is
+        files: Generic.Iterable[String];
 
         Iterator: Generic.Iterator[String] => files.Iterator;
 
@@ -16,7 +16,7 @@ namespace IO is
                 // FileStream.throwIOError("directory", path, FileStream.StaticLastError);
             fi
 
-            let results = new Vector[String]();
+            let results = new Generic.Vector[String]();
 
             if !path.endsWith('/') then
                 path = path + '/';
@@ -33,6 +33,16 @@ namespace IO is
             od
 
             files = results;
+        si
+    si
+
+    @IF.dotnet()
+    class DIRECTORY: Object, Iterable[String] is
+        files: Iterable[String];
+
+        iterator: Iterator[String] => files.iterator;
+
+        init(path: String) is
         si
     si
 si

--- a/src/system/shim.file.ghul
+++ b/src/system/shim.file.ghul
@@ -9,6 +9,12 @@ namespace Shim is
         open_read(path: String) -> System.IO2.TextReader static => System.IO2.File.open_text(path);
 
         @IF.legacy()
+        read_all(path: String) -> String static => IO.File.openRead(path).readAll();
+
+        @IF.dotnet()
+        read_all(path: String) -> String static => System.IO2.File.read_all_text(path);
+
+        @IF.legacy()
         open_append(path: String) -> System.IO2.TextWriter static => new System.IO2.TextWriter(IO.File.openAppend(path));
 
         @IF.dotnet()

--- a/src/system/shim.join.ghul
+++ b/src/system/shim.join.ghul
@@ -1,7 +1,6 @@
 namespace Shim is
     use System.String;
 
-    use System.StringBuffer;
     use System.Text.StringBuilder;
     
     use Collections.Iterable;
@@ -19,7 +18,7 @@ namespace Shim is
         toString() -> String is
             let seen_any = false;
 
-            let result = new StringBuffer();
+            let result = new StringBuilder();
 
             for value in _values do
                 if seen_any then
@@ -31,7 +30,7 @@ namespace Shim is
                 seen_any = true;
             od
 
-            return result;
+            return result.to_string();
         si
         
         @IF.dotnet()

--- a/src/system/shim.string.ghul
+++ b/src/system/shim.string.ghul
@@ -9,6 +9,12 @@ namespace Shim is
         length(value: String) -> int static => value.length;
 
         @IF.legacy()
+        get_at(value: String, index: int) -> char static => value[index];
+
+        @IF.dotnet()
+        get_at(value: String, index: int) -> char static => value.get_at(index);
+
+        @IF.legacy()
         split(value: String, delimiter: char) -> Collections.LIST[String] static => new Collections.LIST[String](value.split(delimiter));
 
         @IF.dotnet()

--- a/src/system/system.console.ghul
+++ b/src/system/system.console.ghul
@@ -13,7 +13,7 @@ namespace System is
             return _in;
         si
 
-        out: IO2.TextWriter static is
+        output: IO2.TextWriter static is
             if !_out? then
                 _out = new IO2.TextWriter(IO.Std.output);
             fi

--- a/tests/cases/parse-statement-pragma-1/test.ghul
+++ b/tests/cases/parse-statement-pragma-1/test.ghul
@@ -2,7 +2,7 @@ namespace Test is
     class Main is
         init() is
             @Test.test_statement_pragma("expression statement test")
-            IO.Std.err.println("this is a test");
+            System.Console.error.write_line("this is a test");
 
             @Test.test_statement_pragma("if statement test")
             if true then
@@ -10,7 +10,7 @@ namespace Test is
                 case 0
                 when 0:
                     @Test.test_statement_pragma("expression statement test")
-                    IO.Std.err.println("this is a test");
+                    System.Console.error.write_line("this is a test");
                 esac                
             else
                 @Test.test_statement_pragma("while statement test")
@@ -26,16 +26,16 @@ namespace Test is
             @Test.test_statement_pragma("try statement test")
             try
                 @Test.test_statement_pragma("expression statement test")
-                IO.Std.err.println("this is a test");
+                System.Console.error.write_line("this is a test");
             catch ex: System.Exception
                 @Test.test_statement_pragma("expression statement test")
-                IO.Std.err.println("this is a test");                
+                System.Console.error.write_line("this is a test");                
             finally
                 @Test.test_statement_pragma("expression statement test")
-                IO.Std.err.println("this is a test");
+                System.Console.error.write_line("this is a test");
             yrt
             
-            
+            System.Console.error.write_line("at end");            
         si
     si
 si


### PR DESCRIPTION
- Fix errors running type check on compiler itself for .NET target
- Switch the type check build script and CI type check jobs over to the .NET target

See Tactical solution for collections and iterators #276