### PR TITLE
Show average execution times for passes

### DIFF
--- a/src/driver/analyser.ghul
+++ b/src/driver/analyser.ghul
@@ -106,7 +106,7 @@ namespace Driver is
     si
     
     class WATCHDOG is        
-        operation_limit: int static => 100;
+        operation_limit: int static => 250;
 
         _is_enabled: bool;
         _operation_count: int;
@@ -114,13 +114,12 @@ namespace Driver is
         _restart_count: int;
 
         want_restart: bool;
-
         init() is si
 
         request_restart() is
             _restart_count = _restart_count + 2;
 
-            if _restart_count > 10 then
+            if _restart_count > 20 then
                 want_restart = true;
             fi
         si
@@ -137,7 +136,12 @@ namespace Driver is
             if want_restart || _operation_count > operation_limit then
                 want_restart = false;
 
-                System.Console.error.write_line("watchdog: requesting restart...");
+                if want_restart then
+                    System.Console.error.write_line("watchdog: restart due to operation count...");
+                else
+                    System.Console.error.write_line("watchdog: restart due to instability...");
+                fi
+                
                 System.Console.error.flush();
 
                 writer.write_line("RESTART");
@@ -150,7 +154,7 @@ namespace Driver is
             if _restart_count > 0 then
                 _restart_count = _restart_count - 1;
             fi
-        si        
+        si
     si
 
     class COMMAND_DESPATCHER is

--- a/src/logging/timers.ghul
+++ b/src/logging/timers.ghul
@@ -11,8 +11,7 @@ namespace Logging is
 
         _started_at: System.DateTime;
 
-        // average_milliseconds: double => _execute_time.divide(cast double(_execute_count)).total_milliseconds;
-        average_milliseconds: double is si
+        average_milliseconds: double => _execute_time.divide(cast double(_execute_count)).total_milliseconds;
 
         init(name: String) is
             _name = name;


### PR DESCRIPTION
Technical improvements:
- Show average timing for one execution of each pass as well as total accumulated time for each pass (could not be committed in #560 as required the floating point type changes to enable call to System.TimeSpan.divide)
- Increase the operation and error thresholds for analysis mode restart