### PR TITLE
Complete implementation of assert statement

### DIFF
--- a/src/driver/analyser.ghul
+++ b/src/driver/analyser.ghul
@@ -165,7 +165,7 @@ namespace Driver is
         si
 
         add_handler(command_name: String, command_handler: CommandHandler) is
-            _assert _command_map[command_name] == null else "replacing command handler for " + command_name;
+            assert _command_map[command_name] == null else "replacing command handler for " + command_name;
 
             _command_map[command_name] = command_handler;
         si

--- a/src/ir/innate_operation_generator.ghul
+++ b/src/ir/innate_operation_generator.ghul
@@ -96,7 +96,7 @@ namespace IR is
         si
 
         gen_bool_not(value: INNATE, context: CONTEXT) is
-            _assert value.arguments? && value.arguments.count == 1 else "not bool missing arguments";
+            assert value.arguments? && value.arguments.count == 1 else "not bool missing arguments";
 
             gen_arguments(value, context);
 
@@ -106,7 +106,7 @@ namespace IR is
         si        
 
         gen_short_circuit_bool(value: INNATE, context: CONTEXT) is
-            _assert value.arguments? && value.arguments.count == 2 else "short circuit bool missing arguments";
+            assert value.arguments? && value.arguments.count == 2 else "short circuit bool missing arguments";
 
             let exit = new IR.LABEL();
             let operation = value.op_name;
@@ -135,7 +135,7 @@ namespace IR is
         si
 
         gen_compare_order(value: INNATE, is_unsigned: bool, context: CONTEXT) is
-            _assert value.arguments? && value.arguments.count == 2 else "compare order missing arguments";
+            assert value.arguments? && value.arguments.count == 2 else "compare order missing arguments";
 
             gen_arguments(value, context);
 
@@ -194,7 +194,7 @@ namespace IR is
         si
 
         gen_compare_reference(value: INNATE, context: CONTEXT) is
-            _assert value.arguments? && value.arguments.count == 2 else "compare reference missing arguments";
+            assert value.arguments? && value.arguments.count == 2 else "compare reference missing arguments";
 
             let left = value.arguments[0];
             let right = value.arguments[1];
@@ -216,7 +216,7 @@ namespace IR is
         si
 
         gen_compare_value(value: INNATE, context: CONTEXT) is
-            _assert value.arguments? && value.arguments.count == 2 else "compare value missing arguments";
+            assert value.arguments? && value.arguments.count == 2 else "compare value missing arguments";
 
             gen_arguments(value, context);
 
@@ -229,7 +229,7 @@ namespace IR is
         si
 
         gen_range(value: INNATE, context: CONTEXT) is
-            _assert value.arguments? && value.arguments.count == 2 else "create range missing arguments";
+            assert value.arguments? && value.arguments.count == 2 else "create range missing arguments";
 
             gen_arguments(value, context);
 

--- a/src/lexical/tokenizer.ghul
+++ b/src/lexical/tokenizer.ghul
@@ -159,7 +159,6 @@ namespace Lexical is
                 symbol_tokens["yrt"] = TOKEN.YRT;
                 symbol_tokens["true"] = TOKEN.TRUE;
                 symbol_tokens["false"] = TOKEN.FALSE;
-                symbol_tokens["_assert"] = TOKEN.ASSERT;
                 symbol_tokens["assert"] = TOKEN.ASSERT;
             fi
         si

--- a/src/semantic/graph/value/value.ghul
+++ b/src/semantic/graph/value/value.ghul
@@ -51,9 +51,9 @@ namespace Semantic.Graph.Value is
         ) is
             super.init();
 
-            _assert type?;
-            _assert constructor?;
-            _assert arguments?;
+            assert type?;
+            assert constructor?;
+            assert arguments?;
 
             self.type = type;
             self.constructor = constructor;
@@ -83,8 +83,8 @@ namespace Semantic.Graph.Value is
         ) is
             super.init();
 
-            _assert type?;
-            _assert value?;
+            assert type?;
+            assert value?;
 
             self.type = type;
             self.value = value;
@@ -120,7 +120,7 @@ namespace Semantic.Graph.Value is
         ) is
             super.init();
 
-            _assert value?;
+            assert value?;
 
             self.value = value;
 
@@ -154,7 +154,7 @@ namespace Semantic.Graph.Value is
         ) is
             super.init();
 
