### PR TITLE
Build fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,20 +29,12 @@ jobs:
         DRY_RUN: ${{ github.event_name == 'pull_request' }}
         DEFAULT_BUMP: patch
 
-    - name: Check version number is valid
-      if: ${{ steps.create_version_number.outputs.new_tag == 'v0.0.0' }}
-      run: exit 1
-
-    - name: Check version number is valid
-      if: ${{ steps.create_version_number.outputs.new_tag == 'v0.0.1' }}
-      run: exit 1
-
-    - name: Check version number is valid
-      if: ${{ steps.create_version_number.outputs.new_tag == 'v0.0.2' }}
-      run: exit 1
-
     - name: Echo version number
       run: 'echo ${{ steps.create_version_number.outputs.new_tag }}'
+
+    - name: Check version number is valid
+      if: ${{ steps.create_version_number.outputs.new_tag == 'v0.0.0' || steps.create_version_number.outputs.new_tag == 'v0.0.1' || steps.create_version_number.outputs.new_tag == '' }}
+      run: exit 1
 
   bootstrap:
     name: Bootstrap compiler
@@ -62,7 +54,7 @@ jobs:
     env:
       HOST: ${{ matrix.host }}
 
-    timeout-minutes: 3
+    timeout-minutes: 5
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/overnight.yml
+++ b/.github/workflows/overnight.yml
@@ -6,63 +6,74 @@ on:
   - cron: "0 0 * * *"
 
 jobs:
-  create_version:
+  version:
     name: Create a version number
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 1
+    outputs:
+      number: ${{ steps.create_version_number.outputs.new_tag }}
 
     steps:
     - uses: actions/checkout@v2
 
-    - name: Prepare version number
-      id: prepare_version_number
-      uses: anothrNick/github-tag-action@1.26.0
+    - name: Create version number
+      id: create_version_number
+      uses: anothrNick/github-tag-action@1.33.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true          
-        DRY_RUN: true
+        DRY_RUN: ${{ github.event_name == 'pull_request' }}
         DEFAULT_BUMP: patch
 
-    - name: Capture version number
-      run: 'echo ${{ steps.prepare_version_number.outputs.new_tag }} >version.txt'
+    - name: Echo version number
+      run: 'echo ${{ steps.create_version_number.outputs.new_tag }}'
 
-    - name: Upload version number
-      uses: actions/upload-artifact@v2
-      with:
-        name: version
-        path: version.txt
+    - name: Check version number is valid
+      if: ${{ steps.create_version_number.outputs.new_tag == 'v0.0.0' || steps.create_version_number.outputs.new_tag == 'v0.0.1' || steps.create_version_number.outputs.new_tag == '' }}
+      run: exit 1
 
   bootstrap:
     name: Bootstrap compiler
-    needs: [create_version]
+    needs: [version]
     runs-on: ubuntu-20.04
-    container: ghul/devcontainer:dotnet
-    timeout-minutes: 10
+
+    strategy:
+      matrix:
+        host: [mono, dotnet]
+
+    container:
+      image: ghcr.io/degory/ghul/devcontainer:${{ matrix.host }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GHCR_PAT }}
+
+    env:
+      HOST: ${{ matrix.host }}
+
+    timeout-minutes: 5
 
     steps:
     - uses: actions/checkout@v2
 
-    - name: Download version number
-      uses: actions/download-artifact@v2
-      with:
-        name: version
-        path: .
-
-    - name: Set version number variable
-      id: version
-      run: echo "::set-output name=current::`cat version.txt`"
-
-    - name: Mono version
-      run: mono --version
+    - name: CLI version
+      run: $HOST --version
 
     - name: Bootstrap compiler
       run: ./build/bootstrap.sh
       env:
-        BUILD_NAME: ${{ steps.version.outputs.current }}
+        BUILD_NAME: ${{ needs.version.outputs.number }}
+
+    - name: Build test runner
+      run: cd ghul-test && ./build/build.sh
+      env:
+        TARGET: ${{ matrix.host }}
+
+    - name: Generate installer
+      run: ./build/make-installer.sh
 
     - uses: actions/upload-artifact@v2
       with:
-        name: installer
+        name: installer-${{ matrix.host }}
         path: installer/ghul.run
 
   legacy:


### PR DESCRIPTION
Bug fixes:
- Increase workflow job timeout for bootstrap to allow for time it takes to pull the Mono development container (see #614)
- Fix issue where overnight build attempted to reference Mono from the .NET container
- Fix issue where overnight build attempted to build the installer without first building the test runner asset

Technical:
- Simplify build version number validity check
- Change overnight build to bootstrap on both Mono and .NET