### PR TITLE
CD workflow improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,16 +7,18 @@ on:
     branches: [master, main]
 
 jobs:
-  create_version:
+  version:
     name: Create a version number
     runs-on: ubuntu-20.04
     timeout-minutes: 10
+    outputs:
+      number: ${{ steps.create_version_number.outputs.new_tag }}
 
     steps:
     - uses: actions/checkout@v2
 
-    - name: Prepare version number
-      id: prepare_version_number
+    - name: Create version number
+      id: create_version_number
       uses: anothrNick/github-tag-action@1.26.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -24,34 +26,22 @@ jobs:
         DRY_RUN: ${{ github.event_name == 'pull_request' }}
         DEFAULT_BUMP: patch
 
-    - name: Capture version number
-      run: 'echo ${{ steps.prepare_version_number.outputs.new_tag }} >version.txt'
-
-    - name: Upload version number
-      uses: actions/upload-artifact@v2
-      with:
-        name: version
-        path: version.txt
+    - name: Echo version number
+      run: 'echo ${{ steps.create_version_number.outputs.new_tag }}'
 
   bootstrap:
     name: Bootstrap compiler
-    needs: [create_version]
+    needs: [version]
     runs-on: ubuntu-20.04
-    container: ghul/devcontainer:stable
+    container:
+      image: ghcr.io/degory/ghul/devcontainer:stable
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GHCR_PAT }}
     timeout-minutes: 10
 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Download version number
-      uses: actions/download-artifact@v2
-      with:
-        name: version
-        path: .
-
-    - name: Set version number variable
-      id: version
-      run: echo "::set-output name=current::`cat version.txt`"
 
     - name: Mono version
       run: mono --version
@@ -59,7 +49,7 @@ jobs:
     - name: Bootstrap compiler
       run: ./build/bootstrap.sh
       env:
-        BUILD_NAME: ${{ steps.version.outputs.current }}
+        BUILD_NAME: ${{ needs.version.outputs.number }}
 
     - name: Build test runner
       run: cd ghul-test && ./build/build.sh
@@ -82,7 +72,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-                    
+
     - name: Download ghul installer
       uses: actions/download-artifact@v2
       with:
@@ -105,7 +95,7 @@ jobs:
         path: mono-test-results.txt
 
   build_dev_container:
-    needs: [bootstrap]
+    needs: [version, bootstrap]
     name: Build development container
     runs-on: ubuntu-20.04    
     if: ${{ github.event_name != 'pull_request' }}
@@ -113,60 +103,46 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Download version number
-      uses: actions/download-artifact@v2
-      with:
-        name: version
-        path: .
-
-    - name: Set version number variable
-      id: version
-      run: echo "::set-output name=current::`cat version.txt`"
-
     - name: Download ghul installer
       uses: actions/download-artifact@v2
       with:
         name: installer
         path: ./installer
-  
-    - name: Docker login
-      run: ./build/docker-login.sh
-      env:
-        DOCKER_USER_NAME: ${{ secrets.DOCKER_USER_NAME }}  
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-  
+
+    - name: Docker login to GHCR
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GHCR_PAT }}
+
     - name: Docker build
-      run: 'docker build . -f devcontainer.dockerfile -t ghul/devcontainer:${{ steps.version.outputs.current }}'
+      run: 'docker build . -f devcontainer.dockerfile -t ghcr.io/degory/ghul/devcontainer:${{ needs.version.outputs.number }}'
 
     - name: Docker push
-      run: docker push ghul/devcontainer:${{ steps.version.outputs.current }}
-
-    - name: Docker logout
-      run: docker logout
-      if: ${{ always() }}
+      run: docker push ghcr.io/degory/ghul/devcontainer:${{ needs.version.outputs.number }}
 
   dev_container_tests:
-    needs: [build_dev_container]
+    needs: [version, build_dev_container]
     name: Run tests in development container
     runs-on: ubuntu-20.04
-    container: mono
     timeout-minutes: 10
     if: ${{ github.event_name != 'pull_request' }}
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: Docker login to GHCR
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GHCR_PAT }}
                     
     - name: Run .NET tests
-      run: 'docker run --env TARGET -v `pwd`:/home/dev/source/ -w /home/dev/source ghul/devcontainer:${{ steps.version.outputs.current }} ghul-test tests | tee dev-container-test-results.txt'
+      run: 'docker run --env TARGET -v `pwd`:/home/dev/source/ -w /home/dev/source ghcr.io/degory/ghul/devcontainer:${{ needs.version.outputs.number }} ghul-test tests | tee dev-container-test-results.txt'
       env:
         TARGET: mono