-            _assert value?;
+            assert value?;
 
             self.value = value;
         si
@@ -185,7 +185,7 @@ namespace Semantic.Graph.Value is
         ) is
             super.init();
 
-            _assert value?;
+            assert value?;
 
             self.value = value;
         si
@@ -213,10 +213,10 @@ namespace Semantic.Graph.Value is
         ) is
             super.init();
 
-            _assert type?;
+            assert type?;
 
             // native generates null values, which cannot easily be prevented and which propogate, and must be cast before use: 
-            // _assert value?;
+            // assert value?;
 
             self.type = type;
             self.value = value;
@@ -245,10 +245,10 @@ namespace Semantic.Graph.Value is
         ) is
             super.init();
 
-            _assert type?;
+            assert type?;
 
             // native generates null values, which cannot easily be prevented and which propogate, and must be cast before use: 
-            // _assert value?;
+            // assert value?;
 
             self.type = type;
             self.value = value;
@@ -277,9 +277,9 @@ namespace Semantic.Graph.Value is
         ) is
             super.init();
 
-            _assert type?;
-            _assert isa_type?;
-            _assert value?;
+            assert type?;
+            assert isa_type?;
+            assert value?;
 
             self.type = type;
             self.isa_type = type;
@@ -310,8 +310,8 @@ namespace Semantic.Graph.Value is
         ) is
             super.init();
 
-            _assert type?;
-            _assert value?;
+            assert type?;
+            assert value?;
 
             self.value = value;
             self.type = type;
@@ -335,7 +335,7 @@ namespace Semantic.Graph.Value is
         init(value: BASE) is
             super.init();
 
-            _assert value?;
+            assert value?;
 
             self.value = value;
         si
@@ -357,7 +357,7 @@ namespace Semantic.Graph.Value is
         ) is
             super.init();
 
-            _assert type?;
+            assert type?;
 
             self.type = type;
         si
@@ -374,7 +374,7 @@ namespace Semantic.Graph.Value is
         init(type: Type.BASE) is
             super.init();
 
-            _assert type?;
+            assert type?;
 
             self.type = type;
         si
@@ -391,7 +391,7 @@ namespace Semantic.Graph.Value is
         init(type: Type.BASE) is
             super.init();
 
-            _assert type?;
+            assert type?;
 
             self.type = type;
         si
@@ -410,8 +410,8 @@ namespace Semantic.Graph.Value is
         init(type: Type.BASE, values: Collections.Iterable[BASE]) is
             super.init();
 
-            _assert type?;
-            _assert values?;
+            assert type?;
+            assert values?;
 
             self.type = type;
             self.values = values;
@@ -443,9 +443,9 @@ namespace Semantic.Graph.Value is
         ) is
             super.init();
 
-            _assert type?;
-            _assert element_type?;
-            _assert values?;
+            assert type?;
+            assert element_type?;
+            assert values?;
 
             self.type = type;
             self.element_type = element_type;
@@ -483,7 +483,7 @@ namespace Semantic.Graph.Value is
             init(value: BASE) is
                 super.init();
 
-                _assert value?;    
+                assert value?;    
 
                 self.value = value;
             si
@@ -506,7 +506,7 @@ namespace Semantic.Graph.Value is
             init(type: Type.BASE) is
                 super.init();
 
-                _assert type?;
+                assert type?;
                     
                 self.type = type;
             si
@@ -536,7 +536,7 @@ namespace Semantic.Graph.Value is
             init(self_: Symbol.BASE, type: Type.BASE) is
                 super.init();
 
-                _assert self_?;
+                assert self_?;
  
                 self.self_ = self_;
 
@@ -594,7 +594,7 @@ namespace Semantic.Graph.Value is
             init(from: BASE, symbol: Symbol.BASE) is
                 super.init();
 
-                _assert symbol?;
+                assert symbol?;
 
                 self.from = from;
                 self.symbol = symbol;
@@ -652,7 +652,7 @@ namespace Semantic.Graph.Value is
             init(from: BASE, symbol: Symbol.BASE) is
                 super.init(from, symbol);
 
-                _assert from?;
+                assert from?;
             si
 
             gen(context: IR.CONTEXT) is
