### PR TITLE
Missing dependency in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -381,7 +381,7 @@ jobs:
       if: ${{ always() }}
 
   legacy_tests:
-    needs: [bootstrap]
+    needs: [bootstrap, build_tester]
     name: Run legacy tests
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
- Add build_tester to needs for legacy_tests job in release.yml

Fixes #462