### PR TITLE
Support passing function arguments by reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
       run: bash ./ghul.run
 
     - name: Run tests
-      run: set -o pipefail ; ghul-test tests | tee test-results.txt
+      run: bash -c "set -o pipefail ; ghul-test tests | tee test-results.txt"
 
     - uses: actions/upload-artifact@v2
       if: ${{ always() }}
@@ -175,7 +175,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Run tests
-      run: set -o pipefail ; ghul-test tests | tee container-test-results.txt
+      run: bash -c "set -o pipefail ; ghul-test tests | tee container-test-results.txt"
 
     - uses: actions/upload-artifact@v2
       if: ${{ always() }}


### PR DESCRIPTION
Enhancements:
- Add `ref` operator, which creates references to variables or expression values suitable for passing to functions expecting `ref` typed arguments (closes #582)

Bug fixes:
- Ambiguous function calls should error (closes #585)
- Arguments in wrong order in overload error messages (closes #584)
- Failing container tests do not fail the release build (closes #588)

Technical:
- Innate property support (closes #265)
- Push version tagged development container images (closes #590)
- Add stubs for additional types in System.Threading