@@ -694,7 +694,7 @@ namespace Semantic.Graph.Value is
             init(symbol: Symbol.BASE, func_type: Semantic.Type.BASE) is
                 super.init(null, symbol);
 
-                _assert func_type?;
+                assert func_type?;
                 
                 self.func_type = func_type;
             si
@@ -717,7 +717,7 @@ namespace Semantic.Graph.Value is
             init(symbol: Symbol.BASE, func_type: Semantic.Type.BASE) is
                 super.init(null, symbol);
 
-                _assert func_type?;
+                assert func_type?;
                 
                 self.func_type = func_type;
             si
@@ -744,8 +744,8 @@ namespace Semantic.Graph.Value is
             init(from: BASE, symbol: Symbol.BASE, value: Graph.Value.BASE) is
                 super.init();
 
-                _assert symbol?;
-                _assert value?;
+                assert symbol?;
+                assert value?;
 
                 self.from = from;
                 self.symbol = symbol;
@@ -797,7 +797,7 @@ namespace Semantic.Graph.Value is
             init(from: Graph.Value.BASE, symbol: Symbol.BASE, value: Graph.Value.BASE) is
                 super.init(from, symbol, value);
 
-                _assert from?;
+                assert from?;
             si
 
             gen(context: IR.CONTEXT) is
@@ -848,8 +848,8 @@ namespace Semantic.Graph.Value is
                 type: Type.BASE) is
                 super.init();
 
-                _assert function?;
-                _assert arguments?;
+                assert function?;
+                assert arguments?;
 
                 self.function = function;
                 self.arguments = arguments;
@@ -887,7 +887,7 @@ namespace Semantic.Graph.Value is
                     self.type = function.return_type;
                 fi
 
-                _assert self.type?;
+                assert self.type?;
             si
 
             gen(context: IR.CONTEXT) is
@@ -922,7 +922,7 @@ namespace Semantic.Graph.Value is
                     self.type = function.return_type;
                 fi
 
-                _assert self.type?;                
+                assert self.type?;                
             si
 
             gen(context: IR.CONTEXT) is
@@ -959,7 +959,7 @@ namespace Semantic.Graph.Value is
                     self.type = function.return_type;
                 fi
 
-                _assert self.type?;                
+                assert self.type?;                
             si
 
             gen(context: IR.CONTEXT) is
@@ -994,7 +994,7 @@ namespace Semantic.Graph.Value is
                     self.type = function.return_type;
                 fi
 
-                _assert self.type?;
+                assert self.type?;
             si
 
             gen(context: IR.CONTEXT) is
@@ -1027,9 +1027,9 @@ namespace Semantic.Graph.Value is
             ) is
                 super.init();
 
-                _assert type?;
-                _assert func_type?;
-                _assert arguments?;
+                assert type?;
+                assert func_type?;
+                assert arguments?;
 
                 self.from = from;
                 self.type = type;
@@ -1097,9 +1097,9 @@ namespace Semantic.Graph.Value is
             init(string: String, type: Type.BASE, suffix: String) is
                 super.init();
 
-                _assert string?;
-                _assert type?;
-                _assert suffix?;
+                assert string?;
+                assert type?;
+                assert suffix?;
 
                 self.string = string;
                 self.type = type;
@@ -1122,8 +1122,8 @@ namespace Semantic.Graph.Value is
             init(string: String, type: Type.BASE) is
                 super.init();
 
-                _assert string?;
-                _assert type?;
+                assert string?;
+                assert type?;
 
                 self.string = string;
                 self.type = type;

--- a/src/semantic/namespaces.ghul
+++ b/src/semantic/namespaces.ghul
@@ -47,7 +47,7 @@ namespace Semantic is
         si
 
         release_namepace_stack(mark: int) is
-            _assert mark <= _prefixes.count;
+            assert mark <= _prefixes.count;
 
             while _prefixes.count > mark do
                 _prefixes.pop();
@@ -90,7 +90,7 @@ namespace Semantic is
             var qualified_name = get_qualified_name(name);
             var ns = find_namespace(qualified_name);
 
-            _assert ns? else "No pre-existing aggregate namespace found";
+            assert ns? else "No pre-existing aggregate namespace found";
 
             _prefixes.push(qualified_name);
 
@@ -100,7 +100,7 @@ namespace Semantic is
         leave_namespace(location: LOCATION, name: String) is
             var ns = find_namespace(current_prefix);
 
