### PR TITLE
Hide internal symbols from completion suggestions

### DIFF
--- a/src/semantic/symbol/symbol.ghul
+++ b/src/semantic/symbol/symbol.ghul
@@ -79,6 +79,8 @@ namespace Semantic.Symbol is
 
         name: String => _name;
 
+        is_internal: bool => _name.starts_with("__");
+
         qualified_name: String is
             assert owner? else "" + get_type() + " " + name + " has no qualified name because owner is null";
 

--- a/src/semantic/symbol_map.ghul
+++ b/src/semantic/symbol_map.ghul
@@ -1,7 +1,7 @@
 namespace Semantic is
     use System;
 
-    class SYMBOL_MAP /* : Collections.MutableMap[String,Symbol.BASE] */ is
+    class SYMBOL_MAP is
         _map: Collections.MAP[String,Symbol.BASE];
 
         count: int => _map.count;
@@ -14,7 +14,7 @@ namespace Semantic is
 
         [name: String]: Symbol.BASE is
             if _map.contains_key(name) then
-                return _map[name];
+                return _map[name];                
             fi            
         si,
         = v is
@@ -35,8 +35,18 @@ namespace Semantic is
         is
             if prefix.length == 0 then
                 for p in _map do
-                    matches[p.key] = p.value;
-                od                
+                    if !p.value.is_internal then
+                        matches[p.key] = p.value;
+                    fi
+                od
+            else
+                for p in _map do
+                    if p.key.starts_with(prefix) then
+                        if !p.value.is_internal then
+                            matches[p.key] = p.value;
+                        fi
+                    fi                    
+                od
             fi
         si
 


### PR DESCRIPTION
Bug fixes:
- Fix issue where internal symbols starting with `__` were offered as code completion suggestions (closes #530)