### PR TITLE
Fix analysis mode

### DIFF
--- a/src/system/system.console.ghul
+++ b/src/system/system.console.ghul
@@ -15,7 +15,7 @@ namespace System is
 
         output: IO2.TextWriter static is
             if !_out? then
-                _out = new IO2.TextWriter(IO.Std.output);
+                _out = new IO2.TextWriter(IO.Std.out);
             fi
 
             return _out;
@@ -23,7 +23,7 @@ namespace System is
         
         error: IO2.TextWriter static is
             if !_error? then
-                _error = new IO2.TextWriter(IO.Std.error);
+                _error = new IO2.TextWriter(IO.Std.err);
             fi
 
             return _error;            


### PR DESCRIPTION

- Analysis mode was broken in the 0.2.25 release. Restore it by referencing the correct L standard output stream.

Fixes #437