-            _assert ns? else "could not find aggregate namespace";
+            assert ns? else "could not find aggregate namespace";
             _prefixes.pop();
         si
 
@@ -118,7 +118,7 @@ namespace Semantic is
         find_namespace(qualified_name: String) -> Symbol.NAMESPACE is
             var result = _namespaces[qualified_name];
 
-            _assert result? else "aggregate namespace should already exist";
+            assert result? else "aggregate namespace should already exist";
 
             return result;
         si

--- a/src/semantic/symbol/classy.ghul
+++ b/src/semantic/symbol/classy.ghul
@@ -282,7 +282,7 @@ namespace Semantic.Symbol is
         si
 
         find_member_only(name: String) -> BASE is
-            _assert ancestors? else "ancestors is null";
+            assert ancestors? else "ancestors is null";
 
             for a in ancestors do
                 if a? && a.scope? then

--- a/src/semantic/symbol/enum.ghul
+++ b/src/semantic/symbol/enum.ghul
@@ -31,7 +31,7 @@ namespace Semantic.Symbol is
         si
 
         get_ancestor(index: int) -> Type.BASE is
-            _assert index == 0;
+            assert index == 0;
 
             return _ancestor_;
         si

--- a/src/semantic/symbol/function.ghul
+++ b/src/semantic/symbol/function.ghul
@@ -206,9 +206,9 @@ namespace Semantic.Symbol is
         il_type_name: String is
             let result = new System.Text.StringBuilder();
 
-            _assert self? else "function il_type_name self is null";
+            assert self? else "function il_type_name self is null";
 
-            _assert 
+            assert 
                 unspecialized_arguments? || !specialized_from?
             else
                 "function specialized from generic has no copy of original unspecialised arguments";
@@ -346,7 +346,7 @@ namespace Semantic.Symbol is
         si
 
         specialize(type_map: Collections.MAP[String,Type.BASE], owner: GENERIC) -> Function is
-            _assert owner? else "cannot specialize with null owner";
+            assert owner? else "cannot specialize with null owner";
 
             @IF.legacy()
             let result = cast Function(clone());

--- a/src/semantic/symbol/innate.ghul
+++ b/src/semantic/symbol/innate.ghul
@@ -21,7 +21,7 @@ namespace Semantic.Symbol is
         si
 
         load(location: LOCATION, from: Graph.Value.BASE, loader: SYMBOL_LOADER) -> Graph.Value.BASE is
-            _assert !from? else "instance load of function";
+            assert !from? else "instance load of function";
 
             // FIXME: this should probably error
             return loader.load_global_function(self);
@@ -34,7 +34,7 @@ namespace Semantic.Symbol is
         si        
 
         call(location: Source.LOCATION, from: Graph.Value.BASE, arguments: Collections.LIST[Graph.Value.BASE], type: Semantic.Type.BASE, caller: FUNCTION_CALLER) -> Graph.Value.BASE is
-            _assert !from? else "instance call of innate function";
+            assert !from? else "instance call of innate function";
 
             return caller.call_innate_function(self, arguments, self.arguments, type);
         si
@@ -60,12 +60,12 @@ namespace Semantic.Symbol is
         si
 
         load(location: LOCATION, from: Graph.Value.BASE, loader: SYMBOL_LOADER) -> Graph.Value.BASE is
-            _assert !from? else "load global function from instance context";
+            assert !from? else "load global function from instance context";
             return loader.load_global_function(self);
         si
 
         call(location: Source.LOCATION, from: Graph.Value.BASE, arguments: Collections.LIST[Graph.Value.BASE], type: Semantic.Type.BASE, caller: FUNCTION_CALLER) -> Graph.Value.BASE is
-            _assert !from? else "call global function from instance context";
+            assert !from? else "call global function from instance context";
             return caller.call_global_function(self, arguments, self.arguments, type);
         si
     si

--- a/src/semantic/symbol/method.ghul
+++ b/src/semantic/symbol/method.ghul
@@ -105,7 +105,7 @@ namespace Semantic.Symbol is
         init(location: LOCATION, owner: Scope, name: String, enclosing_scope: Scope) is
             super.init(location, owner, name, enclosing_scope);
 