-
-    - uses: actions/upload-artifact@v2
-      if: ${{ always() }}
-      with:
-        name: mono-test-results
-        path: |
-          tests/test-results.md
 
     - uses: actions/upload-artifact@v2
       if: ${{ always() }}
@@ -175,7 +151,7 @@ jobs:
         path: dev-container-test-results.txt
 
   tag_containers:
-    needs: [dev_container_tests]
+    needs: [version, dev_container_tests]
     name: Tag containers
     runs-on: ubuntu-20.04
     if: ${{ github.event_name != 'pull_request' }}
@@ -183,47 +159,36 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Download version number
-      uses: actions/download-artifact@v2
+    - name: Docker login to GHCR
+      uses: docker/login-action@v1
       with:
-        name: version
-        path: .
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GHCR_PAT }}
 
-    - name: Set version number variable
-      id: version
-      run: echo "::set-output name=current::`cat version.txt`"
-
-    - name: Docker login
-      run: ./build/docker-login.sh
-      env:
-        DOCKER_USER_NAME: ${{ secrets.DOCKER_USER_NAME }}  
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Docker login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USER_NAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Docker pull
-      run: docker pull ghul/devcontainer:${{ steps.version.outputs.current }}
+      run: docker pull ghcr.io/degory/ghul/devcontainer:${{ needs.version.outputs.number }}
 
-    - name: Docker tag stable
-      if: ${{ github.event_name == 'push' }}
-      run: docker tag ghul/devcontainer:${{ steps.version.outputs.current }} ghul/devcontainer:stable
+    - name: Docker tag GHCR
+      run: docker tag ghcr.io/degory/ghul/devcontainer:${{ needs.version.outputs.number }} ghcr.io/degory/ghul/devcontainer:stable
+      
+    - name: Docker tag Docker Hub
+      run: docker tag ghcr.io/degory/ghul/devcontainer:${{ needs.version.outputs.number }} ghul/devcontainer:stable
 
-    - name: Docker push
-      if: ${{ github.event_name == 'push' }}
+    - name: Docker push GHCR
+      run: docker push ghcr.io/degory/ghul/devcontainer:stable
+
+    - name: Docker push Docker Hub
       run: docker push ghul/devcontainer:stable
 
-    - name: Docker tag test
-      if: ${{ github.event_name != 'push' }}
-      run: docker tag ghul/devcontainer:${{ steps.version.outputs.current }} ghul/devcontainer:test
-
-    - name: Docker push
-      if: ${{ github.event_name != 'push' }}
-      run: docker push ghul/devcontainer:test
-
-    - name: Docker logout
-      run: docker logout
-      if: ${{ always() }}    
-
   create_release:
-    needs: [dev_container_tests]
+    needs: [version, dev_container_tests]
     name: Create release
     runs-on: ubuntu-20.04
     if: ${{ github.event_name != 'pull_request' }}
@@ -232,16 +197,6 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-
-    - name: Download version number
-      uses: actions/download-artifact@v2
-      with:
-        name: version
-        path: .
-
-    - name: Set version number variable
-      id: version
-      run: echo "::set-output name=current::`cat version.txt`"
 
     - name: Download ghul installer
       uses: actions/download-artifact@v2
@@ -258,8 +213,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ steps.version.outputs.current }}
-        release_name: ${{ steps.version.outputs.current }}
+        tag_name: ${{ needs.version.outputs.number }}
+        release_name: ${{ needs.version.outputs.number }}
         body_path: changelog.txt
         draft: true
 

--- a/.github/workflows/overnight.yml
+++ b/.github/workflows/overnight.yml
@@ -69,11 +69,13 @@ jobs:
     # stop Docker from deleting the legacy container in case I need it:
     name: Legacy container keepalive
     runs-on: ubuntu-20.04
-    container: ghul/compiler:stable
     timeout-minutes: 10
 
     steps:
     - uses: actions/checkout@v2
 
-    -name: Run legacy compiler
-    run: ghul
+    - name: Pull legacy compiler container
+      run: docker pull ghul/compiler:stable
+
+    - name: Run legacy compiler
+      run: docker run ghul/compiler:stable ghul


### PR DESCRIPTION
Enhancements:
- Push copy of development container image to GitHub Container Registry for improved resilience (closes #539)

Technical improvements:
- Use GitHub Container Registry to source the container image used to bootstrap, and to hold the unpublished development container image, to reduce chargeable bandwidth use
- Pass version number between jobs using `needs` rather than by uploading/downloading artefact
- Use Docker's login action rather than our hand-rolled script
- Fix incorrect YAML config for overnight build workflow
- Fix broken container config for legacy container keep-alive in overnight build workflow