-            _assert owner? else "abstract method created without owner";
+            assert owner? else "abstract method created without owner";
         si
 
         call(location: Source.LOCATION, from: Graph.Value.BASE, arguments: Collections.LIST[Graph.Value.BASE], type: Semantic.Type.BASE, caller: FUNCTION_CALLER) -> Graph.Value.BASE is

--- a/src/semantic/symbol/symbol.ghul
+++ b/src/semantic/symbol/symbol.ghul
@@ -77,7 +77,7 @@ namespace Semantic.Symbol is
         name: String => _name;
 
         qualified_name: String is
-            _assert owner? else Shim.OBJ.type_name(self) + " " + name + " has no qualified name because owner is null";
+            assert owner? else Shim.OBJ.type_name(self) + " " + name + " has no qualified name because owner is null";
 
             return owner.qualify(name);
         si
@@ -118,7 +118,7 @@ namespace Semantic.Symbol is
                 throw new Exception("symbol is own owner");
             fi
 
-            _assert owner? && isa BASE(owner) else "owner is null or not a symbol";
+            assert owner? && isa BASE(owner) else "owner is null or not a symbol";
 
             return cast BASE(owner).il_qualified_name;
         si        
@@ -128,7 +128,7 @@ namespace Semantic.Symbol is
                 throw new Exception("symbol is own owner");
             fi
 
-            _assert owner? && isa BASE(owner) else "owner is null or not a symbol";
+            assert owner? && isa BASE(owner) else "owner is null or not a symbol";
 
             return cast BASE(owner).il_type_name;
         si

--- a/src/semantic/symbol/variable.ghul
+++ b/src/semantic/symbol/variable.ghul
@@ -47,7 +47,7 @@ namespace Semantic.Symbol is
         description: String => name + ": " + type + " // local variable";
 
         il_def: String is
-            _assert type? else "local has null type";
+            assert type? else "local has null type";
 
             return ".locals init (" + type.il_type_name + " " + il_name + ")";
         si    
@@ -59,12 +59,12 @@ namespace Semantic.Symbol is
         si
 
         load(location: LOCATION, from: Graph.Value.BASE, loader: SYMBOL_LOADER) -> Graph.Value.BASE is
-            _assert !from?;
+            assert !from?;
             return loader.load_local_variable(self);
         si
 
         store(location: LOCATION, from: Graph.Value.BASE, value: Graph.Value.BASE, loader: SYMBOL_LOADER) -> Graph.Value.BASE is
-            _assert !from?;
+            assert !from?;
             return loader.store_local_variable(self, value);
         si
     si
@@ -79,12 +79,12 @@ namespace Semantic.Symbol is
         si
 
         load(location: LOCATION, from: Graph.Value.BASE, loader: SYMBOL_LOADER) -> Graph.Value.BASE is
-            _assert !from?;
+            assert !from?;
             return loader.load_local_argument(self);
         si
 
         store(location: LOCATION, from: Graph.Value.BASE, value: Graph.Value.BASE, loader: SYMBOL_LOADER) -> Graph.Value.BASE is
-            _assert !from?;
+            assert !from?;
             return loader.store_local_argument(self, value);
         si
     si
@@ -100,12 +100,12 @@ namespace Semantic.Symbol is
         si
 
         load(location: LOCATION, from: Graph.Value.BASE, loader: SYMBOL_LOADER) -> Graph.Value.BASE is
-            _assert !from? else "load global function from instance context";
+            assert !from? else "load global function from instance context";
             return loader.load_global_variable(self);
         si
 
         store(location: LOCATION, from: Graph.Value.BASE, value: Graph.Value.BASE, loader: SYMBOL_LOADER) -> Graph.Value.BASE is
-            _assert !from? else "load global function from instance context";
+            assert !from? else "load global function from instance context";
             return loader.store_global_variable(self, value);
         si
     si

--- a/src/semantic/symbol_table.ghul
+++ b/src/semantic/symbol_table.ghul
@@ -31,7 +31,7 @@ namespace Semantic is
                 fi
             od
             
-            _assert false else "no current namespace";
+            assert false else "no current namespace";
         si
 
         current_declaration_context: DeclarationContext is
@@ -108,7 +108,7 @@ namespace Semantic is
         si
 
         release_scope_stack(mark: int) is
-            _assert mark <= _stack.count;
+            assert mark <= _stack.count;
 
             while _stack.count > mark do
                 _stack.remove_at(_stack.count - 1);
@@ -147,7 +147,7 @@ namespace Semantic is
                 throw new System.Exception("attempting to leave use scope");
             fi
 
-            _assert current_scope == scope else "scope stack corrupt";
+            assert current_scope == scope else "scope stack corrupt";
             
             _stack.remove_at(_stack.count - 1);
         si

--- a/src/semantic/type/type.ghul
+++ b/src/semantic/type/type.ghul
@@ -227,10 +227,10 @@ namespace Semantic.Type is
         ancestors: Collections.LIST[BASE] => cast Symbol.GENERIC(symbol).ancestors;
 
         short_description: String is
-            _assert self? else "self is null";
-            _assert symbol? else "symbol is null";
-            _assert symbol.name? else "symbol.name is null";
-            _assert arguments? else "arguments is null";
+            assert self? else "self is null";
+            assert symbol? else "symbol is null";
+            assert symbol.name? else "symbol.name is null";
+            assert arguments? else "arguments is null";
 
             let result = new System.Text.StringBuilder();
 
@@ -241,7 +241,7 @@ namespace Semantic.Type is
             var seen_any = false;
 
             for a in arguments do
-                _assert a? else "argument is null";
+                assert a? else "argument is null";
 
                 if seen_any then
                     result.append(',');
@@ -736,7 +736,7 @@ namespace Semantic.Type is
         si
 
         specialize(generic_cache: GENERIC_CACHE, arguments: Collections.MAP[String,Type.BASE]) -> FUNCTION_GROUP is
-            _assert false else "specializing function group sets owner to null";
+            assert false else "specializing function group sets owner to null";
 
             let result = new FUNCTION_GROUP(
                 name,

--- a/src/syntax/parser/base.ghul
+++ b/src/syntax/parser/base.ghul
@@ -86,7 +86,7 @@ namespace Syntax.Parser is
                 et.add(k);
             od
 
-            _assert et.count > 0 else "should have at least one expected token";
+            assert et.count > 0 else "should have at least one expected token";
 
             _expected_tokens = et;
         si

--- a/src/syntax/parser/context.ghul
+++ b/src/syntax/parser/context.ghul
@@ -59,18 +59,18 @@ namespace Syntax.Parser is
         si
 
         mark() is
-            _assert speculative_parse_tokens == null else "cannot start nested speculative parse";
+            assert speculative_parse_tokens == null else "cannot start nested speculative parse";
             speculative_parse_tokens = new Collections.LIST[Lexical.TOKEN_PAIR]();
             speculative_parse_tokens.add(current);
         si
 
         commit() is
-            _assert speculative_parse_tokens? else "cannot commit: not in speculative parse";
+            assert speculative_parse_tokens? else "cannot commit: not in speculative parse";
             speculative_parse_tokens = null;
         si
 
         backtrack() is
-            _assert speculative_parse_tokens? else "cannot backtrack: not in speculative parse";
+            assert speculative_parse_tokens? else "cannot backtrack: not in speculative parse";
             write_tokens(speculative_parse_tokens);
             speculative_parse_tokens = null;
         si

--- a/src/syntax/parser/expression/node.ghul
+++ b/src/syntax/parser/expression/node.ghul
@@ -121,7 +121,7 @@ namespace Syntax.Parser.Expression is
 
                 var right: Tree.Expression.NODE = expression_tertiary_parser.parse(context);
 
-                _assert right? else "parse right failed";
+                assert right? else "parse right failed";
 
                 do
                     var right_precedence = precedence(context);

--- a/src/syntax/process/conditional_compilation.ghul
+++ b/src/syntax/process/conditional_compilation.ghul
@@ -42,7 +42,7 @@ namespace Syntax.Process is
         si
 
         visit(pragma_: Definition.PRAGMA) is
-            _assert pragma_.pragma_? else "pragma is null";
+            assert pragma_.pragma_? else "pragma is null";
 
             let p = pragma_.pragma_;
 
@@ -64,7 +64,7 @@ namespace Syntax.Process is
         si
 
         visit(pragma_: Statement.PRAGMA) is
-            _assert pragma_.pragma_? else "pragma is null";
+            assert pragma_.pragma_? else "pragma is null";
 
             let p = pragma_.pragma_;
 

--- a/src/syntax/process/declare_symbols.ghul
+++ b/src/syntax/process/declare_symbols.ghul
@@ -164,8 +164,8 @@ namespace Syntax.Process is
             if function.for_property? then
                 let symbol = symbol_for(function.for_property);
 
-                _assert symbol? else "function is accessor for property but no property found: " + function.location;
-                _assert isa Semantic.Symbol.Property(symbol) else "function is accessor for property but associated symbol is not a property: " + function.location;
+                assert symbol? else "function is accessor for property but no property found: " + function.location;
+                assert isa Semantic.Symbol.Property(symbol) else "function is accessor for property but associated symbol is not a property: " + function.location;
 
                 property = cast Semantic.Symbol.Property(symbol);
             fi

--- a/src/syntax/process/generate_il.ghul
+++ b/src/syntax/process/generate_il.ghul
@@ -627,8 +627,8 @@ namespace Syntax.Process is
         si
 
         visit(case_: Statement.CASE) is
-            _assert case_.expression?;
-            _assert case_.matches?;
+            assert case_.expression?;
+            assert case_.matches?;
 
             let temp = new IR.TEMP(_context, case_.id, case_.expression.value);
 
@@ -747,7 +747,7 @@ namespace Syntax.Process is
 
             if outer_try? then
                 if return_value? then
-                    _assert outer_try.return_value? else "outer try has no return value temporary";
+                    assert outer_try.return_value? else "outer try has no return value temporary";
                     outer_try.return_value.store(return_value.load());
                 fi
                 

--- a/src/syntax/process/printer/base.ghul
+++ b/src/syntax/process/printer/base.ghul
@@ -487,8 +487,8 @@ namespace Syntax.Process.Printer is
             var is_first = true;
             var seen_else = false;
 
-            _assert i?;
-            _assert i.branches?;
+            assert i?;
+            assert i.branches?;
 
             for b in i.branches do
                 location(b);
@@ -497,7 +497,7 @@ namespace Syntax.Process.Printer is
                     IoC.CONTAINER.instance.logger.error(b.location, "broken if statement");
                 fi
 
-                _assert !seen_else;
+                assert !seen_else;
                 
                 if b.condition? then
                     if is_first then

--- a/src/syntax/tree/body/expression.ghul
+++ b/src/syntax/tree/body/expression.ghul
@@ -9,7 +9,7 @@ namespace Syntax.Tree.Body is
         init(location: LOCATION, expression: Expression.NODE) is
             super.init(location);
 
-            _assert expression?;
+            assert expression?;
 
             self.expression = expression;
         si

--- a/src/syntax/tree/definition/property.ghul
+++ b/src/syntax/tree/definition/property.ghul
@@ -26,7 +26,7 @@ namespace Syntax.Tree.Definition is
         ) is
             super.init(location, modifiers);
 
-            _assert type_expression?;
+            assert type_expression?;
 
             self.type_expression = type_expression;
             self.name = name;

--- a/src/syntax/tree/definition/variable/node.ghul
+++ b/src/syntax/tree/definition/variable/node.ghul
@@ -26,7 +26,7 @@ namespace Syntax.Tree.Variable is
         si
 
         copy() -> NODE is
-            _assert initializer == null else "cannot copy a variable node with non null initializer";
+            assert initializer == null else "cannot copy a variable node with non null initializer";
 
             return new NODE(
                 location,

--- a/src/syntax/tree/pragma/node.ghul
+++ b/src/syntax/tree/pragma/node.ghul
@@ -14,7 +14,7 @@ namespace Syntax.Tree.Pragma is
         ) is
             super.init(location);
 
-            _assert name?;
+            assert name?;
 
             self.name = name;
             self.arguments = arguments;

--- a/src/system/collections.ghul
+++ b/src/system/collections.ghul
@@ -127,7 +127,7 @@ namespace Collections is
         si
 
         remove_at(index: int) is
-            _assert index == _vector.Length - 1 else "fixme: cannot remove element except index == count-1";
+            assert index == _vector.Length - 1 else "fixme: cannot remove element except index == count-1";
 
             _vector.pop();
         si


### PR DESCRIPTION
- Migrate references to temporary `_assert` statement to final `assert` statement
- Remove `_assert` token scaffolding

Fixes:
- More efficient assertion mechanism (closes #404)
- Alternative to Object.assert() (closes #445)