### PR TITLE
Fix conditional compilation of `use`

### DIFF
--- a/src/compiler/parse_exception.ghul
+++ b/src/compiler/parse_exception.ghul
@@ -1,8 +1,12 @@
 namespace Compiler is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
 
     class PARSE_EXCEPTION: Exception is
-        init(message: String) is
+        init(message: string) is
             super.init(message);
         si
 

--- a/src/driver/analyser.ghul
+++ b/src/driver/analyser.ghul
@@ -1,4 +1,8 @@
 namespace Driver is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
      
     use IoC;
@@ -10,8 +14,8 @@ namespace Driver is
     si
 
     trait WorkItemLookup is
-        file_names: Collections.Iterable[String];
-        find_work_item(file_name: String) -> SOURCE_FILE;
+        file_names: Collections.Iterable[string];
+        find_work_item(file_name: string) -> SOURCE_FILE;
     si
 
     class ANALYSER is
@@ -20,7 +24,7 @@ namespace Driver is
         _compiler: COMPILER;
         _timers: TIMERS;
 
-        _command_map: Collections.MAP[String,CommandHandler];
+        _command_map: Collections.MAP[string,CommandHandler];
         _despatcher: COMMAND_DESPATCHER;
 
         init(
@@ -35,12 +39,12 @@ namespace Driver is
             writer: IO2.TextWriter,
             build_flags: BUILD_FLAGS
         ) is
-            _log = System.Console.error;
+            _log = STD.error;
             _compiler = compiler;
             _timers = timers;
             _symbol_table = symbol_table;
 
-            _command_map = new Collections.MAP[String,CommandHandler]();
+            _command_map = new Collections.MAP[string,CommandHandler]();
 
             let watchdog = new WATCHDOG();
 
@@ -137,12 +141,12 @@ namespace Driver is
                 want_restart = false;
 
                 if want_restart then
-                    System.Console.error.write_line("watchdog: restart due to instability...");
+                    STD.error.write_line("watchdog: restart due to instability...");
                 else
-                    System.Console.error.write_line("watchdog: recycle...");
+                    STD.error.write_line("watchdog: recycle...");
                 fi
                 
-                System.Console.error.flush();
+                STD.error.flush();
 
                 writer.write_line("RESTART");
                 writer.write("" + cast char(12));
@@ -163,7 +167,7 @@ namespace Driver is
         _watchdog: WATCHDOG;
         _reader: IO2.TextReader;
         _writer: IO2.TextWriter;
-        _command_map: Collections.MAP[String,CommandHandler];
+        _command_map: Collections.MAP[string,CommandHandler];
 
         _listening: bool;
 
@@ -180,10 +184,10 @@ namespace Driver is
             _log = log;
             _watchdog = watchdog;
 
-            _command_map = new Collections.MAP[String,CommandHandler]();
+            _command_map = new Collections.MAP[string,CommandHandler]();
         si
 
-        add_handler(command_name: String, command_handler: CommandHandler) is
+        add_handler(command_name: string, command_handler: CommandHandler) is
             assert !_command_map.contains_key(command_name) else "replacing command handler for " + command_name;
 
             _command_map[command_name] = command_handler;
@@ -240,7 +244,7 @@ namespace Driver is
             return false;
         si
 
-        read_command() -> System.String is
+        read_command() -> string is
             let desynchronized = false;
 
             do
@@ -287,7 +291,7 @@ namespace Driver is
         si
     si
 
-    class HOVER_HANDLER: Object, CommandHandler is
+    class HOVER_HANDLER: object, CommandHandler is
         _watchdog: WATCHDOG;
         _symbol_use_locations: Semantic.SYMBOL_USE_LOCATIONS;
 
@@ -321,7 +325,7 @@ namespace Driver is
                     fi
                 fi
             catch e: Exception
-                System.Console.error.write_line("HOVER: " + e.get_type() + e.message);
+                STD.error.write_line("HOVER: " + e.get_type() + e.message);
                 _watchdog.request_restart();
 
                 if !written_header then
@@ -329,14 +333,14 @@ namespace Driver is
                 fi
             yrt
 
-            System.Console.error.flush();
+            STD.error.flush();
 
             writer.write("" + cast char(12));
             writer.flush();
         si
     si
 
-    class FIND_DEFINITION_HANDLER: Object, CommandHandler is
+    class FIND_DEFINITION_HANDLER: object, CommandHandler is
         _watchdog: WATCHDOG;
         _symbol_use_locations: Semantic.SYMBOL_USE_LOCATIONS;
 
@@ -374,7 +378,7 @@ namespace Driver is
                     fi
                 fi
             catch e: Exception
-                System.Console.error.write_line("DEFINITION:" + e.get_type() + ": " + e.message);
+                STD.error.write_line("DEFINITION:" + e.get_type() + ": " + e.message);
                 _watchdog.request_restart();
 
                 if !written_header then
@@ -382,20 +386,20 @@ namespace Driver is
                 fi                
             yrt
 
-            System.Console.error.flush();
+            STD.error.flush();
 
             writer.write("" + cast char(12));
             writer.flush();
         si
     si
 
-    class FILE_EDITED_HANDLER: Object, CommandHandler, WorkItemLookup, Collections.Iterable[SOURCE_FILE] is
+    class FILE_EDITED_HANDLER: object, CommandHandler, WorkItemLookup, Collections.Iterable[SOURCE_FILE] is
         _watchdog: WATCHDOG;
         _compiler: COMPILER;
-        _work_items: Collections.MutableMap[String,SOURCE_FILE];
+        _work_items: Collections.MutableMap[string,SOURCE_FILE];
         _build_flags: BUILD_FLAGS;
 
-        file_names: Collections.Iterable[String] => _work_items.keys;
+        file_names: Collections.Iterable[string] => _work_items.keys;
 
         iterator: Collections.Iterator[SOURCE_FILE]
             => _work_items.values.iterator;
@@ -407,11 +411,11 @@ namespace Driver is
         is
             _watchdog = watchdog;
             _compiler = compiler;
-            _work_items = new Collections.MAP[String,SOURCE_FILE]();
+            _work_items = new Collections.MAP[string,SOURCE_FILE]();
             _build_flags = build_flags;
         si
 
-        find_work_item(path: String) -> SOURCE_FILE is
+        find_work_item(path: string) -> SOURCE_FILE is
             if _work_items.contains_key(path) then
                 return _work_items[path];
             fi
@@ -432,19 +436,19 @@ namespace Driver is
 
                 _compiler.post_parse([source_file]);
             catch e: Exception
-                System.Console.error.write_line("PARSE: " + e.get_type() + ": " + e.message);
+                STD.error.write_line("PARSE: " + e.get_type() + ": " + e.message);
 
                 _watchdog.request_restart();
             yrt
 
-            System.Console.error.flush();
+            STD.error.flush();
 
             writer.write("" + cast char(12));
             writer.flush();
         si
     si
 
-    class ANALYSE_HANDLER: Object, CommandHandler is
+    class ANALYSE_HANDLER: object, CommandHandler is
         _watchdog: WATCHDOG;
         _compiler: COMPILER;
         _symbol_table: Semantic.SYMBOL_TABLE;
@@ -508,7 +512,7 @@ namespace Driver is
                 _watchdog.enable();
 
             catch e: Exception
-                System.Console.error.write_line("ANALYSE:" + e.get_type() + ": " + e.message);
+                STD.error.write_line("ANALYSE:" + e.get_type() + ": " + e.message);
 
                 _watchdog.request_restart();
 
@@ -523,7 +527,7 @@ namespace Driver is
         si
     si
 
-    class COMPLETION_HANDLER: Object, CommandHandler is
+    class COMPLETION_HANDLER: object, CommandHandler is
         _watchdog: WATCHDOG;
         _completer: Syntax.Process.COMPLETER;
         _work_item_lookup: WorkItemLookup;
@@ -555,12 +559,12 @@ namespace Driver is
 
                     if results? then
                         for pair in results do
-                            writer.write_line("{0}\t{1}\t{2}", [pair.key, cast int(pair.value.completion_kind), pair.value.description]: Object);
+                            writer.write_line("{0}\t{1}\t{2}", [pair.key, cast int(pair.value.completion_kind), pair.value.description]: object);
                         od
                     fi
                 fi
             catch e: Exception
-                System.Console.error.write_line("COMPLETION:" + e.get_type() + ": " + e.message);
+                STD.error.write_line("COMPLETION:" + e.get_type() + ": " + e.message);
 
                 _watchdog.request_restart();
 
@@ -569,20 +573,20 @@ namespace Driver is
                 fi
             yrt
 
-            System.Console.error.flush();
+            STD.error.flush();
 
             writer.write("" + cast char(12));
             writer.flush();
         si
 
-        find_completions(path: String, target_line: int, target_column: int) -> Collections.Iterable[Collections.Pair[String,Semantic.Symbol.BASE]] is
+        find_completions(path: string, target_line: int, target_column: int) -> Collections.Iterable[Collections.Pair[string,Semantic.Symbol.BASE]] is
             let i = _work_item_lookup.find_work_item(path);
 
             return _completer.find_completions(i.definition, target_line, target_column);
         si
     si
 
-    class SIGNATURE_HANDLER: Object, CommandHandler is
+    class SIGNATURE_HANDLER: object, CommandHandler is
         _watchdog: WATCHDOG;
         _signature_help: Syntax.Process.SIGNATURE_HELP;
         _work_item_lookup: WorkItemLookup;
@@ -622,7 +626,7 @@ namespace Driver is
                     fi
                 fi
             catch e: Exception
-                System.Console.error.write_line("SIGNATURE:" + e.get_type() + ": " + e.message);
+                STD.error.write_line("SIGNATURE:" + e.get_type() + ": " + e.message);
 
                 _watchdog.request_restart();
 
@@ -631,13 +635,13 @@ namespace Driver is
                 fi
             yrt
 
-            System.Console.error.flush();
+            STD.error.flush();
 
             writer.write("" + cast char(12));
             writer.flush();
         si
 
-        get_function_doc_for(function: Semantic.Symbol.Function) -> String is
+        get_function_doc_for(function: Semantic.Symbol.Function) -> string is
             let result = new System.Text.StringBuilder();
 
             result
@@ -652,14 +656,14 @@ namespace Driver is
             return result.to_string();
         si
 
-        find_signatures(path: String, target_line: int, target_column: int) -> Semantic.OVERLOAD_MATCHES_RESULT is
+        find_signatures(path: string, target_line: int, target_column: int) -> Semantic.OVERLOAD_MATCHES_RESULT is
             let i = _work_item_lookup.find_work_item(path);
 
             return _signature_help.find_signatures(i.definition, target_line, target_column);
         si
     si
 
-    class SYMBOLS_HANDLER: Object, CommandHandler is
+    class SYMBOLS_HANDLER: object, CommandHandler is
         _watchdog: WATCHDOG;
         _symbol_definition_locations: Semantic.SYMBOL_DEFINITION_LOCATIONS;
         _work_item_lookup: WorkItemLookup;
@@ -696,7 +700,7 @@ namespace Driver is
                     fi
                 fi
             catch e: Exception
-                System.Console.error.write_line("SYMBOLS: " + e.get_type() + ": " + e.message);
+                STD.error.write_line("SYMBOLS: " + e.get_type() + ": " + e.message);
 
                 _watchdog.request_restart();
 
@@ -705,13 +709,13 @@ namespace Driver is
                 fi
             yrt
 
-            System.Console.error.flush();
+            STD.error.flush();
 
             writer.write("" + cast char(12));
             writer.flush();
         si
 
-        write_symbol_list_for_file(writer: IO2.TextWriter, path: String, symbols: Collections.Iterable[Semantic.Symbol.BASE]) is
+        write_symbol_list_for_file(writer: IO2.TextWriter, path: string, symbols: Collections.Iterable[Semantic.Symbol.BASE]) is
             writer.write_line(path);
 
             if symbols? then
@@ -723,7 +727,7 @@ namespace Driver is
             fi
         si
 
-        get_symbol_info_for(symbol: Semantic.Symbol.BASE) -> String is
+        get_symbol_info_for(symbol: Semantic.Symbol.BASE) -> string is
             let result = new System.Text.StringBuilder();
 
             let qualified_name = symbol.qualified_name;
@@ -749,7 +753,7 @@ namespace Driver is
         si
     si
 
-    class REFERENCES_HANDLER: Object, CommandHandler is
+    class REFERENCES_HANDLER: object, CommandHandler is
         _watchdog: WATCHDOG;
         _symbol_use_locations: Semantic.SYMBOL_USE_LOCATIONS;
 
@@ -786,14 +790,14 @@ namespace Driver is
                 fi
 
             catch e: Exception
-                System.Console.error.write_line("REFERENCES: " + e.get_type() + ": " + e.message);
+                STD.error.write_line("REFERENCES: " + e.get_type() + ": " + e.message);
 
                 if !written_header then
                     writer.write_line("REFERENCES");
                 fi
             yrt
 
-            System.Console.error.flush();
+            STD.error.flush();
 
             writer.write("" + cast char(12));
             writer.flush();
@@ -807,7 +811,7 @@ namespace Driver is
             od
         si
 
-        format_location(location: LOCATION) -> String is
+        format_location(location: LOCATION) -> string is
             let result = new System.Text.StringBuilder();
 
             result
@@ -825,7 +829,7 @@ namespace Driver is
         si
     si
 
-    class RESTART_HANDLER: Object, CommandHandler is
+    class RESTART_HANDLER: object, CommandHandler is
         init() is si
 
         handle(reader: IO2.TextReader, writer: IO2.TextWriter) is

--- a/src/driver/build_flags.ghul
+++ b/src/driver/build_flags.ghul
@@ -1,4 +1,8 @@
 namespace Driver is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
 
     class BUILD_FLAGS is

--- a/src/driver/compiler.ghul
+++ b/src/driver/compiler.ghul
@@ -1,4 +1,8 @@
 namespace Driver is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
 
     use Collections.Iterable;
@@ -17,14 +21,14 @@ namespace Driver is
 
         build_passes: Collections.MutableList[Pass];
 
-        generated_source_files: Collections.MutableList[String];
+        generated_source_files: Collections.MutableList[string];
 
         init() is
             container = IoC.CONTAINER.instance;
             logger = container.logger;       
 
             source_files = new LIST[SOURCE_FILE]();
-            generated_source_files = new LIST[String]();
+            generated_source_files = new LIST[string]();
 
             post_parse_passes = new LIST[Pass]();
             add_pass(post_parse_passes, "conditional-compilation", (source_file: SOURCE_FILE) -> void is conditional_compilation_pass(source_file); si);
@@ -60,13 +64,13 @@ namespace Driver is
             source_files.clear();
         si
 
-        add_pass(passes: Collections.MutableList[Pass], description: String, apply: SOURCE_FILE -> void) is
+        add_pass(passes: Collections.MutableList[Pass], description: string, apply: SOURCE_FILE -> void) is
             passes.add(new PASS(container.timers, description, null, apply, null));
         si
 
         add_pass(
             passes: Collections.MutableList[Pass],
-            description: String,
+            description: string,
             start: () -> void,
             apply: SOURCE_FILE -> void, 
             finish: () -> void
@@ -79,7 +83,7 @@ namespace Driver is
             passes.add(pass);
         si
 
-        parse_and_queue(path: String, reader: IO2.TextReader, build_flags: BUILD_FLAGS) is
+        parse_and_queue(path: string, reader: IO2.TextReader, build_flags: BUILD_FLAGS) is
             queue(
                 parse(path, reader, build_flags)
             );
@@ -93,7 +97,7 @@ namespace Driver is
             self.source_files.add_range(source_files);
         si
 
-        parse(path: String, reader: IO2.TextReader, build_flags: BUILD_FLAGS) -> SOURCE_FILE is
+        parse(path: string, reader: IO2.TextReader, build_flags: BUILD_FLAGS) -> SOURCE_FILE is
             let tokenizer = new Lexical.TOKENIZER(
                 logger,
                 path,
@@ -167,14 +171,14 @@ namespace Driver is
                     IoC.CONTAINER.instance.namespaces.pop_all_namespaces();                    
 
                     if i.build_flags.dump_tree then
-                        System.Console.error.write_line(i.definition);
+                        STD.error.write_line(i.definition);
                     fi
                 od
 
                 pass.finish();
 
                 @IF.not.release()
-                System.Console.error.write_line(container.timers[pass._description]);
+                STD.error.write_line(container.timers[pass._description]);
             od
         si
 

--- a/src/driver/main.ghul
+++ b/src/driver/main.ghul
@@ -1,6 +1,12 @@
 namespace Driver is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
-    use System.IO2.File;
+    use FILE = System.IO2.File;
+    use DIRECTORY = System.IO2.Directory;
+    use PATH = System.IO2.Path;
 
     use Collections.Iterable;
     use Collections.LIST;
@@ -10,40 +16,40 @@ namespace Driver is
 
     class Main is
         paths: Driver.PATH_CONFIG;
-        project_name: String;
+        project_name: string;
         container: IoC.CONTAINER;
         compiler: COMPILER;
         flags: BUILD_FLAGS;
         output_file_name_generator: OUTPUT_FILE_NAME_GENERATOR;
-        assemblies: LIST[String];
-        library_locations: LIST[String];
-        ghul_source_files: LIST[String];
+        assemblies: LIST[string];
+        library_locations: LIST[string];
+        ghul_source_files: LIST[string];
 
-        standard_ghul_library_locations: Iterable[String] => new LIST[String](["dotnet/ghul", "dotnet/stubs"]);
+        standard_ghul_library_locations: Iterable[string] => new LIST[string](["dotnet/ghul", "dotnet/stubs"]);
 
-        entry(arguments: String[]) static is
+        entry(arguments: string[]) static is
             @IL.entrypoint()
 
-            let full_arguments = new LIST[String](arguments.count + 1);
+            let full_arguments = new LIST[string](arguments.count + 1);
 
             full_arguments.add("ghul.exe");
 
             full_arguments.add_range(arguments);
 
-            let instance = new Main(new LIST[String](full_arguments));
+            let instance = new Main(new LIST[string](full_arguments));
         si
         
-        init(arguments: LIST[String]) is
+        init(arguments: LIST[string]) is
             let result = 1;
 
             try
-                System.Console.input_encoding = new System.Text.UTF8Encoding(false);
-                System.Console.output_encoding = new System.Text.UTF8Encoding(false);
+                STD.input_encoding = new System.Text.UTF8Encoding(false);
+                STD.output_encoding = new System.Text.UTF8Encoding(false);
 
                 if arguments.count <= 1 then
-                    System.Console.output.write_line("ghūl " + Source.BUILD.number);
+                    STD.output.write_line("ghūl " + Source.BUILD.number);
 
-                    System.Console.output.flush();
+                    STD.output.flush();
 
                     System.Environment.exit(0);
                 fi
@@ -77,29 +83,29 @@ namespace Driver is
 
                 result = finish_build();
             catch e: Exception
-                System.Console.error.write_line(e);
-                System.Console.error.flush();
+                STD.error.write_line(e);
+                STD.error.flush();
 
                 result = 1;
             yrt
 
             if result == 0 then
-                System.Console.error.write_line("*** succeeded ***");
+                STD.error.write_line("*** succeeded ***");
             else
-                System.Console.error.write_line("!!! failed !!!");
+                STD.error.write_line("!!! failed !!!");
             fi
             
             // FIXME: the runtime should be doing this - wrapping the L stderr + stdout IO.Writers should not prevent them getting flushed:
-            System.Console.error.flush();
-            System.Console.output.flush();
+            STD.error.flush();
+            STD.output.flush();
 
             System.Environment.exit(result);
         si
 
-        parse_flags(args: Iterable[String]) is
-            assemblies = new LIST[String]();
-            ghul_source_files = new LIST[String]();
-            library_locations = new LIST[String]();
+        parse_flags(args: Iterable[string]) is
+            assemblies = new LIST[string]();
+            ghul_source_files = new LIST[string]();
+            library_locations = new LIST[string]();
 
             let args_iterator = args.iterator;
 
@@ -113,12 +119,12 @@ namespace Driver is
             let want_type_check = false;
             let do_not_want_type_check = false;
 
-            let get_next_argument = (a: Collections.Iterator[String]) -> String is
+            let get_next_argument = (a: Collections.Iterator[string]) -> string is
                 a.move_next();
                 return a.current.trim();
             si;
 
-            let conditional_defines = new Collections.LIST[String]();
+            let conditional_defines = new Collections.LIST[string]();
 
             for s in args_iterator do
                 if s =~ "-A" || s =~ "--analyse" then
@@ -153,7 +159,7 @@ namespace Driver is
                 elif s =~ "-a" || s =~ "--assembly" then
                     assemblies.add(get_next_argument(args_iterator));
                 elif s.starts_with('-') then
-                    System.Console.error.write_line("warning: ignoring unknown option: " + s);
+                    STD.error.write_line("warning: ignoring unknown option: " + s);
                 elif SOURCE_FILE_CATEGORIZER.is_ghul(s) then
                     output_file_name_generator.seen_file(s);
                     ghul_source_files.add(s);
@@ -197,7 +203,7 @@ namespace Driver is
 
                 container.boilerplate_generator.gen(
                     "header-v2", 
-                    [IO2.Path.get_file_name_without_extension(output_file_name_generator.result)]
+                    [PATH.get_file_name_without_extension(output_file_name_generator.result)]
                 );
             fi
         si
@@ -236,7 +242,7 @@ namespace Driver is
 
             let ilasm_path = "/usr/lib/ghul/ilasm/ilasm";
 
-            if !File.exists(ilasm_path) then
+            if !FILE.exists(ilasm_path) then
                 Console.error.write_line(".NET Core ILAsm not found: falling back to /usr/bin/ilasm");
                 ilasm_path = "/usr/bin/ilasm";
             fi            
@@ -265,7 +271,7 @@ namespace Driver is
                 return result;
             fi
 
-            let runtime_config_file: String;
+            let runtime_config_file: string;
 
             if output_file.last_index_of('.') == output_file.length - 4 then
                 runtime_config_file = output_file.substring(0, output_file.last_index_of('.')) + ".runtimeconfig.json";
@@ -273,7 +279,7 @@ namespace Driver is
                 runtime_config_file = output_file + ".runtimeconfig.json";
             fi
             
-            let runtime_config = System.IO2.File.create_text(runtime_config_file);
+            let runtime_config = FILE.create_text(runtime_config_file);
             runtime_config.write("{\"runtimeOptions\":{\"tfm\":\"netcoreapp5.0\",\"framework\":{\"name\":\"Microsoft.NETCore.App\",\"version\":\"5.0.0\"}}}");
             runtime_config.close();
 
@@ -284,7 +290,7 @@ namespace Driver is
             result = chmod.exit_code;
 
             if result != 0 then
-                System.Console.error.write_line("compiled successfully but failed to set executable bit on resulting binary: " + output_file);
+                STD.error.write_line("compiled successfully but failed to set executable bit on resulting binary: " + output_file);
             fi
 
             return result;
@@ -293,10 +299,10 @@ namespace Driver is
         queue_library_locations() is
             let cuttoff = 0;
             
-            let locations_to_queue: Iterable[String];
+            let locations_to_queue: Iterable[string];
 
             if library_locations.count > 0 then
-                let explicit_locations = new LIST[String](library_locations.count);
+                let explicit_locations = new LIST[string](library_locations.count);
                 
                 for location in library_locations do
                     explicit_locations.add(get_library_location(location));
@@ -312,12 +318,12 @@ namespace Driver is
             od
         si
 
-        queue_library_location(directory: String) is
+        queue_library_location(directory: string) is
             if !directory.ends_with('/') then
                 directory = directory + '/';
             fi
 
-            let files: Iterable[String] = System.IO2.Directory.get_files(directory);
+            let files: Iterable[string] = DIRECTORY.get_files(directory);
             
             for file in files do
                 if file.ends_with(".ghul") then
@@ -334,14 +340,14 @@ namespace Driver is
             od            
         si
         
-        queue_source_file(path: String) is
-            let reader = System.IO2.File.open_text(path);
+        queue_source_file(path: string) is
+            let reader = FILE.open_text(path);
 
             compiler.parse_and_queue(path, reader, flags.copy());
         si
 
-        get_library_locations(directories: Iterable[String]) -> Iterable[String] is
-            let result = new LIST[String]();
+        get_library_locations(directories: Iterable[string]) -> Iterable[string] is
+            let result = new LIST[string]();
             
             for directory in directories do
                 result.add(get_library_location(directory));
@@ -350,7 +356,7 @@ namespace Driver is
             return result;            
         si
 
-        get_library_location(directory: System.String) -> System.String is
+        get_library_location(directory: string) -> string is
             if !directory.starts_with('/') then
                 directory = paths.library_prefix + directory;
             fi
@@ -371,12 +377,12 @@ namespace Driver is
                 container.symbol_definition_locations,
                 container.completer,
                 container.signature_help,
-                System.Console.input,
-                System.Console.output,
+                STD.input,
+                STD.output,
                 flags
             );
 
-            System.Console.error.write_line("ghūl compiler " + Source.BUILD.number + ": serving analysis requests");
+            STD.error.write_line("ghūl compiler " + Source.BUILD.number + ": serving analysis requests");
 
             analyser.run();
         si

--- a/src/driver/output_file_name_generator.ghul
+++ b/src/driver/output_file_name_generator.ghul
@@ -1,10 +1,14 @@
 namespace Driver is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
 
     class OUTPUT_FILE_NAME_GENERATOR is
-        _current: String;
+        _current: string;
 
-        result: String is
+        result: string is
             if _current? then
                 return _current;
             else
@@ -15,11 +19,11 @@ namespace Driver is
         init() is
         si
 
-        force(path: String) is
+        force(path: string) is
             _current = path;
         si
 
-        seen_file(path: String) is
+        seen_file(path: string) is
             if _current? then
                 return;
             fi

--- a/src/driver/pass.ghul
+++ b/src/driver/pass.ghul
@@ -1,4 +1,8 @@
 namespace Driver is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
 
     use Logging.TIMERS;
@@ -6,11 +10,11 @@ namespace Driver is
     
     class Pass is
         _timers: TIMERS;
-        _description: String;
+        _description: string;
 
         init(
             timers: TIMERS,
-            description: String
+            description: string
         )
         is
             self._timers = timers;
@@ -31,7 +35,7 @@ namespace Driver is
 
         get_hash_code() -> int => _description.get_hash_code();
 
-        to_string() -> String => _timers[_description].to_string();
+        to_string() -> string => _timers[_description].to_string();
     si
 
     class PASS: Pass is
@@ -41,7 +45,7 @@ namespace Driver is
 
         init(
             timers: TIMERS,
-            description: String,
+            description: string,
             start: () -> void,
             apply: SOURCE_FILE -> void,
             finish: () -> void

--- a/src/driver/path_config.ghul
+++ b/src/driver/path_config.ghul
@@ -1,8 +1,12 @@
 namespace Driver is
-    class PATH_CONFIG is
-        _library_prefix: System.String;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
 
-        library_prefix: System.String public is
+    class PATH_CONFIG is
+        _library_prefix: string;
+
+        library_prefix: string public is
             if _library_prefix? then
                 return _library_prefix;
             else

--- a/src/driver/source_file.ghul
+++ b/src/driver/source_file.ghul
@@ -1,14 +1,18 @@
 namespace Driver is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
 
     class SOURCE_FILE is
         build_flags: BUILD_FLAGS;
-        file_name: String;
+        file_name: string;
         definition: Syntax.Tree.Definition.NODE;
 
         init(
             build_flags: BUILD_FLAGS,
-            file_name: String,
+            file_name: string,
             definition: Syntax.Tree.Definition.NODE
         )
         is
@@ -17,7 +21,7 @@ namespace Driver is
             self.definition = definition;
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             file_name;
     si
 si

--- a/src/driver/source_file_categorizer.ghul
+++ b/src/driver/source_file_categorizer.ghul
@@ -1,8 +1,12 @@
 namespace Driver is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
 
     class SOURCE_FILE_CATEGORIZER is
-        is_ghul(file_name: String) -> bool static =>
+        is_ghul(file_name: string) -> bool static =>
             file_name.ends_with(".ghul");
     si
 si

--- a/src/ioc/container.ghul
+++ b/src/ioc/container.ghul
@@ -1,4 +1,6 @@
 namespace IoC is
+    use STD = System.Console;
+
     use Syntax;
     use Parser.LAZY_PARSER;
 
@@ -98,7 +100,7 @@ namespace IoC is
         signature_help: Syntax.Process.SIGNATURE_HELP;
 
         init() is
-            _logger_wrapper = new Logging.LOGGER_WRAPPER(new Logging.HUMAN_READABLE_LOGGER(System.Console.error));
+            _logger_wrapper = new Logging.LOGGER_WRAPPER(new Logging.HUMAN_READABLE_LOGGER(STD.error));
             timers = new Logging.TIMERS();
 
             path_config = new Driver.PATH_CONFIG();

--- a/src/ir/boilerplate_generator.ghul
+++ b/src/ir/boilerplate_generator.ghul
@@ -1,28 +1,32 @@
 namespace IR is
-    use System;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
+    use FILE = System.IO2.File;
     
     class BOILERPLATE_GENERATOR is
         _paths: Driver.PATH_CONFIG;
         _context: CONTEXT;
 
-        _snippets: Collections.MAP[String,String];
+        _snippets: Collections.MAP[string,string];
 
         init(context: CONTEXT, paths: Driver.PATH_CONFIG) is
             _context = context;
             _paths = paths;
 
-            _snippets = new Collections.MAP[String,String]();
+            _snippets = new Collections.MAP[string,string]();
         si
 
-        gen(name: String) is
+        gen(name: string) is
             gen(name, null);
         si
 
-        gen(name: String, args: Collections.Iterable[String]) is
-            let snippet: String;
+        gen(name: string, args: Collections.Iterable[string]) is
+            let snippet: string;
             
             if !_snippets.contains_key(name) then
-                snippet = System.IO2.File.read_all_text(_paths.library_prefix + "dotnet/il/" + name + ".il");
+                snippet = FILE.read_all_text(_paths.library_prefix + "dotnet/il/" + name + ".il");
 
                 _snippets[name] = snippet;
             else

--- a/src/ir/brancher.ghul
+++ b/src/ir/brancher.ghul
@@ -1,5 +1,9 @@
 namespace IR is
-        use System;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
+    use System;
 
     class LABEL is
         _next_id: int static;
@@ -12,7 +16,7 @@ namespace IR is
             _next_id = _next_id + 1;
         si
 
-        to_string() -> String => "L_" + id;
+        to_string() -> string => "L_" + id;
     si
 
     enum COMPARE is
@@ -51,14 +55,14 @@ namespace IR is
     class BRANCHER is
         _context: CONTEXT;
 
-        _branch_instructions: Collections.MAP[BRANCH, System.String];
-        _compare_instructions: Collections.MAP[COMPARE, System.String];
+        _branch_instructions: Collections.MAP[BRANCH, string];
+        _compare_instructions: Collections.MAP[COMPARE, string];
 
         init(context: CONTEXT) is
             _context = context;
 
-            _branch_instructions = new Collections.MAP[BRANCH, System.String]();
-            _compare_instructions = new Collections.MAP[COMPARE, System.String]();
+            _branch_instructions = new Collections.MAP[BRANCH, string]();
+            _compare_instructions = new Collections.MAP[COMPARE, string]();
 
             _branch_instructions[BRANCH.EQ] = "beq";
             _branch_instructions[BRANCH.GE] = "bge";
@@ -88,7 +92,7 @@ namespace IR is
             _compare_instructions[COMPARE.NZ] = "cfalse";
         si
         
-        label(l: LABEL, comment: System.String) is
+        label(l: LABEL, comment: string) is
             _context.write_line("" + l + ":", comment);
         si
 
@@ -100,7 +104,7 @@ namespace IR is
             _context.write_line("leave " + l);
         si
         
-        branch(b: BRANCH, value: Semantic.Graph.Value.BASE, l: LABEL, comment: System.String) is
+        branch(b: BRANCH, value: Semantic.Graph.Value.BASE, l: LABEL, comment: string) is
             Semantic.Graph.Value.BASE.gen(value, _context);
             
             _context.write_line(get_branch_instruction(b) + " " + l, comment);
@@ -112,7 +116,7 @@ namespace IR is
             _context.write_line(get_branch_instruction(b) + " " + l);
         si
 
-        branch(b: BRANCH, left: Semantic.Graph.Value.BASE, right: Semantic.Graph.Value.BASE, l: LABEL, comment: System.String) is
+        branch(b: BRANCH, left: Semantic.Graph.Value.BASE, right: Semantic.Graph.Value.BASE, l: LABEL, comment: string) is
             Semantic.Graph.Value.BASE.gen(left, _context);
             Semantic.Graph.Value.BASE.gen(right, _context);
             
@@ -126,7 +130,7 @@ namespace IR is
             _context.write_line(get_branch_instruction(b) + " " + l);
         si
 
-        branch(l: LABEL, comment: System.String) is
+        branch(l: LABEL, comment: string) is
             _context.write_line(_branch_instructions[BRANCH.ALWAYS] + " " + l, comment);
         si
 
@@ -134,7 +138,7 @@ namespace IR is
             _context.write_line(_branch_instructions[BRANCH.ALWAYS] + " " + l);
         si
 
-        get_branch_instruction(b: BRANCH) -> String is
+        get_branch_instruction(b: BRANCH) -> string is
             let instruction = _branch_instructions[b];
 
             if instruction? then

--- a/src/ir/context.ghul
+++ b/src/ir/context.ghul
@@ -1,6 +1,10 @@
 namespace IR is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
-    use System.IO2.File;
+    use FILE = System.IO2.File;
     use Collections.SORTED_LIST;
 
     use Semantic.Graph.Value.Call;
@@ -12,16 +16,16 @@ namespace IR is
             self.want_comments = want_comments;
         si
 
-        write(value: Object) is
+        write(value: object) is
             throw new NotImplementedException("assembly output must implement write_line");            
         si
         
-        write_line(value: Object) is
+        write_line(value: object) is
             write(value);
             write("\n");
         si
         
-        write_line(indent: int, value: Object) is
+        write_line(indent: int, value: object) is
             if want_comments then
                 write_indent(indent);
                 write_line(value);
@@ -30,7 +34,7 @@ namespace IR is
             fi
         si
 
-        write_line(indent: int, value: Object, comment: Object) is
+        write_line(indent: int, value: object, comment: object) is
             if want_comments then
                 write_indent(indent);
                 write_line("" + value + "        // " + comment);
@@ -39,7 +43,7 @@ namespace IR is
             fi
         si
 
-        write_comment_line(indent: int, comment: Object) is
+        write_comment_line(indent: int, comment: object) is
             if want_comments then
                 write_indent(indent);
                 write_line("// " + comment);
@@ -58,11 +62,11 @@ namespace IR is
     si
 
     class FILE_ASSEMBLER_OUTPUT: AssemblyOutput is
-        path: String;
+        path: string;
         writer: IO2.TextWriter;
 
         init(
-            path: String,
+            path: string,
             writer: IO2.TextWriter,
             want_comments: bool
         ) is
@@ -72,7 +76,7 @@ namespace IR is
             self.writer = writer;
         si
 
-        write(value: Object) is
+        write(value: object) is
             writer.write(value);
         si
 
@@ -86,7 +90,7 @@ namespace IR is
             super.init(false);
         si
 
-        write(value: Object) is
+        write(value: object) is
             // do nothing
         si
     si
@@ -100,7 +104,7 @@ namespace IR is
             buffer = new System.Text.StringBuilder();
         si
 
-        write(value: Object) is
+        write(value: object) is
             buffer.append(value);
         si
     si
@@ -109,21 +113,21 @@ namespace IR is
         _logger: Logging.Logger;
         _indent: int;
 
-        _seen: Collections.SET[String];
+        _seen: Collections.SET[string];
         _outputs: Collections.STACK[AssemblyOutput];
 
         throw_on_fixme: bool public;
 
         init(logger: Logging.Logger) is
             _logger = logger;
-            _seen = new Collections.SET[String]();
+            _seen = new Collections.SET[string]();
             _outputs = new Collections.STACK[AssemblyOutput]();
             _outputs.push(new STUB_ASSEMBLER_OUTPUT());
         si
 
         current_output: AssemblyOutput => _outputs.peek();
 
-        fixme(value: Object) is
+        fixme(value: object) is
             if throw_on_fixme then
                 throw new System.NotImplementedException("FIXME: " + value);
             else
@@ -131,19 +135,19 @@ namespace IR is
             fi            
         si
 
-        write(value: String) is
+        write(value: string) is
             current_output.write(value);
         si
             
-        write_line(value: Object) is
+        write_line(value: object) is
             current_output.write_line(_indent, value);
         si
 
-        write_line(value: Object, comment: Object) is            
+        write_line(value: object, comment: object) is            
             current_output.write_line(_indent, value, comment);
         si
 
-        write_comment_line(comment: Object) is
+        write_comment_line(comment: object) is
             current_output.write_comment_line(_indent, comment);
         si
         
@@ -169,20 +173,20 @@ namespace IR is
             _outputs.pop();
         si
 
-        enter_file(path: String, want_comments: bool) is
+        enter_file(path: string, want_comments: bool) is
             let writer: IO2.TextWriter;
 
             if _seen.contains(path) then
-                writer = File.append_text(path);
+                writer = FILE.append_text(path);
             else
-                writer = File.create_text(path);
+                writer = FILE.create_text(path);
                 _seen.add(path);
             fi
             
             _outputs.push(new FILE_ASSEMBLER_OUTPUT(path, writer, want_comments));
         si
 
-        leave_file(path: String) is
+        leave_file(path: string) is
             assert
                 _outputs.count > 0 &&
                 isa FILE_ASSEMBLER_OUTPUT(current_output) &&
@@ -198,7 +202,7 @@ namespace IR is
             _outputs.push(new BUFFER_ASSEMBLER_OUTPUT(want_comments));
         si
 
-        leave_buffer() -> String is
+        leave_buffer() -> string is
             assert
                 _outputs.count > 0 &&
                 isa BUFFER_ASSEMBLER_OUTPUT(current_output)

--- a/src/ir/innate_operation_generator.ghul
+++ b/src/ir/innate_operation_generator.ghul
@@ -1,14 +1,18 @@
 namespace IR is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
-        use Semantic.Graph.Value.Call;
+    use Semantic.Graph.Value.Call;
 
     class INNATE_OPERATION_GENERATOR is
         _logger: Logging.Logger;
         _boxer: VALUE_BOXER;
         _brancher: IR.BRANCHER;
-        _type_and_operation_handlers: Collections.MAP[String,(INNATE,CONTEXT) -> void];
-        _operation_handlers: Collections.MAP[String,(INNATE,CONTEXT) -> void];
-        _type_handlers: Collections.MAP[String,(INNATE,CONTEXT) -> void];
+        _type_and_operation_handlers: Collections.MAP[string,(INNATE,CONTEXT) -> void];
+        _operation_handlers: Collections.MAP[string,(INNATE,CONTEXT) -> void];
+        _type_handlers: Collections.MAP[string,(INNATE,CONTEXT) -> void];
 
         init(
             logger: Logging.Logger,
@@ -19,9 +23,9 @@ namespace IR is
             _boxer = boxer;
             _brancher = brancher;
 
-            _type_and_operation_handlers = new Collections.MAP[String,(INNATE,CONTEXT) -> void]();
-            _operation_handlers = new Collections.MAP[String,(INNATE,CONTEXT) -> void]();
-            _type_handlers = new Collections.MAP[String,(INNATE,CONTEXT) -> void]();
+            _type_and_operation_handlers = new Collections.MAP[string,(INNATE,CONTEXT) -> void]();
+            _operation_handlers = new Collections.MAP[string,(INNATE,CONTEXT) -> void]();
+            _type_handlers = new Collections.MAP[string,(INNATE,CONTEXT) -> void]();
 
             _type_and_operation_handlers["compare.order"] = (value: INNATE, context: CONTEXT) -> void is gen_compare_order(value, false, context); si;
             _type_and_operation_handlers["compare.uorder"] = (value: INNATE, context: CONTEXT) -> void is gen_compare_order(value, true, context); si;
@@ -74,8 +78,8 @@ namespace IR is
         si     
         
         try_handle(
-            key: String,
-            handlers: Collections.MAP[String,(INNATE,CONTEXT) -> void],
+            key: string,
+            handlers: Collections.MAP[string,(INNATE,CONTEXT) -> void],
             value: INNATE,
             context: IR.CONTEXT) -> bool is
 
@@ -142,7 +146,7 @@ namespace IR is
             let actual_operation = value.actual_operation;
 
             let needs_not = false;
-            let instruction: String = "unknown compare order: " + actual_operation;
+            let instruction: string = "unknown compare order: " + actual_operation;
 
             if actual_operation =~ ">" then
                 instruction = "cgt";

--- a/src/ir/local_id_generator.ghul
+++ b/src/ir/local_id_generator.ghul
@@ -1,4 +1,8 @@
 namespace IR is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
             
     class LOCAL_ID_GENERATOR is
@@ -14,7 +18,7 @@ namespace IR is
 
         // FIXME: could keep a set of local variable names seen in the current function and
         // only add a suffix if the name is actually not unique 
-        get_unique_il_name_for(name: String) -> String => "'" + name + "." + next_id + "'";
+        get_unique_il_name_for(name: string) -> string => "'" + name + "." + next_id + "'";
         
         init() is
             _next_id_stack = new Collections.STACK[int]();            

--- a/src/ir/temp.ghul
+++ b/src/ir/temp.ghul
@@ -1,5 +1,9 @@
 namespace IR is
-        use System;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
+    use System;
 
     class TEMP is
         _context: IR.CONTEXT;
@@ -9,7 +13,7 @@ namespace IR is
         suffix: int;
         type: Semantic.Type.BASE;
 
-        name: String is
+        name: string is
             if suffix > 0 then
                 return "'.temp." + id + "." + suffix + "'";
             else

--- a/src/ir/value_converter.ghul
+++ b/src/ir/value_converter.ghul
@@ -1,12 +1,15 @@
 namespace IR is
-    use System.String;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+    
     use Semantic;
 
     class VALUE_CONVERTER is
         _logger: Logging.Logger;
         _ghul_symbol_lookup: Semantic.GHUL_SYMBOL_LOOKUP;
 
-        _instructions: Collections.MAP[String, String];
+        _instructions: Collections.MAP[string, string];
 
         init(
             logger: Logging.Logger,
@@ -23,7 +26,7 @@ namespace IR is
                 return;
             fi
             
-            _instructions = new Collections.MAP[String, String]();
+            _instructions = new Collections.MAP[string, string]();
 
             add_instruction(_ghul_symbol_lookup.get_bool_type(), "conv.u1");
 
@@ -45,11 +48,11 @@ namespace IR is
             add_instruction(_ghul_symbol_lookup.get_double_type(), "conv.r8");
         si
 
-        add_instruction(type: Type.NAMED, instruction: String) is
+        add_instruction(type: Type.NAMED, instruction: string) is
             _instructions[type.symbol.qualified_name] = instruction;
         si        
 
-        get_instruction(type: Type.BASE) -> String is
+        get_instruction(type: Type.BASE) -> string is
             complete_initialization();
 
             if !type? || !type.symbol? then

--- a/src/lexical/token.ghul
+++ b/src/lexical/token.ghul
@@ -1,4 +1,8 @@
 namespace Lexical is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     enum TOKEN is
         FIRST,
         PLUS,

--- a/src/lexical/token_names.ghul
+++ b/src/lexical/token_names.ghul
@@ -1,13 +1,17 @@
 namespace Lexical is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     class TOKEN_NAMES  is
-        names: Collections.MAP[TOKEN,String];
+        names: Collections.MAP[TOKEN,string];
 
         _instance: TOKEN_NAMES static;
 
         init() is
-            names = new Collections.MAP[TOKEN,String]();
+            names = new Collections.MAP[TOKEN,string]();
 
             names[TOKEN.PLUS] = "+";
             names[TOKEN.AND] = "&";
@@ -119,7 +123,7 @@ namespace Lexical is
             return _instance;
         si
 
-        [token: Lexical.TOKEN]: String static is
+        [token: Lexical.TOKEN]: string static is
             let n = instance.names;
 
             if n.contains_key(token) then
@@ -129,8 +133,8 @@ namespace Lexical is
             fi
         si
 
-        [tokens: Collections.Iterable[Lexical.TOKEN]]: String static is
-            var sorted_tokens = new Collections.LIST[String]();
+        [tokens: Collections.Iterable[Lexical.TOKEN]]: string static is
+            var sorted_tokens = new Collections.LIST[string]();
 
             for t in tokens do
                 sorted_tokens.add(TOKEN_NAMES[t]);

--- a/src/lexical/tokenizer.ghul
+++ b/src/lexical/tokenizer.ghul
@@ -1,4 +1,8 @@
 namespace Lexical is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Logging;
@@ -33,20 +37,20 @@ namespace Lexical is
     si
 
     class TOKENIZER_EXCEPTION: Exception  is
-        init(s: String) is
+        init(s: string) is
             super.init(s);
         si
     si
 
     class TOKEN_MAP  is
-        map: Collections.MAP[String,TOKEN];
+        map: Collections.MAP[string,TOKEN];
 
         init() is
             super.init();
-            map = new Collections.MAP[String,TOKEN](223);
+            map = new Collections.MAP[string,TOKEN](223);
         si
 
-        [s: String]: TOKEN public
+        [s: string]: TOKEN public
             is
                 if map.contains_key(s) then
                     var t = map[s];
@@ -66,18 +70,18 @@ namespace Lexical is
     class TOKEN_PAIR  is
         token: TOKEN;
         location: LOCATION;
-        string: String;
+        value_string: string;
 
-        name: String => TOKEN_NAMES[token];
+        name: string => TOKEN_NAMES[token];
 
-        to_string() -> String => 
+        to_string() -> string => 
             "" + location + ": " + TOKEN_NAMES[token] + ": " + string;
     
-        init(token: TOKEN, location: LOCATION, string: String) is
+        init(token: TOKEN, location: LOCATION, value: string) is
             super.init();
             self.token = token;
             self.location = location;
-            self.string = string;
+            self.value_string = value;
         si
     si
 
@@ -88,13 +92,13 @@ namespace Lexical is
         _token_pair: TOKEN_PAIR;
         symbol_tokens: TOKEN_MAP static;
         operator_chars: Collections.SET[char] static;
-        operator_tokens: Collections.MAP[String,TOKEN] static;
+        operator_tokens: Collections.MAP[string,TOKEN] static;
         buffer: TOKEN_BUFFER;
         input: IO2.TextReader;
         end_of_file: bool;
         _prev_char: char;
         cursor: LOCATION_CURSOR;
-        _token_name: String[];
+        _token_name: string[];
 
         static_init() static is 
             if symbol_tokens == null then
@@ -102,7 +106,7 @@ namespace Lexical is
                     '!', '$', '%', '^', '&', '*', '-', '+', '=', '|', ':', '@', '~', '#', '\\', '<', '>', '.', '?', '/'
                 ]: char );
 
-                operator_tokens = new Collections.MAP[String,TOKEN]();
+                operator_tokens = new Collections.MAP[string,TOKEN]();
                 operator_tokens["="] = TOKEN.ASSIGN;
                 operator_tokens[":"] = TOKEN.COLON;
                 operator_tokens["."] = TOKEN.DOT;
@@ -165,7 +169,7 @@ namespace Lexical is
             fi
         si
 
-        init(logger: Logger, file_name: String, i: IO2.TextReader) is            
+        init(logger: Logger, file_name: string, i: IO2.TextReader) is            
             super.init();
 
             self.logger = logger;
@@ -220,8 +224,8 @@ namespace Lexical is
             _prev_char = c;
         si
 
-        current_string: String is
-            return _token_pair.string;
+        current_string: string is
+            return _token_pair.value_string;
         si
 
         read_escape() -> char is

--- a/src/logging/logger.ghul
+++ b/src/logging/logger.ghul
@@ -1,4 +1,8 @@
 namespace Logging is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     use Source;
  
@@ -7,12 +11,12 @@ namespace Logging is
         error_count: int;
         any_errors: bool;
 
-        exception(location: LOCATION, exception: Exception, message: String);
-        fatal(location: LOCATION, message: String);
-        error(location: LOCATION, message: String);
-        warn(location: LOCATION, message: String);
-        poison(location: LOCATION, message: String);
-        info(location: LOCATION, message: String);
+        exception(location: LOCATION, exception: Exception, message: string);
+        fatal(location: LOCATION, message: string);
+        error(location: LOCATION, message: string);
+        warn(location: LOCATION, message: string);
+        poison(location: LOCATION, message: string);
+        info(location: LOCATION, message: string);
 
         @IF.release()
         write_poison_messages();
@@ -25,7 +29,7 @@ namespace Logging is
      * depend on it, and the underlying logger can be changed 
      * as needed without updating existing references
      */     
-    class LOGGER_WRAPPER: Object, Logger is
+    class LOGGER_WRAPPER: object, Logger is
         logger: Logger public;
 
         is_poisoned: bool => logger.is_poisoned;
@@ -36,23 +40,23 @@ namespace Logging is
             self.logger = logger;
         si
 
-        exception(location: LOCATION, exception: Exception, message: String) is
+        exception(location: LOCATION, exception: Exception, message: string) is
             logger.exception(location, exception, message);
         si
         
-        fatal(location: LOCATION, message: String) is
+        fatal(location: LOCATION, message: string) is
             logger.fatal(location, message);
         si
 
-        error(location: LOCATION, message: String) is
+        error(location: LOCATION, message: string) is
             logger.error(location, message);
         si
 
-        warn(location: LOCATION, message: String) is
+        warn(location: LOCATION, message: string) is
             logger.warn(location, message);
         si
 
-        poison(location: LOCATION, message: String) is
+        poison(location: LOCATION, message: string) is
             logger.poison(location, message);
         si
 
@@ -61,7 +65,7 @@ namespace Logging is
             logger.write_poison_messages();
         si        
 
-        info(location: LOCATION, message: String) is
+        info(location: LOCATION, message: string) is
             logger.info(location, message);
         si
 
@@ -72,7 +76,7 @@ namespace Logging is
 
     class LoggerBase is
         @IF.release()
-        _poison_messages: Collections.LIST[String];
+        _poison_messages: Collections.LIST[string];
 
         is_poisoned: bool;
         error_count: int;
@@ -84,23 +88,23 @@ namespace Logging is
             self.writer = writer;
         si
 
-        write(location: LOCATION, severity: String, message: String) is
+        write(location: LOCATION, severity: string, message: string) is
             throw new NotImplementedException("abstract: implement me");
         si
 
-        check_internal(location: LOCATION, message: String) -> bool is
+        check_internal(location: LOCATION, message: string) -> bool is
             throw new NotImplementedException("abstract: implement me");
         si
 
-        exception(location: LOCATION, exception: Exception, message: String) is
+        exception(location: LOCATION, exception: Exception, message: string) is
             throw new NotImplementedException("abstract: implement me");
         si
 
-        fatal(location: LOCATION, message: String) is
+        fatal(location: LOCATION, message: string) is
             write(location, "error", message);
         si
 
-        error(location: LOCATION, message: String) is
+        error(location: LOCATION, message: string) is
             error_count = error_count + 1;
             if error_count >= 5000 then
                 throw new Exception("too many errors");
@@ -113,11 +117,11 @@ namespace Logging is
             write(location, "error", message);
         si
 
-        warn(location: LOCATION, message: String) is
+        warn(location: LOCATION, message: string) is
             write(location, "warn", message);
         si
 
-        poison(location: LOCATION, message: String) is
+        poison(location: LOCATION, message: string) is
             is_poisoned = true;
 
             @IF.not.release()
@@ -128,13 +132,13 @@ namespace Logging is
         si
 
         @IF.release()
-        buffer_poison_message(location: LOCATION, message: String) is
+        buffer_poison_message(location: LOCATION, message: string) is
             if !_poison_messages? then
-                _poison_messages = new Collections.LIST[String]();
+                _poison_messages = new Collections.LIST[string]();
             fi
 
             _poison_messages.add(
-                String.format(
+                string.format(
                     "{0}: {1},{2}..{3},{4}: {5}: {6}\n",
                     [
                         location.file_name, 
@@ -158,7 +162,7 @@ namespace Logging is
             fi
         si
 
-        info(location: LOCATION, message: String) is
+        info(location: LOCATION, message: string) is
             write(location, "info", message);
         si
         
@@ -173,31 +177,31 @@ namespace Logging is
             super.init(writer);
         si
 
-        exception(location: LOCATION, exception: Exception, message: String) is
+        exception(location: LOCATION, exception: Exception, message: string) is
             if !location? then
                 location = LOCATION.dummy;
             fi
             
-            System.Console.error.write_line(exception);
+            STD.error.write_line(exception);
 
             fatal(location, message);
         si
 
-        fatal(location: LOCATION, message: String) is
+        fatal(location: LOCATION, message: string) is
             super.fatal(location, message);
 
             // FIXME: #562 terminate on fatal exceptions
             throw new Exception("fatal error");
         si
 
-        check_internal(location: LOCATION, message: String) -> bool is
+        check_internal(location: LOCATION, message: string) -> bool is
             if location.is_internal then
                 fatal(location, "error in internal symbol: " + message);
                 return true;
             fi
         si
 
-        write(location: LOCATION, severity: String, message: String) is
+        write(location: LOCATION, severity: string, message: string) is
             writer.write(
                 "{0}: {1},{2}..{3},{4}: {5}: {6}\n",
                 [
@@ -218,23 +222,23 @@ namespace Logging is
             super.init(writer);
         si
 
-        check_internal(location: LOCATION, message: String) -> bool is
+        check_internal(location: LOCATION, message: string) -> bool is
             if location.is_internal then
                 @IF.not.release()                
-                System.Console.error.write_line("ignore error for internal symbol: " + location + ": " + message);
+                STD.error.write_line("ignore error for internal symbol: " + location + ": " + message);
                 return true;
             fi
 
             return false;
         si
 
-        exception(location: LOCATION, exception: Exception, message: String) is
+        exception(location: LOCATION, exception: Exception, message: string) is
             @IF.not.release()            
-            System.Console.error.write_line("exception: " + location + ": " + exception.get_type() + ": " + exception.message);
+            STD.error.write_line("exception: " + location + ": " + exception.get_type() + ": " + exception.message);
         si
 
-        write(location: LOCATION, severity: String, message: String) is
-            let s = String.format(
+        write(location: LOCATION, severity: string, message: string) is
+            let s = string.format(
                 "{0}\t{1}\t{2}\t{3}\t{4}\t{5}\t{6}",
                 [
                     location.file_name, 
@@ -248,7 +252,7 @@ namespace Logging is
             ).replace('\n', ' ') + '\n';
 
             if s.contains("{6}") then
-                System.Console.error.write_line("garbled error: " + s);
+                STD.error.write_line("garbled error: " + s);
                 return;    
             fi            
 

--- a/src/logging/timers.ghul
+++ b/src/logging/timers.ghul
@@ -1,11 +1,14 @@
 namespace Logging is
-    use System.String;
-    use System.Text.StringBuilder;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
+        use System.Text.StringBuilder;
 
     use Collections.MAP;
 
     class TIMER is
-        _name: String;
+        _name: string;
         _execute_count: int;
         _execute_time: System.TimeSpan;
 
@@ -13,7 +16,7 @@ namespace Logging is
 
         average_milliseconds: double => _execute_time.divide(cast double(_execute_count)).total_milliseconds;
 
-        init(name: String) is
+        init(name: string) is
             _name = name;
             _execute_time = new System.TimeSpan(0L); 
         si
@@ -27,10 +30,10 @@ namespace Logging is
             _execute_time = _execute_time.add(System.DateTime.now.subtract(_started_at));
         si
 
-        to_string() -> String is
+        to_string() -> string is
             if _execute_count > 0 then
                 return 
-                String.format(
+                string.format(
                     "{0} count: {1} total time: {2} average time: {3} ms",
                     [
                         _name, 
@@ -39,7 +42,7 @@ namespace Logging is
                         average_milliseconds
                     ]
                 );
-            // String.format(
+            // string.format(
                 //     "{0}\t{1}\t{2}\t{3}",
                 //     [
                 //         _name, 
@@ -56,13 +59,13 @@ namespace Logging is
     si
 
     class TIMERS is
-        _timers: MAP[String,TIMER];
+        _timers: MAP[string,TIMER];
 
         init() is
-            _timers = new MAP[String,TIMER]();
+            _timers = new MAP[string,TIMER]();
         si
 
-        [name: String]: TIMER is
+        [name: string]: TIMER is
             if !_timers.contains_key(name) then
                 _timers[name] = new TIMER(name);
             fi
@@ -70,15 +73,15 @@ namespace Logging is
             return _timers[name];                
         si
         
-        start(name: String) is
+        start(name: string) is
             self[name].start();
         si
         
-        finish(name: String) is
+        finish(name: string) is
             self[name].finish();            
         si
 
-        to_string() -> String is
+        to_string() -> string is
             let result = new StringBuilder();
 
             for t in _timers.values do

--- a/src/logging/tracer.ghul
+++ b/src/logging/tracer.ghul
@@ -1,20 +1,22 @@
 namespace Logging is
-    use System.Object;
-    use System.String;
-    use System.Console;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
+            use System.Console;
 
     class DEBUG is
         is_enabled: bool public;
 
-        write(message: String) static is
+        write(message: string) static is
             // Console.write(message);
         si
 
-        write_line(message: String) static is
+        write_line(message: string) static is
             // Console.error.write_line(message);            
         si
         
-        write_line(value: Object) static is
+        write_line(value: object) static is
             // Console.error.write_line(value);            
         si
     si

--- a/src/semantic/dotnet/assemblies.ghul
+++ b/src/semantic/dotnet/assemblies.ghul
@@ -1,6 +1,11 @@
 namespace Semantic.DotNet is
-    use System.Type2;
-    use System.String;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
+    use TYPE = System.Type2;
+    use PATH = System.IO2.Path;
+
     use System.Console;
 
     use System.Reflection.Assembly;
@@ -21,9 +26,9 @@ namespace Semantic.DotNet is
 
         _is_started: bool;
 
-        assemblies_by_name: MAP[String,Assembly];
-        assemblies_by_dotnet_namespace: MAP[String,SET[Assembly]];
-        assemblies_by_ghul_namespace: MAP[String,SET[Assembly]];
+        assemblies_by_name: MAP[string,Assembly];
+        assemblies_by_dotnet_namespace: MAP[string,SET[Assembly]];
+        assemblies_by_ghul_namespace: MAP[string,SET[Assembly]];
 
         init(
             timers: TIMERS,
@@ -38,9 +43,9 @@ namespace Semantic.DotNet is
 
             _is_enabled = true;
 
-            assemblies_by_name = new MAP[String,Assembly]();
-            assemblies_by_dotnet_namespace = new MAP[String,SET[Assembly]]();
-            assemblies_by_ghul_namespace = new MAP[String,SET[Assembly]]();
+            assemblies_by_name = new MAP[string,Assembly]();
+            assemblies_by_dotnet_namespace = new MAP[string,SET[Assembly]]();
+            assemblies_by_ghul_namespace = new MAP[string,SET[Assembly]]();
         si
 
         disable() is
@@ -55,7 +60,7 @@ namespace Semantic.DotNet is
             let default_imports = ["System.Console", "System.Runtime", "System.IO.FileSystem", "System.Collections"];
 
             for a in default_imports do
-                import(System.IO2.Path.combine("/usr/share/dotnet/shared/Microsoft.NETCore.App/5.0.0/", a + ".dll"));                
+                import(PATH.combine("/usr/share/dotnet/shared/Microsoft.NETCore.App/5.0.0/", a + ".dll"));                
             od
 
             Console.error.write_line(_timers);
@@ -75,9 +80,9 @@ namespace Semantic.DotNet is
         si
 
         create_namespaces() is
-            let current = new LIST[String]();
+            let current = new LIST[string]();
 
-            let namespaces = new LIST[String]();
+            let namespaces = new LIST[string]();
 
             // for ns in assemblies_by_ghul_namespace do
             //     Console.error.write_line("namespace: " + ns.key + " assemblies: " + new Shim.JOIN[Assembly](ns.value));
@@ -90,9 +95,9 @@ namespace Semantic.DotNet is
             namespaces.sort();
 
             for a in namespaces do
-                let to_create = new LIST[String](a.split(['.']));
+                let to_create = new LIST[string](a.split(['.']));
 
-                // Console.error.write_line("initially in " + new Shim.JOIN[String](current, "/"));
+                // Console.error.write_line("initially in " + new Shim.JOIN[string](current, "/"));
 
                 while current.count > to_create.count do
                     // Console.error.write_line("drop excess " + current[current.count - 1]);
@@ -101,7 +106,7 @@ namespace Semantic.DotNet is
                     current.remove_at(current.count - 1);
                 od
 
-                // Console.error.write_line("dropped excess down to " + new Shim.JOIN[String](current, "/"));
+                // Console.error.write_line("dropped excess down to " + new Shim.JOIN[string](current, "/"));
 
                 let index = 0;
 
@@ -116,7 +121,7 @@ namespace Semantic.DotNet is
                     current.remove_at(current.count - 1);
                 od
 
-                // Console.error.write_line("dropped non matching down to " + new Shim.JOIN[String](current, "/"));
+                // Console.error.write_line("dropped non matching down to " + new Shim.JOIN[string](current, "/"));
 
                 for i in index..to_create.count do
                     let ns = _namespaces.declare_and_enter_namespace(Source.LOCATION.dummy, to_create[i], null);
@@ -134,13 +139,13 @@ namespace Semantic.DotNet is
             od            
         si        
 
-        import(assembly_names: Iterable[String]) is
+        import(assembly_names: Iterable[string]) is
             for assembly_name in assembly_names do
                 import(assembly_name);
             od            
         si
 
-        import(path: String) is
+        import(path: string) is
             _timers.start("import assembly");
 
             try
@@ -164,8 +169,8 @@ namespace Semantic.DotNet is
             yrt            
         si
 
-        import(name: String, assembly: Assembly) is
-            let distinct_namespaces = new SET[String]();
+        import(name: string, assembly: Assembly) is
+            let distinct_namespaces = new SET[string]();
 
             try
                 for type in assembly.get_exported_types() do
@@ -202,7 +207,7 @@ namespace Semantic.DotNet is
             od
         si
         
-        find(assembly_name: String, namespace_name: String, type_name: String) -> Type2 is
+        find(assembly_name: string, namespace_name: string, type_name: string) -> TYPE is
             let assembly: Assembly;            
         
             if !assemblies_by_name.try_get_value(assembly_name, assembly ref) then
@@ -222,7 +227,7 @@ namespace Semantic.DotNet is
             fi                
         si
         
-        find(namespace_name: String, name: String) -> Type2 is
+        find(namespace_name: string, name: string) -> TYPE is
             let set: SET[Assembly];
 
             // Console.error.write_line("search for type: " + name + " in namespace: " + namespace_name);
@@ -231,7 +236,7 @@ namespace Semantic.DotNet is
                 // Console.error.write_line("namespace " + namespace_name +  " not found in any assembly");
                 // Console.error.write_line("searched from " + new System.Diagnostics.StackTrace());
 
-                // Console.write_line("not found in: " + new Shim.JOIN[Collections.Pair[System.String,SET[Assembly]]](assemblies_containing_namespace));
+                // Console.write_line("not found in: " + new Shim.JOIN[Collections.Pair[string,SET[Assembly]]](assemblies_containing_namespace));
 
                 return null;
             fi

--- a/src/semantic/dotnet/innate_types.ghul
+++ b/src/semantic/dotnet/innate_types.ghul
@@ -1,5 +1,5 @@
 namespace Semantic.DotNet is
-    use System.Type2;
+    use TYPE = System.Type2;
 
     // FIXME: should not be required
     class INNATE_TYPES is
@@ -11,7 +11,7 @@ namespace Semantic.DotNet is
             _type_mapper = type_mapper;
         si
                 
-        get_dotnet_void_type() -> Type2 is
+        get_dotnet_void_type() -> TYPE is
             return typeof void;
         si
 

--- a/src/semantic/dotnet/namespace_details.ghul
+++ b/src/semantic/dotnet/namespace_details.ghul
@@ -1,12 +1,14 @@
 namespace Semantic.DotNet is
-    use System.String;
-    
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+        
     class NAMESPACE_DETAILS is
-        ghul_name: String;
-        dotnet_name: String;
-        assembly_name: String;
+        ghul_name: string;
+        dotnet_name: string;
+        assembly_name: string;
 
-        init(ghul_name: String, dotnet_name: String, assembly_name: String) is
+        init(ghul_name: string, dotnet_name: string, assembly_name: string) is
             assert ghul_name? else "ghul_name is null";
 
             self.ghul_name = ghul_name;
@@ -14,6 +16,6 @@ namespace Semantic.DotNet is
             self.assembly_name = assembly_name;
         si
 
-        to_string() -> String => "namespace: (ghul name: " + ghul_name + " dotnet_name: " + dotnet_name + " assembly_name: " + assembly_name + ")";
+        to_string() -> string => "namespace: (ghul name: " + ghul_name + " dotnet_name: " + dotnet_name + " assembly_name: " + assembly_name + ")";
     si
 si

--- a/src/semantic/dotnet/symbol_cache.ghul
+++ b/src/semantic/dotnet/symbol_cache.ghul
@@ -1,21 +1,24 @@
 namespace Semantic.DotNet is
-    use System.String;
-    use System.Type2;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
+    use TYPE = System.Type2;
     
     use Collections.MAP;
 
     // FIXME: rename this - it's not a cache - it's essential that symbols are interned for
     // correct functioning of the type system:
     class SYMBOL_CACHE is
-        symbols_by_dotnet_type: MAP[Type2,Symbol.Scoped];
-        symbols_by_ghul_name: MAP[String,Symbol.Scoped];
+        symbols_by_dotnet_type: MAP[TYPE,Symbol.Scoped];
+        symbols_by_ghul_name: MAP[string,Symbol.Scoped];
 
         init() is
-            symbols_by_dotnet_type = new MAP[Type2,Symbol.Scoped]();
-            symbols_by_ghul_name = new MAP[String,Symbol.Scoped]();
+            symbols_by_dotnet_type = new MAP[TYPE,Symbol.Scoped]();
+            symbols_by_ghul_name = new MAP[string,Symbol.Scoped]();
         si
 
-        get_symbol(dotnet_type: Type2) -> Symbol.Scoped is
+        get_symbol(dotnet_type: TYPE) -> Symbol.Scoped is
             let result: Symbol.Scoped;
 
             symbols_by_dotnet_type.try_get_value(dotnet_type, result ref);
@@ -23,7 +26,7 @@ namespace Semantic.DotNet is
             return result;
         si
 
-        get_symbol(ghul_name: String) -> Symbol.Scoped is
+        get_symbol(ghul_name: string) -> Symbol.Scoped is
             let result: Symbol.Scoped;
 
             symbols_by_ghul_name.try_get_value(ghul_name, result ref);
@@ -31,7 +34,7 @@ namespace Semantic.DotNet is
             return result;
         si
 
-        add_symbol(type: Type2, ghul_name: String, symbol: Symbol.Scoped) is
+        add_symbol(type: TYPE, ghul_name: string, symbol: Symbol.Scoped) is
             assert type? else "type is null";
             assert ghul_name? else "ghull name is null";
             assert symbol? else "symbol is null";

--- a/src/semantic/dotnet/symbol_factory.ghul
+++ b/src/semantic/dotnet/symbol_factory.ghul
@@ -1,6 +1,9 @@
 namespace Semantic.DotNet is
-    use System.String;
-    use System.Type2;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
+    use TYPE = System.Type2;
     use System.Console;
 
     use System.Reflection;
@@ -15,7 +18,7 @@ namespace Semantic.DotNet is
         _innate_types: INNATE_TYPES;
         _type_name_map: TYPE_NAME_MAP;
         _type_mapper: TYPE_MAPPER;
-        _assembly_names: MAP[Assembly,String];
+        _assembly_names: MAP[Assembly,string];
 
         _non_generic_get_enumerator: MethodInfo;
 
@@ -29,26 +32,26 @@ namespace Semantic.DotNet is
             _innate_types = innate_types;
             _type_name_map = type_name_map;
             _type_mapper = type_mapper;
-            _assembly_names = new MAP[Assembly,String]();
+            _assembly_names = new MAP[Assembly,string]();
 
             let mnt = typeof Collections.MoveNext;
             _non_generic_get_enumerator = mnt.get_method("GetEnumerator");
         si
 
-        create_symbol(type: Type2, ghul_name: String, il_name: String) -> Symbol.Scoped is            
+        create_symbol(type: TYPE, ghul_name: string, il_name: string) -> Symbol.Scoped is            
             if type.is_class || type.is_value_type || type.is_interface || type.is_enum then
                 return create_class(type, ghul_name, il_name);
             fi
         si
 
-        create_class(type: Type2, ghul_name: String, il_name: String) -> Symbol.Scoped is
+        create_class(type: TYPE, ghul_name: string, il_name: string) -> Symbol.Scoped is
             let ghul_type_name = new TYPE_NAME(ghul_name);
             // let namespace_name = new TYPE_NAME(ghul_type_name.namespace_name);
 
             let owner = new EMPTY_SCOPE(ghul_type_name.namespace_name);
             //  _namespaces.find_or_add_namespace(namespace_name.name, "." + namespace_name.qualified_name);
 
-            let arguments = new LIST[String]();
+            let arguments = new LIST[string]();
 
             let result: Symbol.Classy;
 
@@ -82,7 +85,7 @@ namespace Semantic.DotNet is
             return result;
         si
 
-        create_enum(type: Type2, ghul_name: TYPE_NAME) -> Symbol.ENUM_ is
+        create_enum(type: TYPE, ghul_name: TYPE_NAME) -> Symbol.ENUM_ is
             let namespace_name = new TYPE_NAME(ghul_name.namespace_name);
 
             // Console.error.write_line("get class: " + namespace_name + " " + ghul_name.name + " (" + ghul_name.qualified_name + ")");
@@ -97,7 +100,7 @@ namespace Semantic.DotNet is
             result.il_name_override = "class ['" + assembly_name + "']" + type.full_name;
         si 
 
-        add_ancestors(symbol: Symbol.Scoped, type: Type2) is            
+        add_ancestors(symbol: Symbol.Scoped, type: TYPE) is            
             if !isa Symbol.Classy(symbol) then
                 Console.error.write_line("not a classy: " + type);
                 return;
@@ -110,7 +113,7 @@ namespace Semantic.DotNet is
                 result.add_ancestor(_type_mapper.get_type(type.base_type));
             // elif type.is_interface then
             //     // FIXME: need typeof really or another way to get types by name:
-            //     result.add_ancestor(_type_mapper.get_type(new System.Object().get_type()));
+            //     result.add_ancestor(_type_mapper.get_type(new object().get_type()));
             fi
 
             for i in type.get_interfaces() do
@@ -125,7 +128,7 @@ namespace Semantic.DotNet is
             od                
         si
         
-        add_members(result: Symbol.Scoped, type: Type2) is
+        add_members(result: Symbol.Scoped, type: TYPE) is
             let properties = new LIST[Symbol.Property]();
 
             let arguments = result.argument_names;
@@ -149,7 +152,7 @@ namespace Semantic.DotNet is
             od
         si
 
-        add_members(result: Symbol.ENUM_, type: Type2) is
+        add_members(result: Symbol.ENUM_, type: TYPE) is
             // FIXME:
             let assembly_name = get_assembly_name(type);
 
@@ -189,7 +192,7 @@ namespace Semantic.DotNet is
             fi            
         si
 
-        fixup_property(owner: Symbol.Scoped, type: Type2, property: Symbol.Property) is
+        fixup_property(owner: Symbol.Scoped, type: TYPE, property: Symbol.Property) is
             if property.is_assignable then
                 let assign_accessor = owner.find_direct("__assign_" + property.name);
 
@@ -243,7 +246,7 @@ namespace Semantic.DotNet is
 
             result.il_name_override = method.name;
 
-            let argument_names = new LIST[String]();
+            let argument_names = new LIST[string]();
             let argument_types = new LIST[Type.BASE]();
 
             for a in method.get_parameters() do
@@ -344,7 +347,7 @@ namespace Semantic.DotNet is
             let result: Symbol.Function;
             let location = Source.LOCATION.dummy;
 
-            let name: String;
+            let name: string;
 
             if method.is_special_name then
                 if method.name =~ "get_Item" || method.name =~ "set_Item" then
@@ -389,7 +392,7 @@ namespace Semantic.DotNet is
 
             result.il_name_override = method.name;
             
-            let argument_names = new LIST[String]();
+            let argument_names = new LIST[string]();
             let argument_types = new LIST[Type.BASE]();
 
             for a in method.get_parameters() do
@@ -405,10 +408,10 @@ namespace Semantic.DotNet is
             owner.add_member(result);
         si
 
-        get_assembly_name(type: Type2) -> String is
+        get_assembly_name(type: TYPE) -> string is
             let assembly = type.assembly;
 
-            let result: String;
+            let result: string;
 
             if _assembly_names.try_get_value(assembly, result ref) then
                 return result;

--- a/src/semantic/dotnet/symbol_table.ghul
+++ b/src/semantic/dotnet/symbol_table.ghul
@@ -1,6 +1,9 @@
 namespace Semantic.DotNet is
-    use System.String;
-    use System.Type2;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
+    use TYPE = System.Type2;
 
     use System.Console;
 
@@ -26,7 +29,7 @@ namespace Semantic.DotNet is
             _symbol_cache = new SYMBOL_CACHE();
         si
 
-        get_symbol(ghul_name: String) -> Symbol.Scoped is
+        get_symbol(ghul_name: string) -> Symbol.Scoped is
             if !_assemblies._is_enabled then
                 return null;
             fi
@@ -44,9 +47,9 @@ namespace Semantic.DotNet is
 
             let type_details = _type_name_map.get_type_details(ghul_name);
 
-            let type: Type2;
-            let assembly_name: String;
-            let namespace_name: String;
+            let type: TYPE;
+            let assembly_name: string;
+            let namespace_name: string;
             
             if type_details? then
                 // Console.error.write_line("create symbol from type details: " + type_details);
@@ -80,7 +83,7 @@ namespace Semantic.DotNet is
             fi
         si
         
-        get_symbol(type: Type2) -> Symbol.Scoped is
+        get_symbol(type: TYPE) -> Symbol.Scoped is
             if !_assemblies._is_enabled then
                 return null;
             fi
@@ -98,7 +101,7 @@ namespace Semantic.DotNet is
 
             let type_details = _type_name_map.get_type_details(type);
 
-            let ghul_name: String;
+            let ghul_name: string;
 
             if type_details? then
                 ghul_name = type_details.ghul_name;
@@ -119,7 +122,7 @@ namespace Semantic.DotNet is
             return create_symbol(type, ghul_name, null);
         si
 
-        create_symbol(type: Type2, ghul_name: String, il_name: String) -> Symbol.Scoped is
+        create_symbol(type: TYPE, ghul_name: string, il_name: string) -> Symbol.Scoped is
             Console.error.write_line("create symbol for " + type + " with ghul name " + ghul_name);
 
             let result = _symbol_factory.create_symbol(type, ghul_name, il_name);

--- a/src/semantic/dotnet/type_details.ghul
+++ b/src/semantic/dotnet/type_details.ghul
@@ -1,14 +1,17 @@
 namespace Semantic.DotNet is
-    use System.String;
-    use System.Type2;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
+    use TYPE = System.Type2;
     
     class TYPE_DETAILS is
-        dotnet_type: Type2;
-        ghul_name: String;
-        assembly_name: String;
-        il_name: String;
+        dotnet_type: TYPE;
+        ghul_name: string;
+        assembly_name: string;
+        il_name: string;
 
-        init(dotnet_type: Type2, ghul_name: String, il_name: String, assembly_name: String) is
+        init(dotnet_type: TYPE, ghul_name: string, il_name: string, assembly_name: string) is
             assert dotnet_type? else "dotnet_type is null";
             assert ghul_name? else "ghul_name is null";
 
@@ -18,6 +21,6 @@ namespace Semantic.DotNet is
             self.assembly_name = assembly_name;
         si
 
-        to_string() -> String => "type: (.NET type: " + dotnet_type + " ghul name: " + ghul_name + " il_name: " + il_name + " assembly_name: " + assembly_name + ")";
+        to_string() -> string => "type: (.NET type: " + dotnet_type + " ghul name: " + ghul_name + " il_name: " + il_name + " assembly_name: " + assembly_name + ")";
     si
 si

--- a/src/semantic/dotnet/type_mapper.ghul
+++ b/src/semantic/dotnet/type_mapper.ghul
@@ -1,6 +1,9 @@
 namespace Semantic.DotNet is
-    use System.String;
-    use System.Type2;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
+    use TYPE = System.Type2;
     use System.Console;
 
     use System.Reflection;
@@ -15,7 +18,7 @@ namespace Semantic.DotNet is
         // we don't need to intern types for correctness, but expecting to encounter a lot of references
         // to identical types, so interning them will result in lower memory usage and fewer calls into the 
         // symbol table/symbol cache to materialize the associated ghul symbols
-        _type_cache: MAP[Type2,Type.BASE];
+        _type_cache: MAP[TYPE,Type.BASE];
 
         init(
             symbol_table: System.LAZY[SYMBOL_TABLE],
@@ -24,10 +27,10 @@ namespace Semantic.DotNet is
             _symbol_table = symbol_table;
             _type_name_map = type_name_map;
 
-            _type_cache = new MAP[Type2,Type.BASE]();
+            _type_cache = new MAP[TYPE,Type.BASE]();
         si
 
-        get_type(type: Type2) -> Type.BASE is
+        get_type(type: TYPE) -> Type.BASE is
             let result: Type.BASE;
 
             if _type_cache.try_get_value(type, result ref) then

--- a/src/semantic/dotnet/type_name.ghul
+++ b/src/semantic/dotnet/type_name.ghul
@@ -1,10 +1,12 @@
 namespace Semantic.DotNet is
-    use System.String;
-
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+    
     struct TYPE_NAME is
-        qualified_name: String;
+        qualified_name: string;
 
-        namespace_name: String is
+        namespace_name: string is
             let last_dot_index = qualified_name.last_index_of('.');
 
             if last_dot_index >= 0 then
@@ -12,7 +14,7 @@ namespace Semantic.DotNet is
             fi
         si
 
-        name: String is
+        name: string is
             let last_dot_index = qualified_name.last_index_of('.');
 
             if last_dot_index >= 0 then
@@ -22,14 +24,14 @@ namespace Semantic.DotNet is
             return qualified_name;
         si
 
-        init(qualified_name: String) is
+        init(qualified_name: string) is
             self.qualified_name = qualified_name;
         si
 
-        init(namespace_name: String, name: String) is
+        init(namespace_name: string, name: string) is
             self.qualified_name = namespace_name + "." + name;
         si
 
-        to_string() -> String => qualified_name;        
+        to_string() -> string => qualified_name;        
     si
 si

--- a/src/semantic/dotnet/type_name_map.ghul
+++ b/src/semantic/dotnet/type_name_map.ghul
@@ -1,8 +1,10 @@
 namespace Semantic.DotNet is
-    use System.Object;
-    use System.String;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System.Reflection;
-    use System.Type2;
+    use TYPE = System.Type2;
     use System.Text.StringBuilder;
 
     use System.Console;
@@ -15,22 +17,22 @@ namespace Semantic.DotNet is
     use Collections.MAP;
 
     class TYPE_NAME_MAP is
-        type_details_by_dotnet_type: MutableMap[Type2,TYPE_DETAILS];
-        type_details_by_ghul_name: MutableMap[String,TYPE_DETAILS];
+        type_details_by_dotnet_type: MutableMap[TYPE,TYPE_DETAILS];
+        type_details_by_ghul_name: MutableMap[string,TYPE_DETAILS];
 
-        namespace_details_by_dotnet_namespace: MutableMap[String,NAMESPACE_DETAILS];
-        namespace_details_by_ghul_name: MutableMap[String,NAMESPACE_DETAILS];
+        namespace_details_by_dotnet_namespace: MutableMap[string,NAMESPACE_DETAILS];
+        namespace_details_by_ghul_name: MutableMap[string,NAMESPACE_DETAILS];
 
-        assembly_name_overrides: MutableMap[String,String];
+        assembly_name_overrides: MutableMap[string,string];
 
         init() is
-            type_details_by_dotnet_type = new MAP[Type2,TYPE_DETAILS]();
-            type_details_by_ghul_name = new MAP[String,TYPE_DETAILS]();
+            type_details_by_dotnet_type = new MAP[TYPE,TYPE_DETAILS]();
+            type_details_by_ghul_name = new MAP[string,TYPE_DETAILS]();
 
-            namespace_details_by_dotnet_namespace = new MAP[String,NAMESPACE_DETAILS]();
-            namespace_details_by_ghul_name = new MAP[String,NAMESPACE_DETAILS]();
+            namespace_details_by_dotnet_namespace = new MAP[string,NAMESPACE_DETAILS]();
+            namespace_details_by_ghul_name = new MAP[string,NAMESPACE_DETAILS]();
 
-            assembly_name_overrides = new MAP[String,String]();
+            assembly_name_overrides = new MAP[string,string]();
 
             // Mappings: ghul name -> .NET type / IL name
     
@@ -59,8 +61,8 @@ namespace Semantic.DotNet is
             map_type(typeof single, "Ghul.single", "single", null);
             map_type(typeof double, "Ghul.double", "double", null);
 
-            map_type(typeof System.Object, "System.Object", null, null);
-            map_type(typeof System.String, "System.String", null, null);
+            map_type(typeof object, "object", null, null);
+            map_type(typeof string, "string", null, null);
             map_type(typeof System.Type2, "System.Type2", null, null);
 
             map_type(typeof Collections.NonGenericIterable, "Collections.NonGenericIterable", null, null);
@@ -82,59 +84,59 @@ namespace Semantic.DotNet is
             map_type(typeof Collections.STACK, "Collections.STACK", null, null);
         si
 
-        map_type(dotnet_type: Type2, ghul_name: String, il_name: String, assembly_name: String) is
+        map_type(dotnet_type: TYPE, ghul_name: string, il_name: string, assembly_name: string) is
             let type_details = new TYPE_DETAILS(dotnet_type, ghul_name, il_name, assembly_name);
 
             type_details_by_dotnet_type.add(dotnet_type, type_details);
             type_details_by_ghul_name.add(ghul_name, type_details);
         si
 
-        map_namespace_to_assembly(ghul_namespace: String, dotnet_assembly: String) is
+        map_namespace_to_assembly(ghul_namespace: string, dotnet_assembly: string) is
             let namespace_details = new NAMESPACE_DETAILS(ghul_namespace, null, dotnet_assembly);
 
             namespace_details_by_ghul_name.add(ghul_namespace, namespace_details);
         si
 
-        map_namespace(ghul_namespace_name: String, dotnet_namespace_name: String, dotnet_assembly: String) is
+        map_namespace(ghul_namespace_name: string, dotnet_namespace_name: string, dotnet_assembly: string) is
             let namespace_details = new NAMESPACE_DETAILS(ghul_namespace_name, dotnet_namespace_name, dotnet_assembly);
 
             namespace_details_by_dotnet_namespace.add(dotnet_namespace_name, namespace_details);
             namespace_details_by_ghul_name.add(ghul_namespace_name, namespace_details);
         si
 
-        map_assembly(apparent_assembly_name: String, actual_assembly_name: String) is
+        map_assembly(apparent_assembly_name: string, actual_assembly_name: string) is
             assembly_name_overrides[apparent_assembly_name] = actual_assembly_name;
         si        
 
-        get_type_details(type: Type2) -> TYPE_DETAILS is
+        get_type_details(type: TYPE) -> TYPE_DETAILS is
             let result: TYPE_DETAILS;
             type_details_by_dotnet_type.try_get_value(type, result ref);
 
             return result;
         si
 
-        get_type_details(ghul_qualified_name: String) -> TYPE_DETAILS is
+        get_type_details(ghul_qualified_name: string) -> TYPE_DETAILS is
             let result: TYPE_DETAILS;
             type_details_by_ghul_name.try_get_value(ghul_qualified_name, result ref);
 
             return result;
         si
 
-        get_namespace_details(type: Type2) -> NAMESPACE_DETAILS is
+        get_namespace_details(type: TYPE) -> NAMESPACE_DETAILS is
             let result: NAMESPACE_DETAILS;
             namespace_details_by_dotnet_namespace.try_get_value(type.namespace_, result ref);
 
             return result;
         si
 
-        get_namespace_details(ghul_namespace_name: String) -> NAMESPACE_DETAILS is
+        get_namespace_details(ghul_namespace_name: string) -> NAMESPACE_DETAILS is
             let result: NAMESPACE_DETAILS;
             namespace_details_by_ghul_name.try_get_value(ghul_namespace_name, result ref);
 
             return result;
         si
 
-        get_ghul_namespace(dotnet_type: Type2) -> String is
+        get_ghul_namespace(dotnet_type: TYPE) -> string is
             let type_details = get_type_details(dotnet_type);
 
             if type_details? then
@@ -150,7 +152,7 @@ namespace Semantic.DotNet is
             return dotnet_type.namespace_;
         si
         
-        get_assembly_name(type: Type2) -> String is
+        get_assembly_name(type: TYPE) -> string is
             let type_details = get_type_details(type);
 
             if type_details? then
@@ -166,10 +168,10 @@ namespace Semantic.DotNet is
             return type.assembly.get_name().name;
         si
 
-        get_il_name(type: Type2) -> String is
+        get_il_name(type: TYPE) -> string is
             let type_details = get_type_details(type);
 
-            let assembly_name: String;
+            let assembly_name: string;
 
             if type_details? then
                 if type_details.il_name? then
@@ -190,7 +192,7 @@ namespace Semantic.DotNet is
                     assembly_name = type.assembly.get_name().name;
                 fi
                 
-                let an: String;
+                let an: string;
 
                 if assembly_name_overrides.try_get_value(assembly_name, an ref) then
                     assembly_name = an;
@@ -214,12 +216,12 @@ namespace Semantic.DotNet is
             return buffer.to_string();
         si
         
-        // add_il_name(type: Type2, il_name: String) is
+        // add_il_name(type: TYPE, il_name: string) is
         //     dotnet_type_to_il_name_map.add(type, il_name);
         // si
 
-        get_member_name(owner_ghul_name: String, member_dotnet_name: String) -> String is
-            let result: String;
+        get_member_name(owner_ghul_name: string, member_dotnet_name: string) -> string is
+            let result: string;
 
             // if !dotnet_to_ghul_member_name_map.try_get_value(new TYPE_NAME(owner_ghul_name, member_dotnet_name).qualified_name, result ref) then
 
@@ -230,7 +232,7 @@ namespace Semantic.DotNet is
             return result;
         si
 
-        de_camel(name: String) -> String is
+        de_camel(name: string) -> string is
             let buffer = new StringBuilder();
             let seenAnyLowerCase = false;
 
@@ -263,12 +265,12 @@ namespace Semantic.DotNet is
         si
 
         get_type_name(
-            name_map: MutableMap[String,String],
-            namespace_name_map: Map[String,String], 
-            qualified_name: String
-        ) -> String
+            name_map: MutableMap[string,string],
+            namespace_name_map: Map[string,string], 
+            qualified_name: string
+        ) -> string
         is
-            let result: String;
+            let result: string;
             
             // First look for an exact mapping for the qualified name
             if name_map.try_get_value(qualified_name, result ref) then
@@ -295,15 +297,15 @@ namespace Semantic.DotNet is
         si
 
         /*
-        get_ghul_type_name(type: Type2) -> String =>
+        get_ghul_type_name(type: TYPE) -> string =>
             get_ghul_type_name(type.full_name);
         
-        get_dotnet_type_name(qualified_name: String) -> String =>
+        get_dotnet_type_name(qualified_name: string) -> string =>
 
 
             get_type_name(ghul_to_dotnet_type_name_map, qualified_name);
 
-        get_ghul_type_name(qualified_name: String) -> String is
+        get_ghul_type_name(qualified_name: string) -> string is
             
         si
         */

--- a/src/semantic/dotnet/type_wrapper.ghul
+++ b/src/semantic/dotnet/type_wrapper.ghul
@@ -1,6 +1,9 @@
 namespace Semantic.DotNet is
-    use System.String;
-    use System.Type2;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
+    use TYPE = System.Type2;
     use System.Console;
 
     class TYPE_WRAPPER: Type.NAMED is
@@ -9,7 +12,7 @@ namespace Semantic.DotNet is
         _accessed: int static;
 
         _symbol_table: SYMBOL_TABLE;
-        _dotnet_type: Type2;
+        _dotnet_type: TYPE;
 
         _symbol: Symbol.Scoped;
 
@@ -29,7 +32,7 @@ namespace Semantic.DotNet is
 
         init(
             symbol_table: SYMBOL_TABLE,
-            dotnet_type: Type2
+            dotnet_type: TYPE
         ) is
             super.init(null);
 
@@ -43,7 +46,7 @@ namespace Semantic.DotNet is
     class GENERIC_TYPE_WRAPPER: Type.GENERIC is
         _symbol_table: SYMBOL_TABLE;
         _type_mapper: TYPE_MAPPER;
-        _dotnet_type: Type2;
+        _dotnet_type: TYPE;
 
         _symbol: Symbol.GENERIC;
 
@@ -68,7 +71,7 @@ namespace Semantic.DotNet is
         init(
             symbol_table: SYMBOL_TABLE,
             type_mapper: TYPE_MAPPER,
-            dotnet_type: Type2
+            dotnet_type: TYPE
         ) is
             assert symbol_table? else "symbol table is null";
             assert type_mapper? else "type mapper is null";
@@ -79,7 +82,7 @@ namespace Semantic.DotNet is
             self._dotnet_type = dotnet_type;
         si
 
-        to_string() -> String is
+        to_string() -> string is
             if !_symbol? then
                 return "(non materialized generic type wrapping " + _dotnet_type.to_string() + ")";
             fi

--- a/src/semantic/function_caller.ghul
+++ b/src/semantic/function_caller.ghul
@@ -1,4 +1,8 @@
 namespace Semantic is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Logging;

--- a/src/semantic/graph/action/action.ghul
+++ b/src/semantic/graph/action/action.ghul
@@ -7,6 +7,10 @@ namespace Semantic.Graph.Action is
     si
 
     namespace Store is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
         class BASE is
             right: Value.BASE;
 

--- a/src/semantic/graph/value/value.ghul
+++ b/src/semantic/graph/value/value.ghul
@@ -1,8 +1,11 @@
 namespace Semantic.Graph.Value is
-    use System;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
 
+    use System;
     
-    class BASE: Object, Semantic.Type.Typed is
+    class BASE: object, Semantic.Type.Typed is
         has_type: bool => false;
         is_value_type: bool => has_type && type.is_value_type;
         is_self: bool => false;
@@ -68,7 +71,7 @@ namespace Semantic.Graph.Value is
             context.write_line("newobj instance " + constructor.il_type_name, type);
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             "new:[" + type + "](\"" + constructor.name + "\"," + new Shim.JOIN[BASE](arguments) + ")";
     si
 
@@ -94,7 +97,7 @@ namespace Semantic.Graph.Value is
             gen(value, context);
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             "type_wrapper:[" + type + "](" + value + ")";        
     si
 
@@ -105,9 +108,9 @@ namespace Semantic.Graph.Value is
         type: Type.BASE;
         value: BASE;
 
-        name: String;
+        name: string;
 
-        next_name: String static is
+        next_name: string static is
             let result = "'.address." + _next_id + "'";
 
             _next_id = _next_id + 1;
@@ -147,7 +150,7 @@ namespace Semantic.Graph.Value is
             fi
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             "type_wrapper:[" + type + "](" + value + ")";        
     si
 
@@ -178,7 +181,7 @@ namespace Semantic.Graph.Value is
             context.write_line("box " + type.il_type_name);
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             "box:[" + type + "](" + value + ")";        
     si
 
@@ -204,7 +207,7 @@ namespace Semantic.Graph.Value is
             context.write_line("unbox.any " + type.il_type_name);
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             "unbox:[" + type + "](" + value + ")";        
     si
 
@@ -212,12 +215,12 @@ namespace Semantic.Graph.Value is
         has_type: bool => type?;
         type: Type.BASE;
         value: BASE;
-        instruction: String;
+        instruction: string;
 
         init(
             type: Type.BASE,
             value: BASE,
-            instruction: String
+            instruction: string
         ) is
             super.init();
 
@@ -237,7 +240,7 @@ namespace Semantic.Graph.Value is
             context.write_line(instruction, "convert to " + type);
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             "cast:[" + type + "](" + value + ")";
     si
 
@@ -267,7 +270,7 @@ namespace Semantic.Graph.Value is
             context.write_line("castclass " + type.il_type_name);
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             "cast:[" + type + "](" + value + ")";
     si
 
@@ -301,7 +304,7 @@ namespace Semantic.Graph.Value is
             context.write_line("cgt.un");
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             "isa:[" + isa_type + "](" + value + ")";
     si
 
@@ -328,7 +331,7 @@ namespace Semantic.Graph.Value is
             context.write_line("call class [mscorlib]System.Type class [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)");
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             "typeof:[" + type + "](" + typeof_type + ")";
     si
 
@@ -358,7 +361,7 @@ namespace Semantic.Graph.Value is
             context.write_line("cgt.un");
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             "has-value:[" + type + "](" + value + ")";
     si
 
@@ -384,7 +387,7 @@ namespace Semantic.Graph.Value is
             context.write_line("ceq");
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             "not:[" + type + "](" + value + ")";
     si
 
@@ -406,7 +409,7 @@ namespace Semantic.Graph.Value is
             context.write_line("ldnull");
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             "null:[" + type + "]()";
     si
 
@@ -433,7 +436,7 @@ namespace Semantic.Graph.Value is
             context.fixme("dummy " + type + " from " + location);
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             "isa:[" + type + "]()";
     si
 
@@ -483,7 +486,7 @@ namespace Semantic.Graph.Value is
             context.write_line(call, "tuple " + type);
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             "tuple:[" + type + "](" + values + ")";
     si
 
@@ -529,11 +532,15 @@ namespace Semantic.Graph.Value is
             
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             "sequence:[" + type + "](" + values + ")";
     si
 
     namespace Need is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
         class STORE: BASE is
             has_type: bool => value? && value.has_type;
             type: Type.BASE => value.type;
@@ -552,12 +559,16 @@ namespace Semantic.Graph.Value is
                 context.write_line("unresolved need store");
             si
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "need-store:[" + type + "]";
         si
     si
 
     namespace Expect is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
         class STORABLE: BASE is
             has_type: bool => type?;
             type: Type.BASE;
@@ -574,12 +585,16 @@ namespace Semantic.Graph.Value is
                 context.write_line("unresolved expect");
             si
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "expect-storable:[" + type + "]";
         si
     si
 
     namespace Load is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
         class SELF: BASE, Type.Typed is
             self_: Symbol.BASE;
             has_type: bool => type?;
@@ -613,7 +628,7 @@ namespace Semantic.Graph.Value is
                 context.write_line("ldarg.0", "self " + type);
             si
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "self:[" + type + "]";
         si
 
@@ -628,19 +643,19 @@ namespace Semantic.Graph.Value is
                 super.init(self_, type);
             si
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "super:[" + type + "]";
         si
 
         class TEMP: BASE, Type.Typed is
-            name: String;
+            name: string;
 
             type: Type.BASE;
             has_type: bool => type?;
 
             has_address: bool => true;
 
-            init(name: String, type: Type.BASE) is
+            init(name: string, type: Type.BASE) is
                 self.name = name;
                 self.type = type;
             si
@@ -653,7 +668,7 @@ namespace Semantic.Graph.Value is
                 context.write_line("ldloca " + name, "temp " + type);
             si
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "load:[" + type + "](" + name + "\")";
         si
 
@@ -684,7 +699,7 @@ namespace Semantic.Graph.Value is
                 context.fixme("load member address " + symbol.il_qualified_name);
             si
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "load:[" + type + "](" + from + ",\"" + symbol.name + "\")";
         si
 
@@ -701,7 +716,7 @@ namespace Semantic.Graph.Value is
                 context.write_line("ldloca " + symbol.il_name, symbol);
             si
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "load:[" + type + "](" + from + ",\"" + symbol.name + "\")";
         si
 
@@ -718,7 +733,7 @@ namespace Semantic.Graph.Value is
                 context.write_line("ldarga " + symbol.il_name, symbol);
             si
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "load:[" + type + "](" + from + ",\"" + symbol.name + "\")";
         si
 
@@ -739,7 +754,7 @@ namespace Semantic.Graph.Value is
                 context.write_line("ldflda " + symbol.il_type_name, symbol);
             si
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "load:[" + type + "](" + from + ",\"" + symbol.name + "\")";
         si
 
@@ -756,7 +771,7 @@ namespace Semantic.Graph.Value is
                 context.write_line("ldsflda " + symbol.il_type_name, symbol);
             si
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "load:[" + type + "](\"" + symbol.name + "\")";
         si
 
@@ -779,7 +794,7 @@ namespace Semantic.Graph.Value is
                 context.write_line("newobj instance void " + func_type.il_type_name + "::'.ctor'(object, native int)");
             si
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "load:[" + type + "](" + from + ",\"" + symbol.name + "\")";
         si
 
@@ -802,7 +817,7 @@ namespace Semantic.Graph.Value is
                 context.write_line("newobj instance void " + func_type.il_type_name + "::'.ctor'(object, native int)");
             si
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "load:[" + type + "](" + from + ",\"" + symbol.name + "\")";
         si
 
@@ -817,12 +832,16 @@ namespace Semantic.Graph.Value is
                 context.fixme("captured value");
             si
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "load:[" + type + "](" + from + ",\"" + symbol.name + "\")";
         si
     si
 
     namespace Store is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
         class SYMBOL: BASE, Type.Typed is
             symbol: Symbol.BASE;
             symbol_as_typed: Type.Typed => cast Type.Typed(symbol);
@@ -848,7 +867,7 @@ namespace Semantic.Graph.Value is
                 context.write_line("store member " + symbol);
             si            
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "store:[" + type + "](" + from + ",\"" + symbol.name + "\"," + value + ")";
         si
 
@@ -863,7 +882,7 @@ namespace Semantic.Graph.Value is
                 context.write_line("stloc " + symbol.il_name, symbol);
             si            
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "store:[" + type + "](" + from + ",\"" + symbol.name + "\"," + value + ")";
         si
 
@@ -878,7 +897,7 @@ namespace Semantic.Graph.Value is
                 context.write_line("starg " + symbol.il_name, symbol);
             si
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "load:[" + type + "](" + from + ",\"" + symbol.name + "\")";
         si
 
@@ -896,7 +915,7 @@ namespace Semantic.Graph.Value is
                 context.write_line("stfld " + symbol.il_type_name, symbol);
             si            
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "store:[" + type + "](" + from + ",\"" + symbol.name + "\"," + value + ")";
         si
 
@@ -911,12 +930,16 @@ namespace Semantic.Graph.Value is
                 context.write_line("stsfld " + symbol.il_type_name, symbol);
             si            
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "store:[" + type + "](\"" + symbol.name + "\"," + value + ")";
         si
     si
 
     namespace Call is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
         class INNATE: BASE, Type.Typed is
             function: Semantic.Symbol.InnateFunction;
             from: BASE;
@@ -924,11 +947,11 @@ namespace Semantic.Graph.Value is
             type: Type.BASE;
             has_type: bool => type?;
 
-            actual_operation: String public;
+            actual_operation: string public;
             
-            innate_name: String => function.innate_name;
-            type_name: String => innate_name.substring(0, innate_name.index_of('.'));
-            op_name: String => innate_name.substring(innate_name.index_of('.') + 1);    
+            innate_name: string => function.innate_name;
+            type_name: string => innate_name.substring(0, innate_name.index_of('.'));
+            op_name: string => innate_name.substring(innate_name.index_of('.') + 1);    
 
             init(
                 function: Semantic.Symbol.InnateFunction,
@@ -954,7 +977,7 @@ namespace Semantic.Graph.Value is
                 IoC.CONTAINER.instance.innate_operation_generator.gen(self, context);
             si
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "innate-call:[" + type + "](\"" + function.name + "\"," + from + "," + arguments + ")";
         si
 
@@ -987,7 +1010,7 @@ namespace Semantic.Graph.Value is
                 context.write_line("call " + function.il_type_name);                
             si
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "global-call:[" + type + "](\"" + function.name + "\"," + arguments + ")";
         si
 
@@ -1029,7 +1052,7 @@ namespace Semantic.Graph.Value is
                 fi
             si
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "instance-call:[" + type + "](" + from + ",\"" + function.name + "\"," +  arguments + ")";
         si
 
@@ -1066,7 +1089,7 @@ namespace Semantic.Graph.Value is
                 context.write_line("call instance " + function.il_type_name);
             si
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "struct-call:[" + type + "](" + from + ",\"" + function.name + "\"," +  arguments + ")";
         si
 
@@ -1099,7 +1122,7 @@ namespace Semantic.Graph.Value is
                 context.write_line("call " + function.il_type_name);
             si
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "static-call:[" + type + "](\"" + function.name + "\"," +  arguments + ")";
         si
 
@@ -1176,67 +1199,67 @@ namespace Semantic.Graph.Value is
                 context.write_line(call.to_string());
             si
             
-            to_string() -> String =>
+            to_string() -> string =>
                 "closure-call:[" + type + "](" + from + "," + arguments + ")";
         si
     si
 
     namespace Literal is
         class NUMBER: BASE, Type.Typed is
-            string: String;
+            value: string;
             type: Type.BASE;
-            suffix: String;
-            conv: String;
+            suffix: string;
+            conv: string;
             has_type: bool => type?;
 
-            init(string: String, type: Type.BASE, suffix: String, conv: String) is
+            init(value: string, type: Type.BASE, suffix: string, conv: string) is
                 super.init();
 
-                assert string?;
+                assert value?;
                 assert type?;
                 assert suffix?;
 
-                self.string = string;
+                self.value = value;
                 self.type = type;
                 self.suffix = suffix;
                 self.conv = conv;
             si
 
-            init(string: String, type: Type.BASE, suffix: String) is
-                self.init(string, type, suffix, null);
+            init(value: string, type: Type.BASE, suffix: string) is
+                self.init(value, type, suffix, null);
             si
 
             gen(context: IR.CONTEXT) is
-                context.write_line("ldc." + suffix + " " + string);
+                context.write_line("ldc." + suffix + " " + value);
 
                 if conv? then
                     context.write_line(conv);                    
                 fi
             si
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "literal:[" + type + "](" + string + ")";
         si
 
         class STRING: BASE, Type.Typed is
-            string: String;
+            value: string;
             type: Type.BASE;
             has_type: bool => type?;
 
-            init(string: String, type: Type.BASE) is
+            init(value: string, type: Type.BASE) is
                 super.init();
 
-                assert string?;
+                assert value?;
                 assert type?;
 
-                self.string = string;
+                self.value = value;
                 self.type = type;
             si
 
             gen(context: IR.CONTEXT) is
-                let result = new System.Text.StringBuilder(string.length * 8);
+                let result = new System.Text.StringBuilder(value.length * 8);
 
-                for c in string do
+                for c in value do
                     let uc = cast uint(c); 
 
                     let high = uc / cast uint(256);
@@ -1252,7 +1275,7 @@ namespace Semantic.Graph.Value is
                 context.write_line("ldstr bytearray (" + result + ")");
             si
 
-            to_string() -> String =>
+            to_string() -> string =>
                 "literal:[" + type + "](\"" + string + "\")";
         si
     si

--- a/src/semantic/innate_symbol_lookup.ghul
+++ b/src/semantic/innate_symbol_lookup.ghul
@@ -1,17 +1,21 @@
 namespace Semantic is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     class InnateSymbolLookup is
         _logger: Logging.Logger;
         _symbol_table: SYMBOL_TABLE;
-        _namespace_name: String;
+        _namespace_name: string;
 
         namespace_scope: Scope => _symbol_table.global_scope.find_direct(_namespace_name);
 
         init(
             logger: Logging.Logger,
             symbol_table: SYMBOL_TABLE,
-            namespace_name: String
+            namespace_name: string
         ) is
             _logger = logger;
             _symbol_table = symbol_table;
@@ -19,7 +23,7 @@ namespace Semantic is
         si
 
         get_type(
-            name: String,
+            name: string,
             create: (
                 Source.LOCATION,
                 Semantic.Symbol.Classy
@@ -38,7 +42,7 @@ namespace Semantic is
         si
 
         get_type(
-            name: String,
+            name: string,
             type: Type.BASE,
             create: (
                 Source.LOCATION,
@@ -49,7 +53,7 @@ namespace Semantic is
             => get_type(name, new Collections.LIST[Type.BASE]([type]), -1, create);
 
         get_type(
-            name: String,
+            name: string,
             types: Collections.LIST[Type.BASE],
             create: (
                 Source.LOCATION,
@@ -60,7 +64,7 @@ namespace Semantic is
             => get_type(name, types, 0, create);
 
         get_type(
-            name: String,
+            name: string,
             types: Collections.LIST[Type.BASE],
             exclude_count: int,
             create: (
@@ -93,13 +97,13 @@ namespace Semantic is
             fi
         si
 
-        get_type(name: String) -> Semantic.Type.NAMED 
+        get_type(name: string) -> Semantic.Type.NAMED 
             => new Semantic.Type.NAMED(get_class(name));
 
-        get_class(name: String) -> Semantic.Symbol.Classy
+        get_class(name: string) -> Semantic.Symbol.Classy
             => cast Semantic.Symbol.Classy(get_symbol(name));
 
-        get_symbol(name: String) -> Semantic.Symbol.BASE is
+        get_symbol(name: string) -> Semantic.Symbol.BASE is
             assert
                 namespace_scope?
             else

--- a/src/semantic/namespaces.ghul
+++ b/src/semantic/namespaces.ghul
@@ -1,4 +1,8 @@
 namespace Semantic is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Logging;
@@ -14,11 +18,11 @@ namespace Semantic is
     class NAMESPACES  is
         _logger: Logger;
         _symbol_table: SYMBOL_TABLE;
-        _namespaces: Collections.MAP[String,Symbol.NAMESPACE];
-        _prefixes: Collections.STACK[String];
-        current_prefix: String => _prefixes.peek();
+        _namespaces: Collections.MAP[string,Symbol.NAMESPACE];
+        _prefixes: Collections.STACK[string];
+        current_prefix: string => _prefixes.peek();
 
-        get_qualified_name(name: String) -> String is
+        get_qualified_name(name: string) -> string is
             return current_prefix + '.' + name;
         si
 
@@ -30,13 +34,13 @@ namespace Semantic is
         si
 
         dump_counts() is
-            System.Console.error.write_line("namespaces: " + _namespaces.count);
-            System.Console.error.write_line("prefixes: " + _prefixes.count);
+            STD.error.write_line("namespaces: " + _namespaces.count);
+            STD.error.write_line("prefixes: " + _prefixes.count);
         si        
 
         clear() is
-            _namespaces = new Collections.MAP[String,Symbol.NAMESPACE](65521);
-            _prefixes = new Collections.STACK[String]();
+            _namespaces = new Collections.MAP[string,Symbol.NAMESPACE](65521);
+            _prefixes = new Collections.STACK[string]();
 
             _prefixes.push("");
         si
@@ -55,17 +59,17 @@ namespace Semantic is
         
         declare_and_enter_namespace(
             location: LOCATION, 
-            name: String, 
+            name: string, 
             symbol_definition_listener: Semantic.SymbolDefinitionListener
         ) -> Symbol.NAMESPACE
         is
             var qualified_name = get_qualified_name(name);
 
-            // System.Console.error.write_line("NNN: declare and enter namespace '" + name + "' ('" + qualified_name + "') from '" + current_prefix + "'");
+            // STD.error.write_line("NNN: declare and enter namespace '" + name + "' ('" + qualified_name + "') from '" + current_prefix + "'");
 
             var ns = find_or_add_namespace(name, qualified_name);
 
-            // System.Console.error.write_line("NNN: namespace: " + ns + " hash: " + ns.get_hash_code());
+            // STD.error.write_line("NNN: namespace: " + ns + " hash: " + ns.get_hash_code());
 
             var existing = _symbol_table.current_scope.find_direct(name);
 
@@ -73,16 +77,16 @@ namespace Semantic is
                 assert name?;
                 assert ns?;
 
-                // System.Console.error.write_line("NNN: declare in current scope: " + _symbol_table.current_namespace_context);
+                // STD.error.write_line("NNN: declare in current scope: " + _symbol_table.current_namespace_context);
 
                 _symbol_table.current_namespace_context.declare_namespace(location, name, ns, symbol_definition_listener);
             else
-                // System.Console.error.write_line("NNN: symbol already exists in current scope: " + _symbol_table.current_namespace_context);
+                // STD.error.write_line("NNN: symbol already exists in current scope: " + _symbol_table.current_namespace_context);
 
                 if existing != ns then
 
-                    System.Console.error.write_line("existing symbol is: " + existing + " hash: " + existing.get_hash_code());
-                    System.Console.error.write_line("namespace is: " + ns + " hash: " + ns.get_hash_code());
+                    STD.error.write_line("existing symbol is: " + existing + " hash: " + existing.get_hash_code());
+                    STD.error.write_line("namespace is: " + ns + " hash: " + ns.get_hash_code());
 
                     _logger.error(location, "redefining symbol " + name + " as a namespace, originally defined at " + existing.location);
                     _logger.error(existing.location, "symbol " + name + " is redefined as namespace at " + location);
@@ -91,7 +95,7 @@ namespace Semantic is
 
             _prefixes.push(qualified_name);                
 
-            // System.Console.error.write_line("NNN: now in namespace: '" + current_prefix + "'");
+            // STD.error.write_line("NNN: now in namespace: '" + current_prefix + "'");
 
             return ns;
         si
@@ -104,7 +108,7 @@ namespace Semantic is
             od            
         si
 
-        enter_namespace(location: LOCATION, name: String) -> Symbol.NAMESPACE is
+        enter_namespace(location: LOCATION, name: string) -> Symbol.NAMESPACE is
             var qualified_name = get_qualified_name(name);
             var ns = find_namespace(qualified_name);
 
@@ -112,22 +116,22 @@ namespace Semantic is
 
             _prefixes.push(qualified_name);
 
-            // System.Console.error.write_line("NNN: enter namespace: " + ns + " now in: '" + current_prefix + "'");
+            // STD.error.write_line("NNN: enter namespace: " + ns + " now in: '" + current_prefix + "'");
 
             return ns;
         si
 
-        leave_namespace(location: LOCATION, name: String) is
+        leave_namespace(location: LOCATION, name: string) is
             var ns = find_namespace(current_prefix);
 
             assert ns? else "could not find aggregate namespace";
             
             _prefixes.pop();
 
-            // System.Console.error.write_line("NNN: leave namespace: " + ns + " now in: '" + current_prefix + "'");
+            // STD.error.write_line("NNN: leave namespace: " + ns + " now in: '" + current_prefix + "'");
         si
 
-        find_or_add_namespace(name: String, qualified_name: String) -> Symbol.NAMESPACE is
+        find_or_add_namespace(name: string, qualified_name: string) -> Symbol.NAMESPACE is
             assert name? else "namespace name is null";
             assert qualified_name? else "namespace qualified name is null";
 
@@ -141,7 +145,7 @@ namespace Semantic is
             fi
         si
 
-        find_namespace(qualified_name: String) -> Symbol.NAMESPACE is
+        find_namespace(qualified_name: string) -> Symbol.NAMESPACE is
             assert _namespaces.contains_key(qualified_name) else "aggregate namespace " + qualified_name + " should already exist";
 
             return _namespaces[qualified_name];

--- a/src/semantic/overload_resolver.ghul
+++ b/src/semantic/overload_resolver.ghul
@@ -1,4 +1,8 @@
 namespace Semantic is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Logging;

--- a/src/semantic/scope/block_scope.ghul
+++ b/src/semantic/scope/block_scope.ghul
@@ -1,16 +1,20 @@
 namespace Semantic is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use IoC;
     use Logging;
     use Source;
 
-    class BLOCK_SCOPE: Object, Scope, DeclarationContext  is
+    class BLOCK_SCOPE: object, Scope, DeclarationContext  is
         _enclosing: Scope;
         _symbols: Semantic.SYMBOL_MAP;
 
-        name: String => "[block]";
-        qualified_name: String => _enclosing.qualified_name + ".[block]";
+        name: string => "[block]";
+        qualified_name: string => _enclosing.qualified_name + ".[block]";
 
         symbols: Collections.Iterable[Symbol.BASE] => _symbols.values;
 
@@ -29,24 +33,24 @@ namespace Semantic is
             _symbols = new Semantic.SYMBOL_MAP();
         si
 
-        qualify(name: String) -> String => _enclosing.qualify(name);
+        qualify(name: string) -> string => _enclosing.qualify(name);
 
-        find_direct(name: String) -> Symbol.BASE =>
+        find_direct(name: string) -> Symbol.BASE =>
             _symbols[name];
 
-        find_direct_matches(prefix: String, matches: Collections.MAP[System.String,Semantic.Symbol.BASE]) is
+        find_direct_matches(prefix: string, matches: Collections.MAP[string,Semantic.Symbol.BASE]) is
             _symbols.find_matches(prefix, matches);
         si            
 
-        find_member(name: String) -> Symbol.BASE is
+        find_member(name: string) -> Symbol.BASE is
             throw new NotImplementedException("cannot search for member " + name + " in block scope");
         si
 
-        find_member_matches(prefix: String, matches: Collections.MAP[System.String,Semantic.Symbol.BASE]) is
+        find_member_matches(prefix: string, matches: Collections.MAP[string,Semantic.Symbol.BASE]) is
             throw new NotImplementedException("cannot search for member matches " + prefix + " in block scope");
         si        
 
-        find_enclosing(name: String) -> Symbol.BASE is
+        find_enclosing(name: string) -> Symbol.BASE is
             var result = find_direct(name);
 
             if result? then
@@ -58,63 +62,63 @@ namespace Semantic is
             fi
         si
 
-        find_enclosing_matches(prefix: String, matches: Collections.MAP[System.String,Semantic.Symbol.BASE]) is
+        find_enclosing_matches(prefix: string, matches: Collections.MAP[string,Semantic.Symbol.BASE]) is
             find_direct_matches(prefix, matches);
 
             _enclosing.find_enclosing_matches(prefix, matches);
         si
 
-        declare_undefined(location: LOCATION, kind: String, name: String) -> Scope is
+        declare_undefined(location: LOCATION, kind: string, name: string) -> Scope is
             CONTAINER.instance.logger.error(location, "cannot declare " + kind + " here");
 
             return new Symbol.UNDEFINED(location, self, name);
         si
 
-        declare_class(location: LOCATION, name: String, arguments: Collections.LIST[String], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_class(location: LOCATION, name: string, arguments: Collections.LIST[string], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "class", name);
 
-        declare_trait(location: LOCATION, name: String, arguments: Collections.LIST[String], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_trait(location: LOCATION, name: string, arguments: Collections.LIST[string], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "trait", name);
 
-        declare_struct(location: LOCATION, name: String, arguments: Collections.LIST[String], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_struct(location: LOCATION, name: string, arguments: Collections.LIST[string], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "struct", name);    
 
-        declare_type(location: LOCATION, name: String, index: int, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_type(location: LOCATION, name: string, index: int, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "type", name);
 
-        declare_enum(location: LOCATION, name: String, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_enum(location: LOCATION, name: string, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "enum", name);
 
-        declare_enum_member(location: LOCATION, name: String, value: String, symbol_definition_listener: SymbolDefinitionListener) is
+        declare_enum_member(location: LOCATION, name: string, value: string, symbol_definition_listener: SymbolDefinitionListener) is
             declare_undefined(location, "enum member", name);
         si
 
-        declare_innate(location: LOCATION, name: String, innate_name: String, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_innate(location: LOCATION, name: string, innate_name: string, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "innate", name);
 
-        declare_function(location: LOCATION, name: String, is_static: bool, is_private: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_function(location: LOCATION, name: string, is_static: bool, is_private: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "function", name);
 
-        declare_namespace(location: LOCATION, name: String, namespace_: Symbol.NAMESPACE, symbol_definition_listener: SymbolDefinitionListener) is
+        declare_namespace(location: LOCATION, name: string, namespace_: Symbol.NAMESPACE, symbol_definition_listener: SymbolDefinitionListener) is
             declare_undefined(location, "namespace", name);
         si
 
-        declare_label(location: LOCATION, name: String, symbol_definition_listener: SymbolDefinitionListener) is
+        declare_label(location: LOCATION, name: string, symbol_definition_listener: SymbolDefinitionListener) is
             var label = new Symbol.LABEL(location, self, name);
             declare(location, label, symbol_definition_listener);
         si
 
-        declare_variable(location: LOCATION, name: String, is_static: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_variable(location: LOCATION, name: string, is_static: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var variable = new Symbol.LOCAL_VARIABLE(location, self, name);
             declare(location, variable, symbol_definition_listener);
             return variable;
         si
 
-        declare_closure(location: LOCATION, name: String, owner: Scope, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_closure(location: LOCATION, name: string, owner: Scope, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             return declare_undefined(location, "anonymous function", name);
         si        
 
-        declare_property(location: LOCATION, name: String, is_static: bool, is_private: bool, is_assignable: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_property(location: LOCATION, name: string, is_static: bool, is_private: bool, is_assignable: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "property", name);
 
         declare(location: LOCATION, symbol: Symbol.BASE, symbol_definition_listener: SymbolDefinitionListener) is
@@ -133,7 +137,7 @@ namespace Semantic is
             _symbols[name] = symbol;
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             "" + get_type() + " " + _symbols;
     si
 si

--- a/src/semantic/scope/empty_scope.ghul
+++ b/src/semantic/scope/empty_scope.ghul
@@ -1,38 +1,41 @@
 namespace Semantic is
-    use System.String;
-    use Symbol.BASE;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
+        use Symbol.BASE;
 
     use Collections.MAP;
     use Collections.LIST;
     use Collections.Iterable;
 
     class EMPTY_SCOPE: Scope is
-        _qualifier: String;
-        name: String;
-        qualified_name: String => name;
+        _qualifier: string;
+        name: string;
+        qualified_name: string => name;
         symbols: Iterable[BASE] => new LIST[BASE]();
         type: Type.BASE => null;
         unspecialized_symbol: BASE => null;
         is_trait: bool => false;
 
-        init(name: String) is
+        init(name: string) is
             self.name = name;
             _qualifier = name + ".";
         si
 
-        qualify(name: String) -> String => _qualifier + name;
+        qualify(name: string) -> string => _qualifier + name;
 
-        find_direct(name: String) -> BASE => null;
-        find_member(name: String) -> BASE => null;
-        find_enclosing(name: String) -> BASE => null;
+        find_direct(name: string) -> BASE => null;
+        find_member(name: string) -> BASE => null;
+        find_enclosing(name: string) -> BASE => null;
 
-        find_direct_matches(prefix: String, results: MAP[String,BASE]) is
+        find_direct_matches(prefix: string, results: MAP[string,BASE]) is
         si
 
-        find_member_matches(prefix: String, results: MAP[String,BASE]) is
+        find_member_matches(prefix: string, results: MAP[string,BASE]) is
         si
 
-        find_enclosing_matches(prefix: String, results: MAP[String,BASE]) is
+        find_enclosing_matches(prefix: string, results: MAP[string,BASE]) is
         si
     si
 si

--- a/src/semantic/scope/namespace_scope.ghul
+++ b/src/semantic/scope/namespace_scope.ghul
@@ -1,6 +1,9 @@
 namespace Semantic is
-    use System.String;
-    use System.Console;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
+        use System.Console;
 
     use Semantic.Symbol.NAMESPACE;
 
@@ -19,39 +22,39 @@ namespace Semantic is
     */
 
 
-    class NAMESPACE_SCOPE: System.Object, Scope, NamespaceContext, DeclarationContext  is
+    class NAMESPACE_SCOPE: object, Scope, NamespaceContext, DeclarationContext  is
         _namespace: Symbol.NAMESPACE;
 
-        _symbols: Collections.MAP[String,Symbol.BASE];
-        _used_symbols: Collections.MAP[String,Symbol.BASE];
+        _symbols: Collections.MAP[string,Symbol.BASE];
+        _used_symbols: Collections.MAP[string,Symbol.BASE];
         _used_namespaces: Collections.LIST[Symbol.NAMESPACE];
 
         type: Type.BASE => Type.NONE.instance;
 
         unspecialized_symbol: Symbol.BASE => null;
 
-        name: String => _namespace.name;
-        qualified_name: String => _namespace.qualified_name;
+        name: string => _namespace.name;
+        qualified_name: string => _namespace.qualified_name;
         symbols: Collections.Iterable[Symbol.BASE] => _namespace.symbols;
 
         is_trait: bool => false;
 
         init(namespace_: Symbol.NAMESPACE) is
             _namespace = namespace_;
-            _symbols = new Collections.MAP[String,Symbol.BASE]();
-            _used_symbols = new Collections.MAP[String,Symbol.BASE]();
+            _symbols = new Collections.MAP[string,Symbol.BASE]();
+            _used_symbols = new Collections.MAP[string,Symbol.BASE]();
             _used_namespaces = new Collections.LIST[Symbol.NAMESPACE]();
         si
 
-        qualify(name: String) -> String => _namespace.qualify(name);
+        qualify(name: string) -> string => _namespace.qualify(name);
 
-        find_direct(name: String) -> Symbol.BASE => _namespace.find_direct(name);
+        find_direct(name: string) -> Symbol.BASE => _namespace.find_direct(name);
 
-        find_direct_matches(prefix: String, matches: Collections.MAP[System.String,Semantic.Symbol.BASE]) is
+        find_direct_matches(prefix: string, matches: Collections.MAP[string,Semantic.Symbol.BASE]) is
             _namespace.find_direct_matches(prefix, matches);
         si        
 
-        find_member_matches(prefix: String, results: Collections.MAP[System.String,Semantic.Symbol.BASE]) is
+        find_member_matches(prefix: string, results: Collections.MAP[string,Semantic.Symbol.BASE]) is
             _namespace.find_member_matches(prefix, results);
         si        
 
@@ -65,11 +68,11 @@ namespace Semantic is
             return result;
         si
 
-        find_member(name: String) -> Symbol.BASE is
+        find_member(name: string) -> Symbol.BASE is
             return find_enclosing(name);            
         si
         
-        find_enclosing(name: String) -> Symbol.BASE is
+        find_enclosing(name: string) -> Symbol.BASE is
             let ns_location = _namespace.location;
 
             if _symbols.contains_key(name) then
@@ -112,7 +115,7 @@ namespace Semantic is
             return cache_result(search);
         si
 
-        find_enclosing_matches(prefix: String, matches: Collections.MAP[System.String,Semantic.Symbol.BASE]) is
+        find_enclosing_matches(prefix: string, matches: Collections.MAP[string,Semantic.Symbol.BASE]) is
             _namespace.find_enclosing_matches(prefix, matches);
 
             for n in _used_namespaces do
@@ -124,45 +127,45 @@ namespace Semantic is
             od
         si
         
-        declare_class(location: LOCATION, name: String, arguments: Collections.LIST[String], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_class(location: LOCATION, name: string, arguments: Collections.LIST[string], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             _namespace.declare_class(location, name, arguments, is_stub, enclosing, symbol_definition_listener);
         
-        declare_trait(location: LOCATION, name: String, arguments: Collections.LIST[String], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_trait(location: LOCATION, name: string, arguments: Collections.LIST[string], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             _namespace.declare_trait(location, name, arguments, is_stub, enclosing, symbol_definition_listener);
         
-        declare_struct(location: LOCATION, name: String, arguments: Collections.LIST[String], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_struct(location: LOCATION, name: string, arguments: Collections.LIST[string], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             _namespace.declare_struct(location, name, arguments, is_stub, enclosing, symbol_definition_listener);
         
-        declare_type(location: LOCATION, name: String, index: int, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_type(location: LOCATION, name: string, index: int, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             _namespace.declare_type(location, name, index, symbol_definition_listener);
 
-        declare_enum(location: LOCATION, name: String, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_enum(location: LOCATION, name: string, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             _namespace.declare_enum(location, name, symbol_definition_listener);
         
-        declare_enum_member(location: LOCATION, name: String, value: String, symbol_definition_listener: SymbolDefinitionListener) is
+        declare_enum_member(location: LOCATION, name: string, value: string, symbol_definition_listener: SymbolDefinitionListener) is
             _namespace.declare_enum_member(location, name, value, symbol_definition_listener);           
         si
         
-        declare_closure(location: LOCATION, name: String, owner: Scope, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_closure(location: LOCATION, name: string, owner: Scope, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             _namespace.declare_closure(location, name, owner, enclosing, symbol_definition_listener);
 
-        declare_innate(location: LOCATION, name: String, innate_name: String, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_innate(location: LOCATION, name: string, innate_name: string, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             _namespace.declare_innate(location, name, innate_name, enclosing, symbol_definition_listener);
 
-        declare_function(location: LOCATION, name: String, is_static: bool, is_private: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_function(location: LOCATION, name: string, is_static: bool, is_private: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             _namespace.declare_function(location, name, is_static, is_private, enclosing, symbol_definition_listener);
 
-        declare_variable(location: LOCATION, name: String, is_static: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_variable(location: LOCATION, name: string, is_static: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             _namespace.declare_variable(location, name, is_static, symbol_definition_listener);           
         
-        declare_property(location: LOCATION, name: String, is_static: bool, is_private: bool, is_assignable: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_property(location: LOCATION, name: string, is_static: bool, is_private: bool, is_assignable: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             _namespace.declare_property(location, name, is_static, is_private, is_assignable, symbol_definition_listener);
 
-        declare_label(location: LOCATION, name: String, symbol_definition_listener: SymbolDefinitionListener) is
+        declare_label(location: LOCATION, name: string, symbol_definition_listener: SymbolDefinitionListener) is
             _namespace.declare_label(location, name, symbol_definition_listener);
         si
         
-        declare_namespace(location: LOCATION, name: String, namespace_: Symbol.NAMESPACE, symbol_definition_listener: SymbolDefinitionListener) is
+        declare_namespace(location: LOCATION, name: string, namespace_: Symbol.NAMESPACE, symbol_definition_listener: SymbolDefinitionListener) is
             _namespace.declare_namespace(location, name, namespace_, symbol_definition_listener);
         si
 
@@ -170,10 +173,10 @@ namespace Semantic is
             _used_namespaces.add(namespace_);
         si
 
-        add(name: String, symbol: Symbol.BASE) is
+        add(name: string, symbol: Symbol.BASE) is
             _used_symbols[name] = symbol;
         si        
 
-        to_string() -> String => "namespace scope for: " + _namespace.name;
+        to_string() -> string => "namespace scope for: " + _namespace.name;
     si
 si

--- a/src/semantic/scope/namespace_search_result.ghul
+++ b/src/semantic/scope/namespace_search_result.ghul
@@ -1,5 +1,8 @@
 namespace Semantic is   
-    use System.String;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System.Console;
 
     use Symbol.Function;
@@ -8,13 +11,13 @@ namespace Semantic is
     class NAMESPACE_SEARCH is
         _logger: Logging.Logger;
 
-        name: String;
+        name: string;
 
         owner: Scope;
         functions: METHOD_OVERRIDE_MAP;
         other_symbol: Symbol.BASE;
 
-        init(owner: Symbol.BASE, name: String) is
+        init(owner: Symbol.BASE, name: string) is
             _logger = IoC.CONTAINER.instance.logger;
             
             self.owner = owner;

--- a/src/semantic/scope/scope.ghul
+++ b/src/semantic/scope/scope.ghul
@@ -1,4 +1,8 @@
 namespace Semantic is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use IoC;
@@ -6,8 +10,8 @@ namespace Semantic is
     use Source;
 
     trait Scope is
-        name: String;
-        qualified_name: String;
+        name: string;
+        qualified_name: string;
 
         symbols: Collections.Iterable[Symbol.BASE];
 
@@ -17,33 +21,33 @@ namespace Semantic is
 
         is_trait: bool;
         
-        qualify(name: String) -> String;
-        find_direct(name: String) -> Symbol.BASE;
-        find_member(name: String) -> Symbol.BASE;
-        find_enclosing(name: String) -> Symbol.BASE;
+        qualify(name: string) -> string;
+        find_direct(name: string) -> Symbol.BASE;
+        find_member(name: string) -> Symbol.BASE;
+        find_enclosing(name: string) -> Symbol.BASE;
 
-        find_direct_matches(prefix: System.String, matches: Collections.MAP[String,Symbol.BASE]);
-        find_member_matches(prefix: System.String, matches: Collections.MAP[String,Symbol.BASE]);
-        find_enclosing_matches(prefix: System.String, matches: Collections.MAP[String,Symbol.BASE]);
+        find_direct_matches(prefix: string, matches: Collections.MAP[string,Symbol.BASE]);
+        find_member_matches(prefix: string, matches: Collections.MAP[string,Symbol.BASE]);
+        find_enclosing_matches(prefix: string, matches: Collections.MAP[string,Symbol.BASE]);
     si
 
     trait DeclarationContext is
-        declare_class(location: LOCATION, name: String, arguments: Collections.LIST[String], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope;
-        declare_trait(location: LOCATION, name: String, arguments: Collections.LIST[String], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope;
-        declare_struct(location: LOCATION, name: String, arguments: Collections.LIST[String], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope;
-        declare_type(location: LOCATION, name: String, index: int, symbol_definition_listener: SymbolDefinitionListener) -> Scope;
-        declare_enum(location: LOCATION, name: String, symbol_definition_listener: SymbolDefinitionListener) -> Scope;
-        declare_enum_member(location: LOCATION, name: String, value: String, symbol_definition_listener: SymbolDefinitionListener);
-        declare_closure(location: LOCATION, name: String, owner: Scope, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope;
-        declare_innate(location: LOCATION, name: String, innate_name: String, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope;
+        declare_class(location: LOCATION, name: string, arguments: Collections.LIST[string], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope;
+        declare_trait(location: LOCATION, name: string, arguments: Collections.LIST[string], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope;
+        declare_struct(location: LOCATION, name: string, arguments: Collections.LIST[string], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope;
+        declare_type(location: LOCATION, name: string, index: int, symbol_definition_listener: SymbolDefinitionListener) -> Scope;
+        declare_enum(location: LOCATION, name: string, symbol_definition_listener: SymbolDefinitionListener) -> Scope;
+        declare_enum_member(location: LOCATION, name: string, value: string, symbol_definition_listener: SymbolDefinitionListener);
+        declare_closure(location: LOCATION, name: string, owner: Scope, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope;
+        declare_innate(location: LOCATION, name: string, innate_name: string, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope;
 
-        declare_function(location: LOCATION, name: String, is_static: bool, is_private: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope;
-        declare_variable(location: LOCATION, name: String, is_static: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope;
-        declare_property(location: LOCATION, name: String, is_static: bool, is_private: bool, is_assignable: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope;
-        declare_label(location: LOCATION, name: String, symbol_definition_listener: SymbolDefinitionListener);
+        declare_function(location: LOCATION, name: string, is_static: bool, is_private: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope;
+        declare_variable(location: LOCATION, name: string, is_static: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope;
+        declare_property(location: LOCATION, name: string, is_static: bool, is_private: bool, is_assignable: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope;
+        declare_label(location: LOCATION, name: string, symbol_definition_listener: SymbolDefinitionListener);
     si
 
     trait NamespaceContext is
-        declare_namespace(location: LOCATION, name: String, namespace_: Symbol.NAMESPACE, symbol_definition_listener: SymbolDefinitionListener);
+        declare_namespace(location: LOCATION, name: string, namespace_: Symbol.NAMESPACE, symbol_definition_listener: SymbolDefinitionListener);
     si
 si

--- a/src/semantic/symbol/array.ghul
+++ b/src/semantic/symbol/array.ghul
@@ -1,4 +1,8 @@
 namespace Semantic.Symbol is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use IoC;
@@ -6,7 +10,7 @@ namespace Semantic.Symbol is
     use Source;
 
     class ARRAY: GENERIC is
-        il_type_name: String => arguments[0].il_type_name + "[]";
+        il_type_name: string => arguments[0].il_type_name + "[]";
 
         init(location: LOCATION, symbol: Symbol.Classy, element_type: Type.BASE) is
             super.init(location, symbol, new Collections.LIST[Type.BASE]([element_type]));

--- a/src/semantic/symbol/classy.ghul
+++ b/src/semantic/symbol/classy.ghul
@@ -1,4 +1,8 @@
 namespace Semantic.Symbol is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use IoC;
@@ -7,7 +11,7 @@ namespace Semantic.Symbol is
 
     class Classy: ScopedWithEnclosingScope is
         _ancestors: Collections.LIST[Type.BASE];
-        _enclosing_symbols: Collections.MAP[String,BASE];
+        _enclosing_symbols: Collections.MAP[string,BASE];
 
         _are_overrides_resolved: bool;
 
@@ -18,16 +22,16 @@ namespace Semantic.Symbol is
 
         set_type(value: Type.BASE) is type = value; si
 
-        argument_names: Collections.LIST[String];
+        argument_names: Collections.LIST[string];
         ancestors: Collections.LIST[Type.BASE] => _ancestors;
 
         closures: Collections.LIST[Closure];
 
         is_workspace_visible: bool => true;
 
-        il_name_prefix: String => "";
+        il_name_prefix: string => "";
 
-        il_name: String is
+        il_name: string is
             if il_name_override? then
                 return il_name_override;
             fi
@@ -47,7 +51,7 @@ namespace Semantic.Symbol is
             return result.to_string();
         si
 
-        il_token_name: String is
+        il_token_name: string is
             if il_name_override? then
                 let result = il_qualified_name;
 
@@ -72,7 +76,7 @@ namespace Semantic.Symbol is
             return result.to_string();
         si
 
-        il_type_name: String is
+        il_type_name: string is
             let result = new System.Text.StringBuilder();
 
             if il_name_override? then
@@ -114,7 +118,7 @@ namespace Semantic.Symbol is
         is_derived_from_enum: bool =>
             find_ancestor(IoC.CONTAINER.instance.ghul_symbol_lookup.get_unspecialized_enum_type())?;
 
-        get_il_def(preamble: String) -> String is
+        get_il_def(preamble: string) -> string is
             let result = new System.Text.StringBuilder();
 
             result
@@ -199,18 +203,18 @@ namespace Semantic.Symbol is
             return result.to_string();
         si
 
-        init(location: LOCATION, owner: Scope, name: String, argument_names: Collections.LIST[String], enclosing_scope: Scope) is
+        init(location: LOCATION, owner: Scope, name: string, argument_names: Collections.LIST[string], enclosing_scope: Scope) is
             super.init(location, owner, name, enclosing_scope);
 
             _ancestors = new Collections.LIST[Type.BASE]();
-            _enclosing_symbols = new Collections.MAP[String,BASE]();
+            _enclosing_symbols = new Collections.MAP[string,BASE]();
             self.argument_names = argument_names;
 
             type = new Type.NAMED(self);
         si
 
         get_ancestor(i: int) -> Type.BASE
-            => ancestors[i].specialize(new Collections.MAP[String,Type.BASE]());
+            => ancestors[i].specialize(new Collections.MAP[string,Type.BASE]());
 
         add_ancestor(ancestor: Type.BASE) is
             _ancestors.add(ancestor);
@@ -233,9 +237,9 @@ namespace Semantic.Symbol is
             closures.add(closure);
         si
 
-        find_member(name: String) -> BASE => find_direct(name);
+        find_member(name: string) -> BASE => find_direct(name);
 
-        find_enclosing(name: String) -> BASE is
+        find_enclosing(name: string) -> BASE is
             if _enclosing_symbols.contains_key(name) then
                 return _enclosing_symbols[name];
             fi            
@@ -280,7 +284,7 @@ namespace Semantic.Symbol is
             return find_enclosing_only(name);
         si
 
-        find_ancestor_matches(prefix: String, matches: Collections.MAP[String, Symbol.BASE]) is
+        find_ancestor_matches(prefix: string, matches: Collections.MAP[string, Symbol.BASE]) is
             assert _are_overrides_resolved;
 
             for a in ancestors do
@@ -290,7 +294,7 @@ namespace Semantic.Symbol is
             od
         si
 
-        find_member_matches(prefix: String, matches: Collections.MAP[String, Symbol.BASE]) is
+        find_member_matches(prefix: string, matches: Collections.MAP[string, Symbol.BASE]) is
             assert _are_overrides_resolved;
 
             find_direct_matches(prefix, matches);
@@ -304,7 +308,7 @@ namespace Semantic.Symbol is
             */
         si
 
-        find_enclosing_matches(prefix: String, matches: Collections.MAP[String, Symbol.BASE]) is
+        find_enclosing_matches(prefix: string, matches: Collections.MAP[string, Symbol.BASE]) is
             assert _are_overrides_resolved;
 
             find_member_matches(prefix, matches);
@@ -323,21 +327,21 @@ namespace Semantic.Symbol is
                 return;
             fi
 
-            @IF.debug() System.Console.error.write_line("before resolve overrides: " + self);
+            @IF.debug() STD.error.write_line("before resolve overrides: " + self);
         
             _are_overrides_resolved = true;
 
             for i in 0..ancestors.count do
-                @IF.debug() System.Console.error.write_line("pull down " + self + ": get ancestor: " + i);
+                @IF.debug() STD.error.write_line("pull down " + self + ": get ancestor: " + i);
 
                 let a = get_ancestor(i);
 
-                @IF.debug() System.Console.error.write_line("pull down " + self + ": have ancestor: " + a);
+                @IF.debug() STD.error.write_line("pull down " + self + ": have ancestor: " + a);
 
                 let symbol = a.symbol;
 
                 if symbol? then
-                    @IF.debug() System.Console.error.write_line("pull down " + self + ": pull down ancestor: " + symbol);
+                    @IF.debug() STD.error.write_line("pull down " + self + ": pull down ancestor: " + symbol);
                     symbol.pull_down_super_symbols();
                 fi
             od
@@ -347,15 +351,15 @@ namespace Semantic.Symbol is
             _next_inheritance_dependency_order = _next_inheritance_dependency_order + 1;
 
             let resolver = new SYMBOL_INHERITANCE_RESOLVER(self);
-            @IF.debug() System.Console.error.write_line("pull down " + self + ": call inheritance resolver");
+            @IF.debug() STD.error.write_line("pull down " + self + ": call inheritance resolver");
 
             resolver.pull_into();
         si
     si
 
     class CLASS: Classy, Type.Typed is
-        description: String => "class " + qualified_name;
-        short_description: String => "class " + name;
+        description: string => "class " + qualified_name;
+        short_description: string => "class " + name;
 
         symbol_kind: SYMBOL_KIND => SYMBOL_KIND.CLASS;
         completion_kind: COMPLETION_KIND => COMPLETION_KIND.CLASS;
@@ -365,11 +369,11 @@ namespace Semantic.Symbol is
         is_inheritable: bool => true;
         is_class: bool => true;
 
-        il_def: String => get_il_def(".class public auto ansi beforefieldinit");
+        il_def: string => get_il_def(".class public auto ansi beforefieldinit");
 
-        il_name_prefix: String => "class ";
+        il_name_prefix: string => "class ";
 
-        init(location: LOCATION, owner: Scope, name: String, arguments: Collections.LIST[String], is_stub: bool, enclosing_scope: Scope) is
+        init(location: LOCATION, owner: Scope, name: string, arguments: Collections.LIST[string], is_stub: bool, enclosing_scope: Scope) is
             super.init(location, owner, name, arguments, enclosing_scope);
 
             self.is_stub = is_stub;
@@ -381,7 +385,7 @@ namespace Semantic.Symbol is
 
         // FIXME: most of these can be folded into ClassAndTraitBase:
 
-        declare_type(location: LOCATION, name: String, index: int, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_type(location: LOCATION, name: string, index: int, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.TYPE(location, self, name, index);
 
             declare(location, result, symbol_definition_listener);
@@ -389,7 +393,7 @@ namespace Semantic.Symbol is
             return result;
         si
 
-        declare_enum(location: LOCATION, name: String, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_enum(location: LOCATION, name: string, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.ENUM_(location, self, name);
 
             declare(location, result, symbol_definition_listener);
@@ -397,7 +401,7 @@ namespace Semantic.Symbol is
             return result;
         si
 
-        declare_function(location: LOCATION, name: String, is_static: bool, is_private: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_function(location: LOCATION, name: string, is_static: bool, is_private: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             let result: Function;
 
             if is_static then
@@ -411,7 +415,7 @@ namespace Semantic.Symbol is
             return result;
         si
 
-        declare_innate(location: LOCATION, name: String, innate_name: String, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_innate(location: LOCATION, name: string, innate_name: string, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.INNATE_METHOD(location, self, name, enclosing, innate_name);
 
             declare_function_group(location, result, symbol_definition_listener);
@@ -419,7 +423,7 @@ namespace Semantic.Symbol is
             return result;
         si        
 
-        declare_variable(location: LOCATION, name: String, is_static: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_variable(location: LOCATION, name: string, is_static: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             let result: Variable;
             
             if is_static then
@@ -433,7 +437,7 @@ namespace Semantic.Symbol is
             return result;
         si
 
-        declare_property(location: LOCATION, name: String, is_static: bool, is_private: bool, is_assignable: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_property(location: LOCATION, name: string, is_static: bool, is_private: bool, is_assignable: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             let result: Property;
 
             if is_static then
@@ -449,8 +453,8 @@ namespace Semantic.Symbol is
     si
 
     class TRAIT: Classy, Type.Typed is
-        description: String => "trait " + qualified_name;
-        short_description: String => "trait " + name;
+        description: string => "trait " + qualified_name;
+        short_description: string => "trait " + name;
 
         symbol_kind: SYMBOL_KIND => SYMBOL_KIND.INTERFACE;
         completion_kind: COMPLETION_KIND => COMPLETION_KIND.INTERFACE;
@@ -460,16 +464,16 @@ namespace Semantic.Symbol is
         is_inheritable: bool => true;
         is_trait: bool => true;
 
-        il_name_prefix: String => "class ";
+        il_name_prefix: string => "class ";
 
-        il_def: String => get_il_def(".class public interface auto ansi beforefieldinit");
+        il_def: string => get_il_def(".class public interface auto ansi beforefieldinit");
 
-        init(location: LOCATION, owner: Scope, name: String, arguments: Collections.LIST[String], is_stub: bool, enclosing_scope: Scope) is
+        init(location: LOCATION, owner: Scope, name: string, arguments: Collections.LIST[string], is_stub: bool, enclosing_scope: Scope) is
             super.init(location, owner, name, arguments, enclosing_scope);
             self.is_stub = is_stub;
         si
 
-        declare_type(location: LOCATION, name: String, index: int, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_type(location: LOCATION, name: string, index: int, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.TYPE(location, self, name, index);
 
             declare(location, result, symbol_definition_listener);
@@ -483,7 +487,7 @@ namespace Semantic.Symbol is
 
         // FIXME: most of these can be folded into Classy:
 
-        declare_enum(location: LOCATION, name: String, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_enum(location: LOCATION, name: string, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.ENUM_(location, self, name);
 
             declare(location, result, symbol_definition_listener);
@@ -491,7 +495,7 @@ namespace Semantic.Symbol is
             return result;
         si
 
-        declare_innate(location: LOCATION, name: String, innate_name: String, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_innate(location: LOCATION, name: string, innate_name: string, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.INNATE_FUNCTION(location, self, name, enclosing, innate_name);
 
             declare_function_group(location, result, symbol_definition_listener);
@@ -499,7 +503,7 @@ namespace Semantic.Symbol is
             return result;
         si
 
-        declare_function(location: LOCATION, name: String, is_static: bool, is_private: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_function(location: LOCATION, name: string, is_static: bool, is_private: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result: Function;
             
             if is_static then
@@ -514,7 +518,7 @@ namespace Semantic.Symbol is
             return result;
         si
 
-        declare_property(location: LOCATION, name: String, is_static: bool, is_private: bool, is_assignable: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_property(location: LOCATION, name: string, is_static: bool, is_private: bool, is_assignable: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result: Property;
 
             if is_static then
@@ -531,8 +535,8 @@ namespace Semantic.Symbol is
     si
 
     class STRUCT: Classy, Type.Typed is
-        description: String => "struct " + qualified_name;
-        short_description: String => "struct " + name;
+        description: string => "struct " + qualified_name;
+        short_description: string => "struct " + name;
 
         symbol_kind: SYMBOL_KIND => SYMBOL_KIND.STRUCT;
         completion_kind: COMPLETION_KIND => COMPLETION_KIND.CLASS;
@@ -541,11 +545,11 @@ namespace Semantic.Symbol is
 
         is_value_type: bool => true;
 
-        il_name_prefix: String => "valuetype ";
+        il_name_prefix: string => "valuetype ";
 
-        il_def: String => get_il_def(".class public sealed auto ansi beforefieldinit");
+        il_def: string => get_il_def(".class public sealed auto ansi beforefieldinit");
 
-        init(location: LOCATION, owner: Scope, name: String, arguments: Collections.LIST[String], is_stub: bool, enclosing_scope: Scope) is
+        init(location: LOCATION, owner: Scope, name: string, arguments: Collections.LIST[string], is_stub: bool, enclosing_scope: Scope) is
             super.init(location, owner, name, arguments, enclosing_scope);
             self.is_stub = true;
         si
@@ -556,7 +560,7 @@ namespace Semantic.Symbol is
 
         // FIXME: most of these can be folded into Classy:
 
-        declare_type(location: LOCATION, name: String, index: int, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_type(location: LOCATION, name: string, index: int, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.TYPE(location, self, name, index);
 
             declare(location, result, symbol_definition_listener);
@@ -564,7 +568,7 @@ namespace Semantic.Symbol is
             return result;
         si
 
-        declare_enum(location: LOCATION, name: String, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_enum(location: LOCATION, name: string, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.ENUM_(location, self, name);
 
             declare(location, result, symbol_definition_listener);
@@ -572,7 +576,7 @@ namespace Semantic.Symbol is
             return result;
         si
 
-        declare_innate(location: LOCATION, name: String, innate_name: String, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_innate(location: LOCATION, name: string, innate_name: string, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.INNATE_METHOD(location, self, name, enclosing, innate_name);
 
             declare_function_group(location, result, symbol_definition_listener);
@@ -580,7 +584,7 @@ namespace Semantic.Symbol is
             return result;
         si
 
-        declare_function(location: LOCATION, name: String, is_static: bool, is_private: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_function(location: LOCATION, name: string, is_static: bool, is_private: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             let result: Function;
 
             if is_static then
@@ -594,7 +598,7 @@ namespace Semantic.Symbol is
             return result;
         si
 
-        declare_variable(location: LOCATION, name: String, is_static: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_variable(location: LOCATION, name: string, is_static: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             // FIXME: probably also needs to load address of self:
             var result = new Symbol.INSTANCE_FIELD(location, self, name);
 
@@ -603,7 +607,7 @@ namespace Semantic.Symbol is
             return result;
         si
 
-        declare_property(location: LOCATION, name: String, is_static: bool, is_private: bool, is_assignable: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_property(location: LOCATION, name: string, is_static: bool, is_private: bool, is_assignable: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.INSTANCE_PROPERTY(location, self, name, is_assignable);
 
             declare(location, result, symbol_definition_listener);

--- a/src/semantic/symbol/closure.ghul
+++ b/src/semantic/symbol/closure.ghul
@@ -1,4 +1,8 @@
 namespace Semantic.Symbol is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use IoC;
@@ -6,20 +10,20 @@ namespace Semantic.Symbol is
     use Source;
 
     class Closure: Function, Type.Typed is
-        description: String => "" + type + " // closure";
-        short_description: String => description;
+        description: string => "" + type + " // closure";
+        short_description: string => description;
 
         symbol_kind: SYMBOL_KIND => SYMBOL_KIND.FUNCTION;
         completion_kind: COMPLETION_KIND => COMPLETION_KIND.FUNCTION;
 
-        qualified_name: String => "[closure]" + name; // FIXME
+        qualified_name: string => "[closure]" + name; // FIXME
 
-        il_name: String => name; // FIXME
-        owner_il_name: String => "[closure]"; // FIXME
+        il_name: string => name; // FIXME
+        owner_il_name: string => "[closure]"; // FIXME
 
-        il_body: String public;
+        il_body: string public;
         
-        init(location: LOCATION, owner: Scope, name: String, enclosing_scope: Scope) is
+        init(location: LOCATION, owner: Scope, name: string, enclosing_scope: Scope) is
             super.init(location, owner, name, enclosing_scope);
         si
 
@@ -27,19 +31,19 @@ namespace Semantic.Symbol is
             throw new System.NotImplementedException("abstract");
         si
 
-        to_string() -> String => "[closure " + name + "]";
+        to_string() -> string => "[closure " + name + "]";
     si
 
     class INSTANCE_CLOSURE: Closure is
-        il_def: String => get_il_def(".method public virtual hidebysig instance default ");
+        il_def: string => get_il_def(".method public virtual hidebysig instance default ");
 
         is_instance: bool => true;
 
-        init(location: LOCATION, owner: Scope, name: String, enclosing_scope: Scope) is
+        init(location: LOCATION, owner: Scope, name: string, enclosing_scope: Scope) is
             super.init(location, owner, name, enclosing_scope);
         si
 
-        declare_closure(location: LOCATION, name: String, owner: Scope, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_closure(location: LOCATION, name: string, owner: Scope, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.INSTANCE_CLOSURE(location, owner, name, enclosing);
 
             declare(location, result, null);
@@ -53,13 +57,13 @@ namespace Semantic.Symbol is
     si
 
     class STATIC_CLOSURE: Closure is
-        il_def: String => get_il_def(".method public static hidebysig default ");
+        il_def: string => get_il_def(".method public static hidebysig default ");
 
-        init(location: LOCATION, owner: Scope, name: String, enclosing_scope: Scope) is
+        init(location: LOCATION, owner: Scope, name: string, enclosing_scope: Scope) is
             super.init(location, owner, name, enclosing_scope);
         si
 
-        declare_closure(location: LOCATION, name: String, owner: Scope, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_closure(location: LOCATION, name: string, owner: Scope, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.STATIC_CLOSURE(location, owner, name, enclosing);
 
             declare(location, result, null);

--- a/src/semantic/symbol/enum.ghul
+++ b/src/semantic/symbol/enum.ghul
@@ -1,4 +1,8 @@
 namespace Semantic.Symbol is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use IoC;
@@ -37,8 +41,8 @@ namespace Semantic.Symbol is
 
         type: Type.BASE;
 
-        description: String => "enum " + qualified_name;
-        short_description: String => "enum " + name;
+        description: string => "enum " + qualified_name;
+        short_description: string => "enum " + name;
 
         symbol_kind: SYMBOL_KIND => SYMBOL_KIND.ENUM;
         completion_kind: COMPLETION_KIND => COMPLETION_KIND.ENUM;
@@ -46,7 +50,7 @@ namespace Semantic.Symbol is
 
         is_value_type: bool => true;
 
-        il_type_name: String is
+        il_type_name: string is
             if il_name_override? then
                 return il_qualified_name;
             else
@@ -54,10 +58,10 @@ namespace Semantic.Symbol is
             fi
         si
 
-        il_def: String =>
+        il_def: string =>
             ".class public auto ansi sealed " + il_name + " extends [mscorlib]System.Enum";
 
-        init(location: LOCATION, owner: Scope, name: String) is
+        init(location: LOCATION, owner: Scope, name: string) is
             super.init(location, owner, name);
 
             type = new Type.NAMED(self);
@@ -71,10 +75,10 @@ namespace Semantic.Symbol is
             fi
         si
 
-        specialize(type_map: Collections.MAP[String,Type.BASE], owner: GENERIC) -> BASE
+        specialize(type_map: Collections.MAP[string,Type.BASE], owner: GENERIC) -> BASE
             => self;
 
-        declare_enum_member(location: LOCATION, name: String, value: String, symbol_definition_listener: SymbolDefinitionListener) is
+        declare_enum_member(location: LOCATION, name: string, value: string, symbol_definition_listener: SymbolDefinitionListener) is
             if !value? then
                 value = "" + next_value;
             fi
@@ -84,7 +88,7 @@ namespace Semantic.Symbol is
             declare(location, result, symbol_definition_listener);
         si
 
-        find_member(name: String) -> BASE is
+        find_member(name: string) -> BASE is
             var result = find_direct(name);
 
             if result? then
@@ -100,12 +104,12 @@ namespace Semantic.Symbol is
             return null;
         si
 
-        find_member_matches(prefix: String, matches: Collections.MAP[String, Symbol.BASE]) is
+        find_member_matches(prefix: string, matches: Collections.MAP[string, Symbol.BASE]) is
             find_direct_matches(prefix, matches);
             find_ancestor_matches(prefix, matches);
         si
 
-        find_ancestor_matches(prefix: String, matches: Collections.MAP[String, Symbol.BASE]) is
+        find_ancestor_matches(prefix: string, matches: Collections.MAP[string, Symbol.BASE]) is
             _ancestor_.scope.find_member_matches(prefix, matches);
         si
 
@@ -119,24 +123,24 @@ namespace Semantic.Symbol is
 
         type: Type.BASE => _enum.type;
 
-        value: System.String;
+        value: string;
 
-        description: String => "enum member " + qualified_name;
-        short_description: String => name;
+        description: string => "enum member " + qualified_name;
+        short_description: string => name;
 
         symbol_kind: SYMBOL_KIND => SYMBOL_KIND.ENUM_MEMBER;
         completion_kind: COMPLETION_KIND => COMPLETION_KIND.ENUM;
 
-        il_def: String =>
+        il_def: string =>
             ".field public static literal " + _enum.il_type_name + " " + il_name + " = int32(" + value + ")";
 
-        init(location: LOCATION, owner: ENUM_, name: String, value: String) is
+        init(location: LOCATION, owner: ENUM_, name: string, value: string) is
             super.init(location, owner, name);
 
             self.value = value;
         si
 
-        specialize(type_map: Collections.MAP[String,Symbol.BASE], owner: GENERIC) -> BASE
+        specialize(type_map: Collections.MAP[string,Symbol.BASE], owner: GENERIC) -> BASE
             => self;
 
         load(location: LOCATION, from: Graph.Value.BASE, loader: SYMBOL_LOADER) -> Graph.Value.BASE is

--- a/src/semantic/symbol/function.ghul
+++ b/src/semantic/symbol/function.ghul
@@ -1,4 +1,8 @@
 namespace Semantic.Symbol is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
 
     use Collections.Iterable;
@@ -28,18 +32,18 @@ namespace Semantic.Symbol is
         unspecialized_arguments: Collections.LIST[Type.BASE] public;
         unspecialized_return_type: Type.BASE public;
 
-        argument_names: Collections.LIST[String] public;
+        argument_names: Collections.LIST[string] public;
         symbol_kind: SYMBOL_KIND => SYMBOL_KIND.FUNCTION;
         completion_kind: COMPLETION_KIND => COMPLETION_KIND.FUNCTION;
 
         is_workspace_visible: bool => true;
         is_abstract: bool => false;
 
-        short_description: String => name + "(" + short_argument_descriptions + ") -> " + return_type.short_description;
+        short_description: string => name + "(" + short_argument_descriptions + ") -> " + return_type.short_description;
 
-        il_property_def: String => get_il_def("// not a property ");
+        il_property_def: string => get_il_def("// not a property ");
 
-        il_qualified_name: String is
+        il_qualified_name: string is
             assert
                 owner? && isa BASE(owner)
             else
@@ -48,7 +52,7 @@ namespace Semantic.Symbol is
             return cast BASE(owner).il_type_name + "::" + il_name;
         si
 
-        il_type_name: String is
+        il_type_name: string is
             let result = new System.Text.StringBuilder();
 
             assert self? else "function il_type_name self is null";
@@ -70,9 +74,9 @@ namespace Semantic.Symbol is
             fi
 
             if !rt? then
-                System.Console.error.write_line("function has no return type");
-                System.Console.error.write_line("function has no return type: " + name);
-                System.Console.error.write_line("function has no return type: " + owner + "." + name);
+                STD.error.write_line("function has no return type");
+                STD.error.write_line("function has no return type: " + name);
+                STD.error.write_line("function has no return type: " + owner + "." + name);
 
                 result.append("void ");
             else
@@ -101,7 +105,7 @@ namespace Semantic.Symbol is
                 if argument? then
                     result.append(argument.il_type_name);
                 else
-                    System.Console.error.write_line("broken unspecialized_arguments: " + unspecialized_arguments);
+                    STD.error.write_line("broken unspecialized_arguments: " + unspecialized_arguments);
                 fi
 
                 seen_any = true;
@@ -112,7 +116,7 @@ namespace Semantic.Symbol is
             return result.to_string();
         si
 
-        argument_descriptions: String is
+        argument_descriptions: string is
             let result = new System.Text.StringBuilder();
 
             for i in 0..arguments.count do
@@ -125,7 +129,7 @@ namespace Semantic.Symbol is
             return result.to_string();
         si
 
-        short_argument_descriptions: String is
+        short_argument_descriptions: string is
             let result = new System.Text.StringBuilder();
 
             for i in 0..arguments.count do
@@ -142,7 +146,7 @@ namespace Semantic.Symbol is
 
         =~(other: Function) -> bool => self == other;
 
-        init(location: LOCATION, owner: Scope, name: String, enclosing_scope: Scope) is
+        init(location: LOCATION, owner: Scope, name: string, enclosing_scope: Scope) is
             super.init(location, owner, name, enclosing_scope);
 
             if name =~ "init" then
@@ -152,7 +156,7 @@ namespace Semantic.Symbol is
             type = new Type.NAMED(self);
         si
 
-        get_il_def(preamble: String) -> String is
+        get_il_def(preamble: string) -> string is
             let result = new System.Text.StringBuilder();
             
             result
@@ -200,7 +204,7 @@ namespace Semantic.Symbol is
             _declaring_arguments = false;
         si
 
-        specialize_function(type_map: Collections.MAP[String,Type.BASE], owner: GENERIC) -> Function is
+        specialize_function(type_map: Collections.MAP[string,Type.BASE], owner: GENERIC) -> Function is
             assert owner? else "cannot specialize with null owner";
 
             let result = cast Function(memberwise_clone());
@@ -208,7 +212,7 @@ namespace Semantic.Symbol is
             result.specialized_from = self;
             result._override_class = null;
 
-            // System.Console.error.write_line("set specialized from: " + qualified_name);
+            // STD.error.write_line("set specialized from: " + qualified_name);
 
             if !return_type? then
                 IoC.CONTAINER.instance.logger.poison(self.location, "specialized with null return type");
@@ -245,13 +249,13 @@ namespace Semantic.Symbol is
             elif result.owner != owner then
                 result.owner = result.owner.type.specialize(owner.type_map).symbol;
             else
-                System.Console.error.write_line("" + result + " is already owned by " + owner);
+                STD.error.write_line("" + result + " is already owned by " + owner);
             fi
 
             return result;
         si
 
-        specialize(type_map: Collections.MAP[String,Type.BASE], owner: GENERIC) -> BASE =>
+        specialize(type_map: Collections.MAP[string,Type.BASE], owner: GENERIC) -> BASE =>
             specialize_function(type_map, owner);
 
         get_full_type(ghul_symbol_lookup: GHUL_SYMBOL_LOOKUP) -> Type.NAMED is
@@ -298,7 +302,7 @@ namespace Semantic.Symbol is
             logger.error(function.location, "cannot be overridden by " + function);
         si
 
-        inheritance_warn(logger: Logger, into: Classy, message: String) is
+        inheritance_warn(logger: Logger, into: Classy, message: string) is
             if owner == into then
                 logger.warn(location, message);                    
             else
@@ -306,7 +310,7 @@ namespace Semantic.Symbol is
             fi
         si
 
-        inheritance_error(logger: Logger, into: Classy, message: String) is
+        inheritance_error(logger: Logger, into: Classy, message: string) is
             if owner == into then
                 logger.error(location, message);
             else
@@ -329,7 +333,7 @@ namespace Semantic.Symbol is
             return true;
         si
 
-        ensure_il_name_matches(into: Classy, overridee: Function, override_type: String, logger: Logger) -> bool is
+        ensure_il_name_matches(into: Classy, overridee: Function, override_type: string, logger: Logger) -> bool is
             if il_name !~ overridee.il_name then
                 if il_name_override? then
                     logger.warn(location, "does not " + override_type + " " + overridee + " due to inconsistent IL names (" + il_name + " vs " + overridee.il_name + ")");
@@ -342,7 +346,7 @@ namespace Semantic.Symbol is
             return true;
         si
                 
-        declare_variable(location: LOCATION, name: String, is_static: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_variable(location: LOCATION, name: string, is_static: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             if _declaring_arguments then
                 var result = new Symbol.LOCAL_ARGUMENT(location, self, name);
 
@@ -358,7 +362,7 @@ namespace Semantic.Symbol is
             fi
         si
 
-        declare_function(location: LOCATION, name: String, is_static: bool, is_private: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_function(location: LOCATION, name: string, is_static: bool, is_private: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.GLOBAL_FUNCTION(location, self, name, enclosing);
 
             declare_function_group(location, result, symbol_definition_listener);
@@ -366,7 +370,7 @@ namespace Semantic.Symbol is
             return result;
         si
 
-        get_argument_description(index: int) -> String is
+        get_argument_description(index: int) -> string is
             let result = new System.Text.StringBuilder();
 
             result
@@ -377,7 +381,7 @@ namespace Semantic.Symbol is
             return result.to_string();
         si
 
-        get_short_argument_description(index: int) -> String is
+        get_short_argument_description(index: int) -> string is
             let result = new System.Text.StringBuilder();
 
             result
@@ -388,7 +392,7 @@ namespace Semantic.Symbol is
             return result.to_string();
         si
 
-        to_string() -> String is
+        to_string() -> string is
             let result = new System.Text.StringBuilder();
 
             try
@@ -442,8 +446,8 @@ namespace Semantic.Symbol is
                 // return qualified_name + " (" + short_argument_descriptions + ") -> " + return_type;
                 return result.to_string();
             catch ex: Exception
-                // System.Console.error.write_line("failed to convert function to string: " + name + ", got as far as: " + result);
-                // System.Console.error.write_line(ex);
+                // STD.error.write_line("failed to convert function to string: " + name + ", got as far as: " + result);
+                // STD.error.write_line(ex);
 
                 return "[garbled function: " + result + "]";
             yrt
@@ -452,11 +456,11 @@ namespace Semantic.Symbol is
 
 
     class GLOBAL_FUNCTION: Function is
-        description: String => qualified_name + "(" + argument_descriptions + ") -> " + return_type + " // global function";
+        description: string => qualified_name + "(" + argument_descriptions + ") -> " + return_type + " // global function";
 
-        il_def: String => get_il_def("// global ");
+        il_def: string => get_il_def("// global ");
 
-        init(location: LOCATION, owner: Scope, name: String, enclosing_scope: Scope) is
+        init(location: LOCATION, owner: Scope, name: string, enclosing_scope: Scope) is
             super.init(location, owner, name, enclosing_scope);
         si
 

--- a/src/semantic/symbol/function_group.ghul
+++ b/src/semantic/symbol/function_group.ghul
@@ -1,4 +1,8 @@
 namespace Semantic.Symbol is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use IoC;
@@ -8,8 +12,8 @@ namespace Semantic.Symbol is
     class FUNCTION_GROUP: BASE, Type.Typed is
         // _overrides_resolved: bool;
 
-        description: String => qualified_name + "(...) // function group";
-        short_description: String => name + "(...)";
+        description: string => qualified_name + "(...) // function group";
+        short_description: string => name + "(...)";
         symbol_kind: SYMBOL_KIND => SYMBOL_KIND.FUNCTION;
         completion_kind: COMPLETION_KIND => COMPLETION_KIND.FUNCTION;
 
@@ -19,14 +23,14 @@ namespace Semantic.Symbol is
 
         functions: Collections.MutableList[Function];
 
-        init(location: LOCATION, owner: Scope, name: String) is
+        init(location: LOCATION, owner: Scope, name: string) is
             super.init(location, owner, name);
 
             type = new Type.FUNCTION_GROUP(name, self);
             functions = new Collections.LIST[Function]();
         si
 
-        specialize_function_group(type_map: Collections.MAP[String,Type.BASE], owner: GENERIC) -> FUNCTION_GROUP is
+        specialize_function_group(type_map: Collections.MAP[string,Type.BASE], owner: GENERIC) -> FUNCTION_GROUP is
             let result = cast FUNCTION_GROUP(memberwise_clone());
 
             result.specialized_from = self;
@@ -45,7 +49,7 @@ namespace Semantic.Symbol is
             return result;
         si
 
-        specialize(type_map: Collections.MAP[String,Type.BASE], owner: GENERIC) -> BASE =>
+        specialize(type_map: Collections.MAP[string,Type.BASE], owner: GENERIC) -> BASE =>
             specialize_function_group(type_map, owner);
 
         add(function: Function) is
@@ -78,7 +82,7 @@ namespace Semantic.Symbol is
             fi
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             description + " [" + new Shim.JOIN[Symbol.Function](functions) + "]";
     si
 si

--- a/src/semantic/symbol/function_wrapper.ghul
+++ b/src/semantic/symbol/function_wrapper.ghul
@@ -1,5 +1,7 @@
 namespace Semantic is
-    use System.String;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
 
     use Symbol.Function;
 
@@ -10,7 +12,7 @@ namespace Semantic is
         function: Function;
 
         @IL.name("Equals")
-        =~(other: System.Object) -> bool is
+        =~(other: object) -> bool is
             if !other? then
                 return false;
             elif !isa FUNCTION_WRAPPER(other) then
@@ -24,7 +26,7 @@ namespace Semantic is
         =~(other: FUNCTION_WRAPPER) -> bool is
             let result = _root_function == other._root_function;
 
-            @IF.debug() System.Console.error.write_line("compare functions: " + _root_function + " vs " + other._root_function + ": " + result);
+            @IF.debug() STD.error.write_line("compare functions: " + _root_function + " vs " + other._root_function + ": " + result);
 
             return result;
         si
@@ -41,6 +43,6 @@ namespace Semantic is
 
         get_hash_code() -> int => _hash;
 
-        to_string() -> String => "" + function;
+        to_string() -> string => "" + function;
     si
 si

--- a/src/semantic/symbol/generic.ghul
+++ b/src/semantic/symbol/generic.ghul
@@ -1,4 +1,8 @@
 namespace Semantic.Symbol is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use IoC;
@@ -9,7 +13,7 @@ namespace Semantic.Symbol is
     // with actual type arguments specified for its formal type parameters, and all its member symbols' signatures rewritten 
     // with all instances of each formal type parameter replaced with the corresponding actual type argument  
     class GENERIC: BASE, Scope is
-        type_map: Collections.MAP[String,Type.BASE];
+        type_map: Collections.MAP[string,Type.BASE];
         arguments: Collections.LIST[Type.BASE];
         ancestors: Collections.LIST[Type.BASE] => symbol.ancestors;
         symbol: Classy;
@@ -30,7 +34,7 @@ namespace Semantic.Symbol is
         root_unspecialized_symbol: Symbol.BASE => symbol.root_unspecialized_symbol;
 
         location: LOCATION => symbol.location;
-        name: String => symbol.name;
+        name: string => symbol.name;
 
         access: ACCESS => symbol.access;
 
@@ -39,9 +43,9 @@ namespace Semantic.Symbol is
         is_class: bool => symbol.is_class;
         is_trait: bool => symbol.is_trait;
 
-        qualified_name: String => symbol.qualified_name + "[" + arguments_string + "]";
+        qualified_name: string => symbol.qualified_name + "[" + arguments_string + "]";
 
-        arguments_string: String is
+        arguments_string: string is
             let result = new System.Text.StringBuilder();
 
             let seen_any = false;
@@ -59,9 +63,9 @@ namespace Semantic.Symbol is
             return result.to_string();
         si
         
-        description: String => qualified_name;
+        description: string => qualified_name;
 
-        short_description: String is
+        short_description: string is
             let result = new System.Text.StringBuilder();
 
             result
@@ -90,7 +94,7 @@ namespace Semantic.Symbol is
         completion_kind: COMPLETION_KIND => symbol.completion_kind;
         // is_workspace_visible: bool => true;
 
-        il_type_name: String is
+        il_type_name: string is
             let result = new System.Text.StringBuilder();
 
             let qn = symbol.il_name_override;
@@ -142,7 +146,7 @@ namespace Semantic.Symbol is
             return result.to_string();
         si
 
-        il_def: String => "generic has no il_def: " + self;
+        il_def: string => "generic has no il_def: " + self;
 
         type: Type.BASE is
             return new Type.GENERIC(self.location, self.symbol, self.arguments);
@@ -174,7 +178,7 @@ namespace Semantic.Symbol is
             fi
 
             self.arguments = arguments;
-            type_map = new Collections.MAP[String,Type.BASE]();
+            type_map = new Collections.MAP[string,Type.BASE]();
 
             for i in 0..length do
                 type_map[symbol.argument_names[i]] = arguments[i];
@@ -237,11 +241,11 @@ namespace Semantic.Symbol is
         dump_ancestors(depth: int) is
             for i in 0..self.ancestors.count do
                 for j in 0..depth do
-                    System.Console.error.write("  ");
+                    STD.error.write("  ");
                 od
                 
                 let a = get_ancestor(i);
-                System.Console.error.write_line("" + self + " has ancestor: " + a);
+                STD.error.write_line("" + self + " has ancestor: " + a);
             
                 if isa Type.GENERIC(a) then
                     let s = cast Type.GENERIC(a).symbol;
@@ -288,17 +292,17 @@ namespace Semantic.Symbol is
             fi
         si
 
-        find_direct(name: String) -> BASE is
+        find_direct(name: string) -> BASE is
             assert_symbols_pulled_down();
 
             return _specialize(symbol.find_direct(name));
         si
 
-        find_member(name: String) -> BASE is            
+        find_member(name: string) -> BASE is            
             return _specialize(symbol.find_member(name));
         si
 
-        find_enclosing(name: String) -> BASE is
+        find_enclosing(name: string) -> BASE is
             let unspecialized = symbol.find_enclosing(name);
 
             if unspecialized? && unspecialized.owner == symbol then
@@ -308,8 +312,8 @@ namespace Semantic.Symbol is
             fi
         si
 
-        find_direct_matches(prefix: String, matches: Collections.MAP[String, Symbol.BASE]) is
-            let m = new Collections.MAP[String, Symbol.BASE]();
+        find_direct_matches(prefix: string, matches: Collections.MAP[string, Symbol.BASE]) is
+            let m = new Collections.MAP[string, Symbol.BASE]();
 
             symbol.find_direct_matches(prefix, m);
 
@@ -320,12 +324,12 @@ namespace Semantic.Symbol is
             od
         si
 
-        find_member_matches(prefix: String, matches: Collections.MAP[String, Symbol.BASE]) is
+        find_member_matches(prefix: string, matches: Collections.MAP[string, Symbol.BASE]) is
             find_direct_matches(prefix, matches);
             symbol.find_ancestor_matches(prefix, matches);
         si
 
-        find_enclosing_matches(prefix: String, matches: Collections.MAP[String, Symbol.BASE]) is
+        find_enclosing_matches(prefix: string, matches: Collections.MAP[string, Symbol.BASE]) is
         si
 
         get_hash_code() -> int is
@@ -338,6 +342,6 @@ namespace Semantic.Symbol is
             return result;
         si
 
-        to_string() -> String => qualified_name;
+        to_string() -> string => qualified_name;
     si
 si

--- a/src/semantic/symbol/innate.ghul
+++ b/src/semantic/symbol/innate.ghul
@@ -1,4 +1,8 @@
 namespace Semantic.Symbol is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use IoC;
@@ -6,14 +10,14 @@ namespace Semantic.Symbol is
     use Source;
 
     class InnateFunction: Function is
-        innate_name: String;
-        description: String => qualified_name + "(" + argument_descriptions + ") -> " + return_type + " // innate function " + innate_name;
+        innate_name: string;
+        description: string => qualified_name + "(" + argument_descriptions + ") -> " + return_type + " // innate function " + innate_name;
         
         is_innate: bool => true;
 
-        il_def: String => get_il_def("// innate ");
+        il_def: string => get_il_def("// innate ");
 
-        init(location: LOCATION, owner: Scope, name: String, enclosing_scope: Scope, innate_name: String) is            
+        init(location: LOCATION, owner: Scope, name: string, enclosing_scope: Scope, innate_name: string) is            
             super.init(location, owner, name, enclosing_scope);
 
             self.innate_name = innate_name;
@@ -28,7 +32,7 @@ namespace Semantic.Symbol is
     si
 
     class INNATE_FUNCTION: InnateFunction is
-        init(location: LOCATION, owner: Scope, name: String, enclosing_scope: Scope, innate_name: String) is            
+        init(location: LOCATION, owner: Scope, name: string, enclosing_scope: Scope, innate_name: string) is            
             super.init(location, owner, name, enclosing_scope, innate_name);
         si        
 
@@ -40,7 +44,7 @@ namespace Semantic.Symbol is
     si
 
     class INNATE_METHOD: InnateFunction is
-        init(location: LOCATION, owner: Scope, name: String, enclosing_scope: Scope, innate_name: String) is            
+        init(location: LOCATION, owner: Scope, name: string, enclosing_scope: Scope, innate_name: string) is            
             super.init(location, owner, name, enclosing_scope, innate_name);
         si        
 

--- a/src/semantic/symbol/label.ghul
+++ b/src/semantic/symbol/label.ghul
@@ -1,5 +1,8 @@
-
 namespace Semantic.Symbol is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use IoC;
@@ -7,14 +10,14 @@ namespace Semantic.Symbol is
     use Source;
 
     class LABEL: BASE is
-        description: String => "label " + name;
-        short_description: String => description;
+        description: string => "label " + name;
+        short_description: string => description;
 
-        init(location: LOCATION, owner: Scope, name: String) is
+        init(location: LOCATION, owner: Scope, name: string) is
             super.init(location, owner, name);
         si
 
-        specialize(type_map: Collections.MAP[String,Symbol.BASE], owner: GENERIC) -> BASE
+        specialize(type_map: Collections.MAP[string,Symbol.BASE], owner: GENERIC) -> BASE
             => self;
     si
 si

--- a/src/semantic/symbol/method.ghul
+++ b/src/semantic/symbol/method.ghul
@@ -1,4 +1,8 @@
 namespace Semantic.Symbol is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
 
     use Collections.Iterable;
@@ -9,13 +13,13 @@ namespace Semantic.Symbol is
     use Source;
 
     class INSTANCE_METHOD: Function is
-        description: String => qualified_name + "(" + argument_descriptions + ") -> " + return_type + " // method";
+        description: string => qualified_name + "(" + argument_descriptions + ") -> " + return_type + " // method";
         symbol_kind: SYMBOL_KIND => SYMBOL_KIND.METHOD;
         completion_kind: COMPLETION_KIND => COMPLETION_KIND.METHOD;
 
         is_instance: bool => true;
 
-        il_def: String is
+        il_def: string is
             if name !~ "init" then
                 return get_il_def(".method public virtual hidebysig instance default ");
             else
@@ -23,13 +27,13 @@ namespace Semantic.Symbol is
             fi        
         si 
 
-        il_property_def: String => "instance default " + il_type_name;
+        il_property_def: string => "instance default " + il_type_name;
 
-        init(location: LOCATION, owner: Scope, name: String, enclosing_scope: Scope) is
+        init(location: LOCATION, owner: Scope, name: string, enclosing_scope: Scope) is
             super.init(location, owner, name, enclosing_scope);
         si
 
-        declare_closure(location: LOCATION, name: String, owner: Scope, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_closure(location: LOCATION, name: string, owner: Scope, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.INSTANCE_CLOSURE(location, owner, name, enclosing);
 
             declare(location, result, null);
@@ -56,13 +60,13 @@ namespace Semantic.Symbol is
         si
 
         try_override(into: Classy, overridee: Function, logger: Logging.Logger) is
-            @IF.debug()  System.Console.error.write_line("instance try override: " + into + " " + self + " <- " + overridee);
+            @IF.debug()  STD.error.write_line("instance try override: " + into + " " + self + " <- " + overridee);
 
             overridee.try_instance_override_me(into, self, logger);
         si
 
         try_instance_override_me(into: Classy, overrider: Function, logger: Logger) is
-            @IF.debug()  System.Console.error.write_line("instance try override me: " + into + " " + overrider + " <- " + self);
+            @IF.debug()  STD.error.write_line("instance try override me: " + into + " " + overrider + " <- " + self);
 
             let return_type_matches = overrider.ensure_return_type_matches(into, self, true, logger);
 
@@ -95,13 +99,13 @@ namespace Semantic.Symbol is
     si
 
     class STRUCT_METHOD: INSTANCE_METHOD is
-        description: String => qualified_name + "(" + argument_descriptions + ") -> " + return_type + " // method";
+        description: string => qualified_name + "(" + argument_descriptions + ") -> " + return_type + " // method";
         symbol_kind: SYMBOL_KIND => SYMBOL_KIND.METHOD;
         completion_kind: COMPLETION_KIND => COMPLETION_KIND.METHOD;
 
         override: Function public;
 
-        il_def: String is 
+        il_def: string is 
             if il_name !~ ".ctor" && il_name !~ "'.ctor'" then
                 return get_il_def(".method public final virtual hidebysig instance default ");
             else
@@ -109,9 +113,9 @@ namespace Semantic.Symbol is
             fi        
         si 
 
-        il_property_def: String => "instance default " + il_type_name;
+        il_property_def: string => "instance default " + il_type_name;
 
-        init(location: LOCATION, owner: Scope, name: String, enclosing_scope: Scope) is
+        init(location: LOCATION, owner: Scope, name: string, enclosing_scope: Scope) is
             super.init(location, owner, name, enclosing_scope);
         si
 
@@ -119,7 +123,7 @@ namespace Semantic.Symbol is
             return loader.load_struct_method(from, self);
         si
 
-        declare_closure(location: LOCATION, name: String, owner: Scope, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_closure(location: LOCATION, name: string, owner: Scope, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.INSTANCE_CLOSURE(location, owner, name, enclosing);
 
             declare(location, result, null);
@@ -150,14 +154,14 @@ namespace Semantic.Symbol is
     si
 
     class ABSTRACT_METHOD: INSTANCE_METHOD is
-        description: String => qualified_name + "(" + argument_descriptions + ") -> " + return_type + " // abstract method";
+        description: string => qualified_name + "(" + argument_descriptions + ") -> " + return_type + " // abstract method";
 
-        il_def: String => get_il_def(".method public virtual hidebysig abstract instance default ");
-        il_property_def: String => "instance default " + il_type_name;
+        il_def: string => get_il_def(".method public virtual hidebysig abstract instance default ");
+        il_property_def: string => "instance default " + il_type_name;
 
         is_abstract: bool => true;
 
-        init(location: LOCATION, owner: Scope, name: String, enclosing_scope: Scope) is
+        init(location: LOCATION, owner: Scope, name: string, enclosing_scope: Scope) is
             super.init(location, owner, name, enclosing_scope);
 
             assert owner? else "abstract method created without owner";
@@ -217,20 +221,20 @@ namespace Semantic.Symbol is
     si
 
     class STATIC_METHOD: Function is
-        description: String => qualified_name + "(" + argument_descriptions + ") -> " + return_type + " // class method";
+        description: string => qualified_name + "(" + argument_descriptions + ") -> " + return_type + " // class method";
         symbol_kind: SYMBOL_KIND => SYMBOL_KIND.METHOD;
         completion_kind: COMPLETION_KIND => COMPLETION_KIND.METHOD;
 
         override: Function public;
 
-        il_def: String => get_il_def(".method public hidebysig static default ");
-        il_property_def: String => "default " + il_type_name;
+        il_def: string => get_il_def(".method public hidebysig static default ");
+        il_property_def: string => "default " + il_type_name;
 
-        init(location: LOCATION, owner: Scope, name: String, enclosing_scope: Scope) is
+        init(location: LOCATION, owner: Scope, name: string, enclosing_scope: Scope) is
             super.init(location, owner, name, enclosing_scope);
         si
 
-        declare_closure(location: LOCATION, name: String, owner: Scope, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_closure(location: LOCATION, name: string, owner: Scope, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.STATIC_CLOSURE(location, owner, name, enclosing);
 
             declare(location, result, null);

--- a/src/semantic/symbol/method_override_class.ghul
+++ b/src/semantic/symbol/method_override_class.ghul
@@ -1,6 +1,9 @@
 namespace Semantic is
-    use System.String;
-    use System.Console;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
+        use System.Console;
     use System.Text.StringBuilder;
 
     use Collections.Iterable;
@@ -15,6 +18,7 @@ namespace Semantic is
         arguments: LIST[Type.BASE];
 
         init(arguments: LIST[Type.BASE]) is
+            assert arguments? else "override class arguments list is null";
             self.arguments = arguments;
         si
 
@@ -33,7 +37,7 @@ namespace Semantic is
         si
 
         @IL.name("Equals")
-        =~(other: System.Object) -> bool is
+        =~(other: object) -> bool is
             if !other? then
                 return false;
             fi
@@ -55,6 +59,6 @@ namespace Semantic is
             return result;
         si
 
-        to_string() -> String => "(" + new Shim.JOIN[Type.BASE](arguments) + ")";
+        to_string() -> string => "(" + new Shim.JOIN[Type.BASE](arguments) + ")";
     si    
 si

--- a/src/semantic/symbol/method_override_map.ghul
+++ b/src/semantic/symbol/method_override_map.ghul
@@ -1,6 +1,9 @@
 namespace Semantic is
-    use System.String;
-    use System.Text.StringBuilder;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
+        use System.Text.StringBuilder;
 
     use Collections.Iterable;
     use Collections.Iterator;
@@ -11,11 +14,11 @@ namespace Semantic is
     use Symbol.BASE;
     use Symbol.Function;
 
-    class METHOD_OVERRIDE_MAP: System.Object, Iterable[METHOD_OVERRIDE_SET] is
+    class METHOD_OVERRIDE_MAP: object, Iterable[METHOD_OVERRIDE_SET] is
         _symbols: SET[SYMBOL_WRAPPER];
         _mapper: Shim.MAPPER[SYMBOL_WRAPPER,BASE];
 
-        name: String;
+        name: string;
 
         methods: MAP[METHOD_OVERRIDE_CLASS,METHOD_OVERRIDE_SET];
         symbols: Iterable[BASE] => _mapper;
@@ -33,7 +36,7 @@ namespace Semantic is
             return null;            
         si
 
-        init(name: String) is
+        init(name: string) is
             methods = new MAP[METHOD_OVERRIDE_CLASS,METHOD_OVERRIDE_SET]();
             _symbols = new SET[SYMBOL_WRAPPER]();
             _mapper = new Shim.MAPPER[SYMBOL_WRAPPER,BASE](_symbols, (wrapper: SYMBOL_WRAPPER) -> BASE => wrapper.symbol);
@@ -78,7 +81,7 @@ namespace Semantic is
             method_set.add(method);
         si
 
-        to_string() -> String is
+        to_string() -> string is
             let result = new StringBuilder();
 
             for s in methods do

--- a/src/semantic/symbol/method_override_set.ghul
+++ b/src/semantic/symbol/method_override_set.ghul
@@ -1,6 +1,9 @@
 namespace Semantic is
-    use System.String;
-    use System.Text.StringBuilder;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
+        use System.Text.StringBuilder;
     use System.Console;
     
     use Collections.Iterable;
@@ -10,7 +13,7 @@ namespace Semantic is
 
     use Symbol.Function;
 
-    class DUMMY: System.Object, Iterable[Function] is
+    class DUMMY: object, Iterable[Function] is
         _set: SET[FUNCTION_WRAPPER];
 
         _iterable: Iterable[Function];
@@ -40,7 +43,7 @@ namespace Semantic is
             _set.add(new FUNCTION_WRAPPER(method));
         si
                   
-        to_string() -> String => "" + override_class + ": " + new Shim.JOIN[FUNCTION_WRAPPER](_set);
+        to_string() -> string => "" + override_class + ": " + new Shim.JOIN[FUNCTION_WRAPPER](_set);
 
         get_overrider(into: Symbol.BASE) -> Function is
             @IF.debug()  Console.error.write_line("get overrider from: " + into);
@@ -56,7 +59,7 @@ namespace Semantic is
         si
     si
 
-    class METHOD_OVERRIDE_SET: System.Object /*, Iterable[Function]*/ is
+    class METHOD_OVERRIDE_SET: object /*, Iterable[Function]*/ is
         _set: SET[FUNCTION_WRAPPER];
 
         _iterable: Iterable[Function];
@@ -86,7 +89,7 @@ namespace Semantic is
             _set.add(new FUNCTION_WRAPPER(method));
         si
                   
-        to_string() -> String => "" + override_class + ": " + new Shim.JOIN[FUNCTION_WRAPPER](_set);
+        to_string() -> string => "" + override_class + ": " + new Shim.JOIN[FUNCTION_WRAPPER](_set);
 
         get_overrider(into: Symbol.BASE) -> Function is
             @IF.debug()  Console.error.write_line("get overrider from: " + into);

--- a/src/semantic/symbol/namespace.ghul
+++ b/src/semantic/symbol/namespace.ghul
@@ -1,4 +1,8 @@
 namespace Semantic.Symbol is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use IoC;
@@ -9,19 +13,19 @@ namespace Semantic.Symbol is
     class NAMESPACE: ScopedWithEnclosingScope, NamespaceContext, Type.Typed is
         _dotnet_symbol_table: DotNet.SYMBOL_TABLE;
 
-        qualified_name: String;
+        qualified_name: string;
 
         type: Type.BASE;
 
-        description: String => "namespace " + qualified_name;
-        short_description: String => "namespace " + name;
+        description: string => "namespace " + qualified_name;
+        short_description: string => "namespace " + name;
 
         symbol_kind: SYMBOL_KIND => SYMBOL_KIND.NAMESPACE;
         completion_kind: COMPLETION_KIND => COMPLETION_KIND.MODULE;
 
         is_workspace_visible: bool => true;
 
-        il_qualified_name: String is
+        il_qualified_name: string is
             let parts = qualified_name.substring(1).split(['.']);
 
             let result = new System.Text.StringBuilder(qualified_name.length + parts.count * 3);
@@ -45,9 +49,9 @@ namespace Semantic.Symbol is
         si
 
         // FIXME: the IL generation pass is not using the namespace symbol so does not see this:
-        il_def: String => ".namespace " + il_qualified_name;
+        il_def: string => ".namespace " + il_qualified_name;
 
-        init(location: LOCATION, name: String, enclosing_scope: Scope, qualified_name: String) is
+        init(location: LOCATION, name: string, enclosing_scope: Scope, qualified_name: string) is
             super.init(location, self, name, enclosing_scope);
 
             self.qualified_name = qualified_name;
@@ -55,7 +59,7 @@ namespace Semantic.Symbol is
             type = new Type.NAMED(self);
         si
 
-        qualify(name: String) -> String is
+        qualify(name: string) -> string is
             let q = qualified_name;
 
             if q.length > 1 then
@@ -65,7 +69,7 @@ namespace Semantic.Symbol is
             return name;
         si
 
-        find_direct(name: String) -> BASE is
+        find_direct(name: string) -> BASE is
             assert name? else "searched name is null";
 
             let result = super.find_direct(name);
@@ -93,14 +97,14 @@ namespace Semantic.Symbol is
             fi
         si
         
-        find_member(name: String) -> BASE
+        find_member(name: string) -> BASE
             => find_direct(name);
 
-        find_member_matches(prefix: String, matches: Collections.MAP[String, Symbol.BASE]) is
+        find_member_matches(prefix: string, matches: Collections.MAP[string, Symbol.BASE]) is
             find_direct_matches(prefix, matches);
         si
 
-        declare_namespace(location: LOCATION, name: String, namespace_: Symbol.NAMESPACE, symbol_definition_listener: SymbolDefinitionListener) is
+        declare_namespace(location: LOCATION, name: string, namespace_: Symbol.NAMESPACE, symbol_definition_listener: SymbolDefinitionListener) is
             assert name?;
             assert namespace_?;
             assert namespace_.name?;
@@ -108,7 +112,7 @@ namespace Semantic.Symbol is
             declare(location, namespace_, symbol_definition_listener);
         si
 
-        declare_class(location: LOCATION, name: String, arguments: Collections.LIST[String], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_class(location: LOCATION, name: string, arguments: Collections.LIST[string], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.CLASS(location, self, name, arguments, is_stub, enclosing);
 
             declare(location, result, symbol_definition_listener);
@@ -116,7 +120,7 @@ namespace Semantic.Symbol is
             return result;
         si
 
-        declare_trait(location: LOCATION, name: String, arguments: Collections.LIST[String], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_trait(location: LOCATION, name: string, arguments: Collections.LIST[string], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.TRAIT(location, self, name, arguments, is_stub, enclosing);
 
             declare(location, result, symbol_definition_listener);
@@ -124,7 +128,7 @@ namespace Semantic.Symbol is
             return result;
         si
 
-        declare_struct(location: LOCATION, name: String, arguments: Collections.LIST[String], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_struct(location: LOCATION, name: string, arguments: Collections.LIST[string], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.STRUCT(location, self, name, arguments, is_stub, enclosing);
 
             declare(location, result, symbol_definition_listener);
@@ -132,7 +136,7 @@ namespace Semantic.Symbol is
             return result;
         si
 
-        declare_enum(location: LOCATION, name: String, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_enum(location: LOCATION, name: string, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.ENUM_(location, self, name);
 
             declare(location, result, symbol_definition_listener);
@@ -140,7 +144,7 @@ namespace Semantic.Symbol is
             return result;
         si
 
-        declare_innate(location: LOCATION, name: String, innate_name: String, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_innate(location: LOCATION, name: string, innate_name: string, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.INNATE_FUNCTION(location, self, name, enclosing, innate_name);
 
             declare_function_group(location, result, symbol_definition_listener);
@@ -148,7 +152,7 @@ namespace Semantic.Symbol is
             return result;
         si        
 
-        declare_function(location: LOCATION, name: String, is_static: bool, is_private: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_function(location: LOCATION, name: string, is_static: bool, is_private: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.GLOBAL_FUNCTION(location, self, name, enclosing);
 
             declare_function_group(location, result, symbol_definition_listener);
@@ -156,7 +160,7 @@ namespace Semantic.Symbol is
             return result;
         si
 
-        declare_variable(location: LOCATION, name: String, is_static: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_variable(location: LOCATION, name: string, is_static: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.GLOBAL_VARIABLE(location, self, name);
 
             declare(location, result, symbol_definition_listener);
@@ -164,7 +168,7 @@ namespace Semantic.Symbol is
             return result;
         si
 
-        declare_property(location: LOCATION, name: String, is_static: bool, is_private: bool, is_assignable: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
+        declare_property(location: LOCATION, name: string, is_static: bool, is_private: bool, is_assignable: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope is
             var result = new Symbol.GLOBAL_PROPERTY(location, self, name, is_assignable);
 
             declare(location, result, symbol_definition_listener);

--- a/src/semantic/symbol/pointer.ghul
+++ b/src/semantic/symbol/pointer.ghul
@@ -1,4 +1,8 @@
 namespace Semantic.Symbol is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use IoC;
@@ -6,7 +10,7 @@ namespace Semantic.Symbol is
     use Source;
 
     class POINTER: GENERIC is
-        il_type_name: String => arguments[0].il_type_name + "*";
+        il_type_name: string => arguments[0].il_type_name + "*";
 
         init(location: LOCATION, symbol: Symbol.Classy, element_type: Type.BASE) is
             super.init(location, symbol, new Collections.LIST[Type.BASE]([element_type]));

--- a/src/semantic/symbol/property.ghul
+++ b/src/semantic/symbol/property.ghul
@@ -1,4 +1,8 @@
 namespace Semantic.Symbol is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use IoC;
@@ -12,7 +16,7 @@ namespace Semantic.Symbol is
 
         set_type(value: Type.BASE) is type = value; si
 
-        short_description: String => name + ": " + type.short_description;
+        short_description: string => name + ": " + type.short_description;
         symbol_kind: SYMBOL_KIND => SYMBOL_KIND.PROPERTY;
         completion_kind: COMPLETION_KIND => COMPLETION_KIND.PROPERTY;
         is_assignable: bool;
@@ -20,16 +24,16 @@ namespace Semantic.Symbol is
         is_workspace_visible: bool => true;
 
         read_function: Function public;
-        read_function_il_name_override: String public;
+        read_function_il_name_override: string public;
 
         assign_function: Function public;
-        assign_function_il_name_override: String public;
+        assign_function_il_name_override: string public;
 
-        il_def: String => "// .property public " + type.il_type_name + " " + name;
+        il_def: string => "// .property public " + type.il_type_name + " " + name;
 
         overridees: Collections.Iterable[BASE] => _overridees;
 
-        init(location: LOCATION, owner: Scope, name: String, is_assignable: bool) is
+        init(location: LOCATION, owner: Scope, name: string, is_assignable: bool) is
             super.init(location, owner, name);
 
             assert isa Type.SettableTyped(self) else "oops: should implement SettableTyped: " + self.get_type();
@@ -45,7 +49,7 @@ namespace Semantic.Symbol is
             _overridees.add(overridee);
         si
 
-        specialize(type_map: Collections.MAP[String,Type.BASE], owner: GENERIC) -> BASE is
+        specialize(type_map: Collections.MAP[string,Type.BASE], owner: GENERIC) -> BASE is
             let result = cast Property(self.memberwise_clone());
 
             result.specialized_from = self;
@@ -65,7 +69,7 @@ namespace Semantic.Symbol is
             return result;
         si
 
-        to_string() -> String is
+        to_string() -> string is
             let result = new System.Text.StringBuilder();
 
             try
@@ -76,8 +80,8 @@ namespace Semantic.Symbol is
                 // return qualified_name + " (" + short_argument_descriptions + ") -> " + return_type;
                 return result.to_string();
             catch ex: Exception
-                // System.Console.error.write_line("failed to convert function to string: " + name + ", got as far as: " + result);
-                // System.Console.error.write_line(ex);
+                // STD.error.write_line("failed to convert function to string: " + name + ", got as far as: " + result);
+                // STD.error.write_line(ex);
 
                 return "[garbled property: " + result + "]";
             yrt
@@ -85,17 +89,17 @@ namespace Semantic.Symbol is
     si
 
     class INSTANCE_PROPERTY: Property is
-        description: String => qualified_name + ": " + type + " // instance property";
+        description: string => qualified_name + ": " + type + " // instance property";
 
         is_instance: bool => true;
 
-        il_def: String => ".property " + type.il_type_name + " " + il_name + "()";
+        il_def: string => ".property " + type.il_type_name + " " + il_name + "()";
 
-        il_qualified_name: String is
+        il_qualified_name: string is
             return owner_il_name + "::" + il_name;
         si
         
-        init(location: LOCATION, owner: Scope, name: String, is_assignable: bool) is
+        init(location: LOCATION, owner: Scope, name: string, is_assignable: bool) is
             super.init(location, owner, name, is_assignable);
         si
 
@@ -119,15 +123,15 @@ namespace Semantic.Symbol is
     si
 
     class STATIC_PROPERTY: Property is
-        description: String => qualified_name + ": " + type + " // class property";
+        description: string => qualified_name + ": " + type + " // class property";
 
-        il_def: String => ".property " + type.il_type_name + " " + il_name + "()";
+        il_def: string => ".property " + type.il_type_name + " " + il_name + "()";
 
-        il_qualified_name: String is
+        il_qualified_name: string is
             return owner_il_name + "::" + il_name;
         si
         
-        init(location: LOCATION, owner: Scope, name: String, is_assignable: bool) is
+        init(location: LOCATION, owner: Scope, name: string, is_assignable: bool) is
             super.init(location, owner, name, is_assignable);
         si
 
@@ -141,16 +145,16 @@ namespace Semantic.Symbol is
     si
 
     class GLOBAL_PROPERTY: Property is
-        description: String => qualified_name + ": " + type + " // global property";
+        description: string => qualified_name + ": " + type + " // global property";
 
-        init(location: LOCATION, owner: Scope, name: String, is_assignable: bool) is
+        init(location: LOCATION, owner: Scope, name: string, is_assignable: bool) is
             super.init(location, owner, name, is_assignable);
         si
 
         load(location: LOCATION, from: Graph.Value.BASE, loader: SYMBOL_LOADER) -> Graph.Value.BASE is
             /*
             if from? then
-                System.Console.error.write_line("expected from to be null but got " + from);
+                STD.error.write_line("expected from to be null but got " + from);
             fi
             */
 
@@ -160,7 +164,7 @@ namespace Semantic.Symbol is
         store(location: LOCATION, from: Graph.Value.BASE, value: Graph.Value.BASE, loader: SYMBOL_LOADER) -> Graph.Value.BASE is
             /*
             if from? then
-                System.Console.error.write_line("expected from to be null but got " + from);
+                STD.error.write_line("expected from to be null but got " + from);
             fi
             */
 

--- a/src/semantic/symbol/reference.ghul
+++ b/src/semantic/symbol/reference.ghul
@@ -1,4 +1,8 @@
 namespace Semantic.Symbol is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use IoC;
@@ -6,7 +10,7 @@ namespace Semantic.Symbol is
     use Source;
 
     class REFERENCE: GENERIC is
-        il_type_name: String => arguments[0].il_type_name + "&";
+        il_type_name: string => arguments[0].il_type_name + "&";
 
         init(location: LOCATION, symbol: Symbol.Classy, element_type: Type.BASE) is
             super.init(location, symbol, new Collections.LIST[Type.BASE]([element_type]));

--- a/src/semantic/symbol/symbol.ghul
+++ b/src/semantic/symbol/symbol.ghul
@@ -1,4 +1,8 @@
 namespace Semantic.Symbol is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use IoC;
@@ -55,7 +59,7 @@ namespace Semantic.Symbol is
         TYPE_PARAMETER = 26
     si
 
-    class BASE: Object, Scope is
+    class BASE: object, Scope is
         _owner: Scope;
 
         type: Type.BASE => Type.NONE.instance;
@@ -70,20 +74,20 @@ namespace Semantic.Symbol is
 
         owner: Scope public => _owner, = value is
             if _owner? && !value? then
-                System.Console.error.write_line("clear owner " + self);                
+                STD.error.write_line("clear owner " + self);                
             fi
             
             _owner = value;
         si
         
         location: LOCATION;
-        _name: String;
+        _name: string;
 
-        name: String => _name;
+        name: string => _name;
 
         is_internal: bool => _name.starts_with("__");
 
-        qualified_name: String is
+        qualified_name: string is
             // assert owner? else "" + get_type() + " " + name + " has no qualified name because owner is null";
 
             if owner then
@@ -93,7 +97,7 @@ namespace Semantic.Symbol is
             fi
         si
         
-        il_name: String is
+        il_name: string is
             if il_name_override? then
                 return il_name_override;
             else
@@ -101,7 +105,7 @@ namespace Semantic.Symbol is
             fi
         si
 
-        il_qualified_name: String is
+        il_qualified_name: string is
             if
                 il_name_override? && (
                     il_is_built_in_type || 
@@ -119,12 +123,12 @@ namespace Semantic.Symbol is
             fi
         si        
 
-        il_name_override: String public;
+        il_name_override: string public;
 
         // FIXME: can these go somewhere more specific?
         il_is_built_in_type: bool public;
 
-        owner_il_name: String is
+        owner_il_name: string is
             if self.owner == self then
                 throw new Exception("symbol is own owner");
             fi
@@ -134,7 +138,7 @@ namespace Semantic.Symbol is
             return cast BASE(owner).il_qualified_name;
         si
 
-        owner_il_type_name: String is
+        owner_il_type_name: string is
             if self.owner == self then
                 throw new Exception("symbol is own owner");
             fi
@@ -144,7 +148,7 @@ namespace Semantic.Symbol is
             return cast BASE(owner).il_type_name;
         si
 
-        argument_names: Collections.LIST[String] => new Collections.LIST[String](0);        
+        argument_names: Collections.LIST[string] => new Collections.LIST[string](0);        
         arguments: Collections.LIST[Type.BASE] => new Collections.LIST[Type.BASE](0);
         ancestors: Collections.LIST[Type.BASE] => new Collections.LIST[Type.BASE](0);
 
@@ -163,8 +167,8 @@ namespace Semantic.Symbol is
 
         access: ACCESS => ACCESS.PUBLIC;
 
-        description: String => qualified_name;
-        short_description: String => name;
+        description: string => qualified_name;
+        short_description: string => name;
 
         is_workspace_visible:
              bool => false;
@@ -180,12 +184,12 @@ namespace Semantic.Symbol is
         is_class: bool => false;
         is_trait: bool => false;
 
-        il_type_name: String => il_qualified_name;
-        il_token_name: String => il_type_name;
+        il_type_name: string => il_qualified_name;
+        il_token_name: string => il_type_name;
 
-        il_def: String => name;
+        il_def: string => name;
 
-        =~(other: Object) -> bool is
+        =~(other: object) -> bool is
             if !other? && !isa BASE(other) then
                 return false;
             fi
@@ -195,7 +199,7 @@ namespace Semantic.Symbol is
 
         =~(other: BASE) -> bool => self == other;
         
-        init(location: LOCATION, owner: Scope, name: String) is
+        init(location: LOCATION, owner: Scope, name: string) is
             self.location = location;
             self.owner = owner;
             _name = name;
@@ -207,22 +211,22 @@ namespace Semantic.Symbol is
 
         get_ancestor(i: int) -> Type.BASE is
             if ancestors.count > 0 then
-                System.Console.error.write_line("oops: " + self.get_type() + " " + self + " has ancestors but expected none");
+                STD.error.write_line("oops: " + self.get_type() + " " + self + " has ancestors but expected none");
 
                 for a in ancestors do
-                    System.Console.error.write_line("ancestor: " + a);                    
+                    STD.error.write_line("ancestor: " + a);                    
                 od
             fi
 
             throw new NotImplementedException("" + get_type() + " has no ancestor " + i);
         si
 
-        qualify(name: String) -> String => qualified_name + "." + name;
+        qualify(name: string) -> string => qualified_name + "." + name;
 
         compare_type(other: Symbol.BASE) -> Type.MATCH
             => Type.MATCH.DIFFERENT;
 
-        specialize(type_map: Collections.MAP[String,Type.BASE], owner: GENERIC) -> BASE is
+        specialize(type_map: Collections.MAP[string,Type.BASE], owner: GENERIC) -> BASE is
             throw new NotImplementedException("" + get_type() + " cannot be specialized: " + self);
         si
 
@@ -254,11 +258,11 @@ namespace Semantic.Symbol is
             throw new System.NotImplementedException("implement me");
         si
         
-        find_direct(name: String) -> BASE => null;
+        find_direct(name: string) -> BASE => null;
 
-        find_member(name: String) -> BASE => null;
+        find_member(name: string) -> BASE => null;
 
-        find_enclosing(name: String) -> BASE => null;
+        find_enclosing(name: string) -> BASE => null;
 
         // FIXME: the way we handle inheritance and specialization of generics makes it tricky to get the correctly specialized owner of methods that
         // are interited from a super class or trait. The following works, but the fact that it's needed suggests we ought to be tracking this some other way
@@ -366,23 +370,23 @@ namespace Semantic.Symbol is
             return result;
         si
         
-        find_direct_matches(prefix: String, matches: Collections.MAP[String, Symbol.BASE]) is
+        find_direct_matches(prefix: string, matches: Collections.MAP[string, Symbol.BASE]) is
         si
 
-        find_ancestor_matches(prefix: String, matches: Collections.MAP[String, Symbol.BASE]) is
+        find_ancestor_matches(prefix: string, matches: Collections.MAP[string, Symbol.BASE]) is
         si
 
-        find_member_matches(prefix: String, matches: Collections.MAP[String, Symbol.BASE]) is
+        find_member_matches(prefix: string, matches: Collections.MAP[string, Symbol.BASE]) is
         si
 
-        find_enclosing_matches(prefix: String, matches: Collections.MAP[String, Symbol.BASE]) is
+        find_enclosing_matches(prefix: string, matches: Collections.MAP[string, Symbol.BASE]) is
         si
 
         collapse_group_if_single_member() -> Symbol.BASE is
             return self;
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             "" + get_type() + " '" + name + "' @ " + location;
     si
 
@@ -392,7 +396,7 @@ namespace Semantic.Symbol is
         symbols: Collections.Iterable[BASE] => _symbols.values;
         is_empty: bool => _symbols.count == 0;
 
-        init(location: LOCATION, owner: Scope, name: String) is
+        init(location: LOCATION, owner: Scope, name: string) is
             super.init(location, owner, name);
             _symbols = new SYMBOL_MAP();
         si
@@ -401,9 +405,9 @@ namespace Semantic.Symbol is
             _symbols.clear();
         si
 
-        find_direct(name: String) -> BASE => _symbols[name];
+        find_direct(name: string) -> BASE => _symbols[name];
 
-        find_direct_matches(prefix: String, matches: Collections.MAP[String, Symbol.BASE]) is
+        find_direct_matches(prefix: string, matches: Collections.MAP[string, Symbol.BASE]) is
             _symbols.find_matches(prefix, matches);
         si
 
@@ -426,51 +430,51 @@ namespace Semantic.Symbol is
             _symbols[symbol.name] = symbol;
         si
 
-        declare_undefined(location: LOCATION, kind: String, name: String) -> UNDEFINED is
+        declare_undefined(location: LOCATION, kind: string, name: string) -> UNDEFINED is
             CONTAINER.instance.logger.error(location, "cannot declare " + kind + " here");
 
             return new UNDEFINED(location, self, name);
         si
 
-        declare_namespace(location: LOCATION, name: String, namespace_: NAMESPACE, symbol_definition_listener: SymbolDefinitionListener) is
+        declare_namespace(location: LOCATION, name: string, namespace_: NAMESPACE, symbol_definition_listener: SymbolDefinitionListener) is
             declare_undefined(location, "namespace", name);
         si
 
-        declare_class(location: LOCATION, name: String, arguments: Collections.LIST[String], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_class(location: LOCATION, name: string, arguments: Collections.LIST[string], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "class", name);
 
-        declare_trait(location: LOCATION, name: String, arguments: Collections.LIST[String], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_trait(location: LOCATION, name: string, arguments: Collections.LIST[string], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "trait", name);
 
-        declare_struct(location: LOCATION, name: String, arguments: Collections.LIST[String], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_struct(location: LOCATION, name: string, arguments: Collections.LIST[string], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "struct", name);
 
-        declare_type(location: LOCATION, name: String, index: int, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_type(location: LOCATION, name: string, index: int, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "type", name);
 
-        declare_enum(location: LOCATION, name: String, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_enum(location: LOCATION, name: string, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "enum", name);
 
-        declare_enum_member(location: LOCATION, name: String, value: String, symbol_definition_listener: SymbolDefinitionListener) is
+        declare_enum_member(location: LOCATION, name: string, value: string, symbol_definition_listener: SymbolDefinitionListener) is
             declare_undefined(location, "enum member", name);
         si
 
-        declare_closure(location: LOCATION, name: String, owner: Scope, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_closure(location: LOCATION, name: string, owner: Scope, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "closure", name);
 
-        declare_innate(location: LOCATION, name: String, innate_name: String, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_innate(location: LOCATION, name: string, innate_name: string, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "innate", name);
 
-        declare_function(location: LOCATION, name: String, is_static: bool, is_private: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_function(location: LOCATION, name: string, is_static: bool, is_private: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "function", name);
 
-        declare_variable(location: LOCATION, name: String, is_static: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_variable(location: LOCATION, name: string, is_static: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "variable", name);
 
-        declare_property(location: LOCATION, name: String, is_static: bool, is_private: bool, is_assignable: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_property(location: LOCATION, name: string, is_static: bool, is_private: bool, is_assignable: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "property", name);
 
-        declare_label(location: LOCATION, name: String, symbol_definition_listener: SymbolDefinitionListener) is
+        declare_label(location: LOCATION, name: string, symbol_definition_listener: SymbolDefinitionListener) is
             declare_undefined(location, "label", name);
         si
 
@@ -573,59 +577,59 @@ namespace Semantic.Symbol is
     class UNDEFINED: BASE, Scope, DeclarationContext, Type.Typed is
         type: Type.BASE => new Type.ANY();
 
-        description: String => "undefined";
+        description: string => "undefined";
 
-        il_def: String => "undefined has no il_def: " + self;       
+        il_def: string => "undefined has no il_def: " + self;       
 
-        init(location: LOCATION, owner: Scope, name: String) is
+        init(location: LOCATION, owner: Scope, name: string) is
             super.init(location, owner, name);
         si
 
-        declare_undefined(location: LOCATION, kind: String, name: String) -> UNDEFINED is
+        declare_undefined(location: LOCATION, kind: string, name: string) -> UNDEFINED is
             CONTAINER.instance.logger.error(location, "cannot declare " + kind + " here");
 
             return new UNDEFINED(location, self, name);
         si
 
-        declare_namespace(location: LOCATION, name: String, namespace_: NAMESPACE, symbol_definition_listener: SymbolDefinitionListener) is
+        declare_namespace(location: LOCATION, name: string, namespace_: NAMESPACE, symbol_definition_listener: SymbolDefinitionListener) is
             declare_undefined(location, "namespace", name);
         si
 
-        declare_class(location: LOCATION, name: String, arguments: Collections.LIST[String], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_class(location: LOCATION, name: string, arguments: Collections.LIST[string], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "class", name);
 
-        declare_trait(location: LOCATION, name: String, arguments: Collections.LIST[String], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_trait(location: LOCATION, name: string, arguments: Collections.LIST[string], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "trait", name);
 
-        declare_struct(location: LOCATION, name: String, arguments: Collections.LIST[String], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_struct(location: LOCATION, name: string, arguments: Collections.LIST[string], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "struct", name);
 
-        declare_type(location: LOCATION, name: String, index: int, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_type(location: LOCATION, name: string, index: int, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "type", name);
 
-        declare_enum(location: LOCATION, name: String, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_enum(location: LOCATION, name: string, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "enum", name);
 
-        declare_enum_member(location: LOCATION, name: String, value: String, symbol_definition_listener: SymbolDefinitionListener) is
+        declare_enum_member(location: LOCATION, name: string, value: string, symbol_definition_listener: SymbolDefinitionListener) is
             declare_undefined(location, "enum member", name);
         si
 
-        declare_closure(location: LOCATION, name: String, owner: Scope, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_closure(location: LOCATION, name: string, owner: Scope, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "closure", name);
 
-        declare_innate(location: LOCATION, name: String, innate_name: String, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_innate(location: LOCATION, name: string, innate_name: string, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "innate", name);
 
-        declare_function(location: LOCATION, name: String, is_static: bool, is_private: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_function(location: LOCATION, name: string, is_static: bool, is_private: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "function", name);
 
-        declare_variable(location: LOCATION, name: String, is_static: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_variable(location: LOCATION, name: string, is_static: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "variable", name);
 
-        declare_property(location: LOCATION, name: String, is_static: bool, is_private: bool, is_assignable: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
+        declare_property(location: LOCATION, name: string, is_static: bool, is_private: bool, is_assignable: bool, symbol_definition_listener: SymbolDefinitionListener) -> Scope =>
             declare_undefined(location, "undefine", name);        
 
-        declare_label(location: LOCATION, name: String, symbol_definition_listener: SymbolDefinitionListener) is
+        declare_label(location: LOCATION, name: string, symbol_definition_listener: SymbolDefinitionListener) is
             declare_undefined(location, "label", name);
         si
     si
@@ -633,13 +637,13 @@ namespace Semantic.Symbol is
     class ScopedWithEnclosingScope: Scoped is
         enclosing_scope: Scope;
 
-        init(location: LOCATION, owner: Scope, name: String, enclosing_scope: Scope) is
+        init(location: LOCATION, owner: Scope, name: string, enclosing_scope: Scope) is
             super.init(location, owner, name);
 
             self.enclosing_scope = enclosing_scope;
         si
 
-        find_enclosing_only(name: String) -> BASE is
+        find_enclosing_only(name: string) -> BASE is
             if enclosing_scope? then
                 return enclosing_scope.find_enclosing(name);
             fi
@@ -647,7 +651,7 @@ namespace Semantic.Symbol is
             return null;
         si
 
-        find_enclosing(name: String) -> BASE is
+        find_enclosing(name: string) -> BASE is
             var result = find_direct(name);
 
             if result? then
@@ -657,13 +661,13 @@ namespace Semantic.Symbol is
             fi
         si
 
-        find_enclosing_only_matches(prefix: String, matches: Collections.MAP[String, Symbol.BASE]) is
+        find_enclosing_only_matches(prefix: string, matches: Collections.MAP[string, Symbol.BASE]) is
             if enclosing_scope? then
                 enclosing_scope.find_enclosing_matches(prefix, matches);
             fi
         si
 
-        find_enclosing_matches(prefix: String, matches: Collections.MAP[String, Symbol.BASE]) is
+        find_enclosing_matches(prefix: string, matches: Collections.MAP[string, Symbol.BASE]) is
             find_direct_matches(prefix, matches);
             find_enclosing_only_matches(prefix, matches);
         si

--- a/src/semantic/symbol/symbol_inheritance_resolver.ghul
+++ b/src/semantic/symbol/symbol_inheritance_resolver.ghul
@@ -1,6 +1,9 @@
 namespace Semantic is
-    use System.String;
-    use System.Console;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
+        use System.Console;
 
     use Collections.Iterable;
     use Collections.Iterator;
@@ -26,7 +29,7 @@ namespace Semantic is
 
             let logger = IoC.CONTAINER.instance.logger;
             
-            let overridees = new Collections.MAP[String,METHOD_OVERRIDE_MAP]();
+            let overridees = new Collections.MAP[string,METHOD_OVERRIDE_MAP]();
 
             let members = into.get_all_direct_ancestor_members();
 
@@ -43,7 +46,7 @@ namespace Semantic is
                 overridees_with_this_name.add(symbol);
             od
 
-            let entries = new Shim.JOIN[Collections.Pair[String,METHOD_OVERRIDE_MAP]](overridees, "\n    ");
+            let entries = new Shim.JOIN[Collections.Pair[string,METHOD_OVERRIDE_MAP]](overridees, "\n    ");
 
             @IF.debug() Console.error.write_line("all potential overridees:");
             @IF.debug() Console.error.write_line("    " + entries);
@@ -100,7 +103,7 @@ namespace Semantic is
         si
         
         try_inherit(
-            name: String,
+            name: string,
             overriders: METHOD_OVERRIDE_SET, 
             other_overrider_symbol: BASE,
             overridees: METHOD_OVERRIDE_SET, 
@@ -210,8 +213,8 @@ namespace Semantic is
                     else
                         // @IF.debug() Console.error.write_line("MO 008 A2: " + into);
 
-                        // let function_names = new Shim.MAPPER[FUNCTION_WRAPPER,String](
-                        //     _set, (function: FUNCTION_WRAPPER) -> String => $1.to_strin
+                        // let function_names = new Shim.MAPPER[FUNCTION_WRAPPER,string](
+                        //     _set, (function: FUNCTION_WRAPPER) -> string => $1.to_strin
                         // );
 
                         for os in other_overridee_symbols do
@@ -278,7 +281,7 @@ namespace Semantic is
         si
 
         try_inherit(
-            name: String,
+            name: string,
             overrider_symbol: BASE,
             overridee_symbols: Iterable[BASE],
             logger: Logging.Logger
@@ -388,7 +391,7 @@ namespace Semantic is
             fi
         si
 
-        get_overriders_map_for(overridee_name: String) -> METHOD_OVERRIDE_MAP is
+        get_overriders_map_for(overridee_name: string) -> METHOD_OVERRIDE_MAP is
             let result = new METHOD_OVERRIDE_MAP(overridee_name);
 
             let symbol = into.find_direct(overridee_name);

--- a/src/semantic/symbol/symbol_wrapper.ghul
+++ b/src/semantic/symbol/symbol_wrapper.ghul
@@ -1,6 +1,9 @@
 namespace Semantic is
-    use System.String;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
 
+    
     use Symbol.BASE;
 
     class SYMBOL_WRAPPER is
@@ -10,7 +13,7 @@ namespace Semantic is
         symbol: BASE;
 
         @IL.name("Equals")
-        =~(other: System.Object) -> bool is
+        =~(other: object) -> bool is
             if !other? then
                 return false;
             elif !isa SYMBOL_WRAPPER(other) then
@@ -36,6 +39,6 @@ namespace Semantic is
 
         get_hash_code() -> int => _hash;
 
-        to_string() -> String => "" + symbol; //  + " (from " + _root_symbol + ", hash: " + _hash + ")";
+        to_string() -> string => "" + symbol; //  + " (from " + _root_symbol + ", hash: " + _hash + ")";
     si
 si

--- a/src/semantic/symbol/type.ghul
+++ b/src/semantic/symbol/type.ghul
@@ -1,4 +1,8 @@
 namespace Semantic.Symbol is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use IoC;
@@ -14,9 +18,9 @@ namespace Semantic.Symbol is
 
         index: int;
 
-        il_def: String => "type has no il_def: " + self;
+        il_def: string => "type has no il_def: " + self;
 
-        il_type_name: String => "!" + index;
+        il_type_name: string => "!" + index;
 
         // FIXME: should ancestor be a type not a symbol? We could then just use BASE.ancestors.
         // We'll need multiple ancestors to support multiple constraints anyway
@@ -34,16 +38,16 @@ namespace Semantic.Symbol is
         symbol_kind: SYMBOL_KIND => SYMBOL_KIND.TYPE_PARAMETER;
         completion_kind: COMPLETION_KIND => COMPLETION_KIND.VARIABLE;
 
-        description: String => name + ": " + type + " // type variable";
-        short_description: String => description;
+        description: string => name + ": " + type + " // type variable";
+        short_description: string => description;
 
-        init(location: LOCATION, owner: Scope, name: String, index: int) is
+        init(location: LOCATION, owner: Scope, name: string, index: int) is
             init(location, owner, name, new Type.NAMED(self));
 
             self.index = index; 
         si
 
-        init(location: LOCATION, owner: Scope, name: String, type: Type.BASE) is
+        init(location: LOCATION, owner: Scope, name: string, type: Type.BASE) is
             super.init(location, owner, name);
 
             assert isa Type.SettableTyped(self) else "oops: should implement SettableTyped: " + self.get_type();
@@ -55,7 +59,7 @@ namespace Semantic.Symbol is
             return ancestors[i];
         si
 
-        find_member(name: String) -> BASE is
+        find_member(name: string) -> BASE is
             if ancestor? then
                 let result = ancestor.find_member(name);
 
@@ -63,7 +67,7 @@ namespace Semantic.Symbol is
             fi
         si
 
-        find_member_matches(prefix: String, matches: Collections.MAP[String, Symbol.BASE]) is
+        find_member_matches(prefix: string, matches: Collections.MAP[string, Symbol.BASE]) is
             if ancestor? then
                 ancestor.find_member_matches(prefix, matches);
             fi
@@ -77,7 +81,7 @@ namespace Semantic.Symbol is
             return Type.MATCH.DIFFERENT;
         si
 
-        specialize(type_map: Collections.MAP[String,Type.BASE], owner: GENERIC) -> BASE is
+        specialize(type_map: Collections.MAP[string,Type.BASE], owner: GENERIC) -> BASE is
             if type_map.contains_key(name) then
                 return new TYPE(
                     location,

--- a/src/semantic/symbol/variable.ghul
+++ b/src/semantic/symbol/variable.ghul
@@ -1,4 +1,8 @@
 namespace Semantic.Symbol is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use IoC;
@@ -9,18 +13,18 @@ namespace Semantic.Symbol is
         type: Type.BASE;
         set_type(value: Type.BASE) is type = value; si
 
-        short_description: String => name + ": " + type.short_description;
+        short_description: string => name + ": " + type.short_description;
 
         symbol_kind: SYMBOL_KIND => SYMBOL_KIND.VARIABLE;
         completion_kind: COMPLETION_KIND => COMPLETION_KIND.VARIABLE;
 
-        init(location: LOCATION, owner: Scope, name: String) is
+        init(location: LOCATION, owner: Scope, name: string) is
             super.init(location, owner, name);
 
             assert isa Type.SettableTyped(self) else "oops: should implement SettableTyped: " + self.get_type();
         si
 
-        specialize(type_map: Collections.MAP[String,Type.BASE], owner: GENERIC) -> BASE is
+        specialize(type_map: Collections.MAP[string,Type.BASE], owner: GENERIC) -> BASE is
             let result = cast Variable(memberwise_clone());
 
             result.specialized_from = self;
@@ -36,20 +40,20 @@ namespace Semantic.Symbol is
             return result;
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             "" + get_type() + " " + name + " @ " + location + " type: " + type;
     si
 
     class LOCAL_VARIABLE: Variable, Type.SettableTyped is
-        description: String => name + ": " + type + " // local variable";
+        description: string => name + ": " + type + " // local variable";
 
-        il_def: String is
+        il_def: string is
             assert type? else "local has null type: " + name + " " + location;
             
             return ".locals init (" + type.il_type_name + " " + il_name + ")";
         si    
 
-        init(location: LOCATION, owner: Scope, name: String) is
+        init(location: LOCATION, owner: Scope, name: string) is
             super.init(location, owner, name);
 
             il_name_override = IoC.CONTAINER.instance.local_id_generator.get_unique_il_name_for(name);
@@ -67,11 +71,11 @@ namespace Semantic.Symbol is
     si
 
     class LOCAL_ARGUMENT: Variable, Type.SettableTyped is
-        description: String => name + ": " + type + " // argument";
+        description: string => name + ": " + type + " // argument";
 
-        il_def: String => null;
+        il_def: string => null;
 
-        init(location: LOCATION, owner: Scope, name: String) is
+        init(location: LOCATION, owner: Scope, name: string) is
             super.init(location, owner, name);
         si
 
@@ -89,9 +93,9 @@ namespace Semantic.Symbol is
     class GLOBAL_VARIABLE: Variable, Type.SettableTyped is
         is_workspace_visible: bool => true;
 
-        il_def: String => "// global variable " + type.il_type_name + " " + name;
+        il_def: string => "// global variable " + type.il_type_name + " " + name;
 
-        init(location: LOCATION, owner: Scope, name: String) is
+        init(location: LOCATION, owner: Scope, name: string) is
             super.init(location, owner, name);
         si
 
@@ -113,8 +117,8 @@ namespace Semantic.Symbol is
         completion_kind: COMPLETION_KIND => COMPLETION_KIND.FIELD;
 
         is_workspace_visible: bool => true;
-        il_qualified_name: String => owner_il_name + "::" + il_name;
-        il_type_name: String is
+        il_qualified_name: string => owner_il_name + "::" + il_name;
+        il_type_name: string is
             let t = unspecialized_type;
 
             if !t? then
@@ -124,11 +128,11 @@ namespace Semantic.Symbol is
             return t.il_type_name + " " + owner_il_type_name + "::" + il_name;
         si
 
-        init(location: LOCATION, owner: Scope, name: String) is
+        init(location: LOCATION, owner: Scope, name: string) is
             super.init(location, owner, name);
         si
 
-        specialize(type_map: Collections.MAP[String,Type.BASE], owner: GENERIC) -> BASE is
+        specialize(type_map: Collections.MAP[string,Type.BASE], owner: GENERIC) -> BASE is
             let result = cast Field(super.specialize(type_map, owner));
 
             result.unspecialized_type = type;
@@ -138,13 +142,13 @@ namespace Semantic.Symbol is
     si
 
     class INSTANCE_FIELD: Field is
-        description: String => qualified_name + ": " + type + " // field";
+        description: string => qualified_name + ": " + type + " // field";
 
         is_instance: bool => true;
 
-        il_def: String => ".field public " + type.il_type_name + " " + il_name;
+        il_def: string => ".field public " + type.il_type_name + " " + il_name;
 
-        init(location: LOCATION, owner: Scope, name: String) is
+        init(location: LOCATION, owner: Scope, name: string) is
             super.init(location, owner, name);
         si
 
@@ -168,11 +172,11 @@ namespace Semantic.Symbol is
     si
 
     class STATIC_FIELD: Field is
-        description: String => qualified_name + ": " + type + " // class field";
+        description: string => qualified_name + ": " + type + " // class field";
 
-        il_def: String => ".field public static " + type.il_type_name + " " + il_name;
+        il_def: string => ".field public static " + type.il_type_name + " " + il_name;
 
-        init(location: LOCATION, owner: Scope, name: String) is
+        init(location: LOCATION, owner: Scope, name: string) is
             super.init(location, owner, name);
         si
 
@@ -186,9 +190,9 @@ namespace Semantic.Symbol is
     si
 
     class CAPTURED_VALUE: Variable is
-        description: String => name + ": " + type + " // captured value"; 
+        description: string => name + ": " + type + " // captured value"; 
 
-        init(location: LOCATION, owner: Scope, name: String) is
+        init(location: LOCATION, owner: Scope, name: string) is
             super.init(location, owner, name);
         si
 

--- a/src/semantic/symbol_definition_locations.ghul
+++ b/src/semantic/symbol_definition_locations.ghul
@@ -1,4 +1,8 @@
 namespace Semantic is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Source;
@@ -7,11 +11,11 @@ namespace Semantic is
         add_symbol_definition(location: LOCATION, symbol: Symbol.BASE);
     si
 
-    class SYMBOL_DEFINITION_LOCATIONS: Object, SymbolDefinitionListener is
+    class SYMBOL_DEFINITION_LOCATIONS: object, SymbolDefinitionListener is
         _symbol_use_listener: SymbolUseListener;
 
-        _symbol_definition_map: Collections.MAP[String,Collections.LIST[Symbol.BASE]];
-        _workspace_definition_map: Collections.MAP[String,Collections.LIST[Symbol.BASE]];
+        _symbol_definition_map: Collections.MAP[string,Collections.LIST[Symbol.BASE]];
+        _workspace_definition_map: Collections.MAP[string,Collections.LIST[Symbol.BASE]];
 
         init(symbol_use_listener: SymbolUseListener) is
             _symbol_use_listener = symbol_use_listener;
@@ -20,13 +24,13 @@ namespace Semantic is
         si
 
         dump_counts() is
-            System.Console.error.write_line("symbol definition map: " + _symbol_definition_map.count);
-            System.Console.error.write_line("workspace definition map: " + _workspace_definition_map.count);
+            STD.error.write_line("symbol definition map: " + _symbol_definition_map.count);
+            STD.error.write_line("workspace definition map: " + _workspace_definition_map.count);
         si                
 
         clear() is
-            _symbol_definition_map = new Collections.MAP[String,Collections.LIST[Symbol.BASE]]();
-            _workspace_definition_map = new Collections.MAP[String,Collections.LIST[Symbol.BASE]]();
+            _symbol_definition_map = new Collections.MAP[string,Collections.LIST[Symbol.BASE]]();
+            _workspace_definition_map = new Collections.MAP[string,Collections.LIST[Symbol.BASE]]();
         si
 
         add_symbol_definition(location: LOCATION, symbol: Symbol.BASE) is
@@ -37,7 +41,7 @@ namespace Semantic is
             fi
         si
 
-        find_definitions_from_file(file_name: String, workspace_search: bool) -> Collections.Iterable[Symbol.BASE] is
+        find_definitions_from_file(file_name: string, workspace_search: bool) -> Collections.Iterable[Symbol.BASE] is
             if workspace_search then
                 return get_workspace_list_for_file_name(file_name);
             else
@@ -45,7 +49,7 @@ namespace Semantic is
             fi
         si
 
-        get_symbol_list_for_file_name(file_name: String) -> Collections.LIST[Symbol.BASE] is
+        get_symbol_list_for_file_name(file_name: string) -> Collections.LIST[Symbol.BASE] is
             if _symbol_definition_map.contains_key(file_name) then
                 return _symbol_definition_map[file_name];
             fi
@@ -57,7 +61,7 @@ namespace Semantic is
             return result;
         si
 
-        get_workspace_list_for_file_name(file_name: String) -> Collections.LIST[Symbol.BASE] is
+        get_workspace_list_for_file_name(file_name: string) -> Collections.LIST[Symbol.BASE] is
             if _workspace_definition_map.contains_key(file_name) then
                 return _workspace_definition_map[file_name];                
             fi

--- a/src/semantic/symbol_loader.ghul
+++ b/src/semantic/symbol_loader.ghul
@@ -1,10 +1,14 @@
 namespace Semantic is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
 
     use Logging;
 
     class SYMBOL_LOADER is
-        _null_find_symbol: (String) -> Symbol.BASE static;
+        _null_find_symbol: (string) -> Symbol.BASE static;
     
         _logger: Logger;
         
@@ -16,7 +20,7 @@ namespace Semantic is
 
         _ghul_symbol_lookup: GHUL_SYMBOL_LOOKUP;
 
-        find_symbol: (String) -> Symbol.BASE public;
+        find_symbol: (string) -> Symbol.BASE public;
     
         init(
             logger: Logger,
@@ -30,7 +34,7 @@ namespace Semantic is
             // calls to null anon functions don't always produce a sane stack trace
             if _null_find_symbol == null then
                 _null_find_symbol = 
-                    (name: String) -> Symbol.BASE is
+                    (name: string) -> Symbol.BASE is
                         throw new NotImplementedException("find_symbol is not set");
                     si;
             fi
@@ -44,7 +48,7 @@ namespace Semantic is
             find_symbol = _null_find_symbol;
         si
 
-        load_integer_literal(value: String) -> Graph.Value.BASE =>
+        load_integer_literal(value: string) -> Graph.Value.BASE =>
             new Graph.Value.Literal.NUMBER(value, _ghul_symbol_lookup.get_type("int"), "i4");
 
         load_namespace(symbol: Symbol.NAMESPACE) -> Graph.Value.BASE =>

--- a/src/semantic/symbol_map.ghul
+++ b/src/semantic/symbol_map.ghul
@@ -1,18 +1,22 @@
 namespace Semantic is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
 
     class SYMBOL_MAP is
-        _map: Collections.MAP[String,Symbol.BASE];
+        _map: Collections.MAP[string,Symbol.BASE];
 
         count: int => _map.count;
         
-        values: Collections.VALUE_COLLECTION[String,Symbol.BASE] => _map.values;
+        values: Collections.VALUE_COLLECTION[string,Symbol.BASE] => _map.values;
 
         init() is
-            _map = new Collections.MAP[String,Symbol.BASE]();
+            _map = new Collections.MAP[string,Symbol.BASE]();
         si
 
-        [name: String]: Symbol.BASE is
+        [name: string]: Symbol.BASE is
             if _map.contains_key(name) then
                 return _map[name];                
             fi            
@@ -21,17 +25,17 @@ namespace Semantic is
             _map[name] = v;
         si
 
-        add(name: String, value: Symbol.BASE) is _map.add(name, value); si
+        add(name: string, value: Symbol.BASE) is _map.add(name, value); si
 
-        contains_key(name: String) -> bool => _map.contains_key(name);
+        contains_key(name: string) -> bool => _map.contains_key(name);
 
-        remove(name: String) is _map.remove(name); si
+        remove(name: string) is _map.remove(name); si
                 
         clear() is _map.clear(); si
 
         find_matches(
-            prefix: String,
-            matches: Collections.MAP[String,Semantic.Symbol.BASE])
+            prefix: string,
+            matches: Collections.MAP[string,Semantic.Symbol.BASE])
         is
             if prefix.length == 0 then
                 for p in _map do
@@ -51,9 +55,9 @@ namespace Semantic is
         si
 
         add_match(
-            name: String,
+            name: string,
             match: Semantic.Symbol.BASE,
-            matches: Collections.MAP[String,Semantic.Symbol.BASE]
+            matches: Collections.MAP[string,Semantic.Symbol.BASE]
         ) static is
             if !name.starts_with("__") && !matches.contains_key(name) then
                 matches[name] = match.collapse_group_if_single_member();
@@ -61,8 +65,8 @@ namespace Semantic is
         si
 
         // find_first_match(
-        //     prefix: String
-        // ) -> Collection.TreeNode[String,Semantic.Symbol.BASE] is
+        //     prefix: string
+        // ) -> Collection.TreeNode[string,Semantic.Symbol.BASE] is
         // si        
     si
 si

--- a/src/semantic/symbol_table.ghul
+++ b/src/semantic/symbol_table.ghul
@@ -1,4 +1,8 @@
 namespace Semantic is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
         use Logging;
     use Source;
@@ -93,7 +97,7 @@ namespace Semantic is
         si
 
         dump_counts() is
-            System.Console.error.write_line("scopes map: " + _scopes.count);
+            STD.error.write_line("scopes map: " + _scopes.count);
         si        
 
         clear() is
@@ -161,7 +165,7 @@ namespace Semantic is
             _stack.remove_at(_stack.count - 1);
         si
 
-        to_string() -> String is
+        to_string() -> string is
             var result = new System.Text.StringBuilder();
 
             result.append("symbol table:\n");

--- a/src/semantic/symbol_use_locations.ghul
+++ b/src/semantic/symbol_use_locations.ghul
@@ -1,4 +1,8 @@
 namespace Semantic is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
         use Collections;
 
@@ -8,7 +12,7 @@ namespace Semantic is
         add_symbol_use(location: LOCATION, symbol: Symbol.BASE);
     si
 
-    class SYMBOL_USE_LOCATIONS: Object, SymbolUseListener is
+    class SYMBOL_USE_LOCATIONS: object, SymbolUseListener is
         _symbol_use_map: LOCATION_MAP[Symbol.BASE];
         _symbol_reference_map: Collections.MAP[Symbol.BASE,Collections.SET[LOCATION]];
 
@@ -18,7 +22,7 @@ namespace Semantic is
 
         dump_counts() is
             _symbol_use_map.dump_counts();
-            System.Console.error.write_line("symbol reference map: " + _symbol_reference_map.count);
+            STD.error.write_line("symbol reference map: " + _symbol_reference_map.count);
         si        
 
         clear() is
@@ -41,7 +45,7 @@ namespace Semantic is
         add_symbol_reference(location: LOCATION, symbol: Symbol.BASE) is
             if symbol.overridees? then
                 for o in symbol.overridees do
-                    // System.Console.error.write_line("add overridden symbol reference: " + symbol + " overrides " + o);
+                    // STD.error.write_line("add overridden symbol reference: " + symbol + " overrides " + o);
                     add_symbol_reference(location, o);
                 od  
             fi
@@ -54,7 +58,7 @@ namespace Semantic is
             fi
         si
 
-        find_definition_from_use(file_name: String, line: int, column: int) -> Symbol.BASE is
+        find_definition_from_use(file_name: string, line: int, column: int) -> Symbol.BASE is
             let matches = _symbol_use_map.find_all(file_name, line, column);
 
             if matches.count == 0 then
@@ -104,14 +108,14 @@ namespace Semantic is
     si
 
     class LOCATION_MAP[T] is
-        file_name_to_file: Collections.MAP[String, Collections.MAP[int, Collections.LIST[Pair[LOCATION,T]]]];
+        file_name_to_file: Collections.MAP[string, Collections.MAP[int, Collections.LIST[Pair[LOCATION,T]]]];
 
         init() is
-            file_name_to_file = new Collections.MAP[String, Collections.MAP[int, Collections.LIST[Pair[LOCATION,T]]]]();
+            file_name_to_file = new Collections.MAP[string, Collections.MAP[int, Collections.LIST[Pair[LOCATION,T]]]]();
         si
 
         dump_counts() is
-            System.Console.error.write_line("file name to file map: " + file_name_to_file.count);
+            STD.error.write_line("file name to file map: " + file_name_to_file.count);
         si
 
         put(location: LOCATION, value: T) is
@@ -138,7 +142,7 @@ namespace Semantic is
             od
         si
 
-        find_all(file_name: String, line: int, column: int) -> List[LOCATION_SEARCH_RESULT[T]] is
+        find_all(file_name: string, line: int, column: int) -> List[LOCATION_SEARCH_RESULT[T]] is
             let file = _get_file(file_name);
 
             if !file? || !file.contains_key(line) then
@@ -164,7 +168,7 @@ namespace Semantic is
             return result;
         si
         
-        _get_file(file_name: String) -> Collections.MAP[int, Collections.LIST[Pair[LOCATION,T]]] is
+        _get_file(file_name: string) -> Collections.MAP[int, Collections.LIST[Pair[LOCATION,T]]] is
             if file_name_to_file.contains_key(file_name) then
                 return file_name_to_file[file_name];
             fi

--- a/src/semantic/type/type.ghul
+++ b/src/semantic/type/type.ghul
@@ -1,4 +1,8 @@
 namespace Semantic.Type is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Source;
@@ -18,7 +22,7 @@ namespace Semantic.Type is
         DIFFERENT = 100000
     si
 
-    class BASE: Object, Typed is
+    class BASE: object, Typed is
         scope: Scope => null;
 
         symbol: Symbol.BASE is
@@ -41,7 +45,7 @@ namespace Semantic.Type is
 
         arguments: Collections.LIST[BASE] => new Collections.LIST[BASE](0);
 
-        short_description: String => to_string();
+        short_description: string => to_string();
 
         // FIXME: better than isa XXXX, but still should not need these:
         is_null: bool => false;
@@ -63,17 +67,17 @@ namespace Semantic.Type is
         compare(other: BASE) -> MATCH
             => MATCH.DIFFERENT;
 
-        find_member(name: String) -> Symbol.BASE
+        find_member(name: string) -> Symbol.BASE
             => null;
 
         find_ancestor(type: Type.BASE) -> Type.BASE => null;        
 
-        specialize(type_map: Collections.MAP[String,Type.BASE]) -> BASE is
+        specialize(type_map: Collections.MAP[string,Type.BASE]) -> BASE is
             throw new System.NotImplementedException("specialize " + self.get_type());
         si
 
-        il_type_name: String => "unknown";
-        il_token_name: String => "unknown";
+        il_type_name: string => "unknown";
+        il_token_name: string => "unknown";
     si
 
     class NONE: BASE is
@@ -97,13 +101,13 @@ namespace Semantic.Type is
         compare(other: BASE) -> Type.MATCH
             => MATCH.DIFFERENT;
 
-        il_type_name: String => "none";
+        il_type_name: string => "none";
 
-        to_string() -> String => "!!!";
+        to_string() -> string => "!!!";
     si
 
     class ANY: BASE is
-        il_type_name: String => "any";
+        il_type_name: string => "any";
 
         is_null: bool => true;
         is_any: bool => true;
@@ -112,7 +116,7 @@ namespace Semantic.Type is
             super.init();
         si
 
-        specialize(type_map: Collections.MAP[String,Type.BASE]) -> BASE => self;
+        specialize(type_map: Collections.MAP[string,Type.BASE]) -> BASE => self;
 
         =~(other: BASE) -> bool
             => true;
@@ -120,11 +124,11 @@ namespace Semantic.Type is
         compare(other: BASE) -> Type.MATCH
             => MATCH.ASSIGNABLE;
 
-        to_string() -> String => "***";
+        to_string() -> string => "***";
     si
 
     class NULL: BASE is
-        il_type_name: String => "null";
+        il_type_name: string => "null";
 
         is_null: bool => true;
         is_any: bool => false;
@@ -133,7 +137,7 @@ namespace Semantic.Type is
             super.init();
         si
 
-        specialize(type_map: Collections.MAP[String,Type.BASE]) -> BASE => self;
+        specialize(type_map: Collections.MAP[string,Type.BASE]) -> BASE => self;
 
         =~(other: BASE) -> bool
             => true;
@@ -141,11 +145,11 @@ namespace Semantic.Type is
         compare(other: BASE) -> Type.MATCH
             => MATCH.ASSIGNABLE;
 
-        to_string() -> String => "null";
+        to_string() -> string => "null";
     si
 
     class NAMED: BASE is
-        name: String => symbol.name;
+        name: string => symbol.name;
 
         scope: Scope => symbol;
 
@@ -153,7 +157,7 @@ namespace Semantic.Type is
 
         arguments: Collections.LIST[BASE] => new Collections.LIST[BASE](0);
 
-        short_description: String is
+        short_description: string is
             if symbol? then
                 return symbol.name;
             else
@@ -169,8 +173,8 @@ namespace Semantic.Type is
         is_inheritable: bool => symbol? && symbol.is_inheritable;
         is_class: bool => symbol? && symbol.is_class;
 
-        il_type_name: String => symbol.il_type_name;
-        il_token_name: String => symbol.il_token_name;
+        il_type_name: string => symbol.il_type_name;
+        il_token_name: string => symbol.il_token_name;
 
         init(symbol: Symbol.BASE) is
             super.init();
@@ -178,7 +182,7 @@ namespace Semantic.Type is
             self.symbol = symbol;
         si
 
-        specialize(type_map: Collections.MAP[String,BASE]) -> Type.BASE is
+        specialize(type_map: Collections.MAP[string,BASE]) -> Type.BASE is
             if type_map.contains_key(name) then
                 return type_map[name];
             else
@@ -225,7 +229,7 @@ namespace Semantic.Type is
             return Type.MATCH.DIFFERENT;
         si
 
-        find_member(name: String) -> Symbol.BASE is
+        find_member(name: string) -> Symbol.BASE is
             if symbol? then
                 return symbol.find_member(name);
             fi
@@ -237,7 +241,7 @@ namespace Semantic.Type is
             fi            
         si
 
-        to_string() -> String is
+        to_string() -> string is
             if symbol? then
                 return symbol.qualified_name;
             else
@@ -250,7 +254,7 @@ namespace Semantic.Type is
         arguments: Collections.LIST[BASE] => cast Symbol.GENERIC(symbol).arguments;
         ancestors: Collections.LIST[BASE] => cast Symbol.GENERIC(symbol).ancestors;
 
-        short_description: String is
+        short_description: string is
             assert self? else "self is null";
             assert symbol? else "symbol is null";
             assert symbol.name? else "symbol.name is null";
@@ -308,7 +312,7 @@ namespace Semantic.Type is
             return result;
         si
 
-        specialize_generic(type_map: Collections.MAP[String,BASE]) -> Type.GENERIC is
+        specialize_generic(type_map: Collections.MAP[string,BASE]) -> Type.GENERIC is
             let context = IoC.CONTAINER.instance.symbol_table.current_instance_context;
 
             let we_are_generic = context.arguments.count > 0;
@@ -354,7 +358,7 @@ namespace Semantic.Type is
             fi
         si
 
-        specialize(type_map: Collections.MAP[String,BASE]) -> Type.BASE =>
+        specialize(type_map: Collections.MAP[string,BASE]) -> Type.BASE =>
             specialize_generic(type_map);
 
         =~(other: BASE) -> bool is
@@ -419,11 +423,11 @@ namespace Semantic.Type is
 
                 /*
                 if other_named.name =~ "TUPLE_1" then
-                    System.Console.error.write_line("possible tuple match: " + self + " vs " + other);
+                    STD.error.write_line("possible tuple match: " + self + " vs " + other);
 
                     let match = self.compare(other_named.arguments[0]);
 
-                    System.Console.error.write_line("tuple match score: " + self + " vs " + other_named.arguments[0] + " = " + match);
+                    STD.error.write_line("tuple match score: " + self + " vs " + other_named.arguments[0] + " = " + match);
 
                     if match <= Type.MATCH.ASSIGNABLE then
                         return Type.MATCH.ASSIGNABLE;
@@ -439,7 +443,7 @@ namespace Semantic.Type is
 
         get_hash_code() -> int => symbol.get_hash_code();
 
-        to_string() -> String => symbol.to_string();
+        to_string() -> string => symbol.to_string();
     si
 
     class ACTION_0: NAMED is
@@ -458,7 +462,7 @@ namespace Semantic.Type is
             return new Semantic.Type.ACTION_0(symbol);
         si
 
-        to_string() -> String => "() -> void";
+        to_string() -> string => "() -> void";
     si
 
     class FUNCTION: GENERIC is
@@ -478,7 +482,7 @@ namespace Semantic.Type is
             return new FUNCTION(location, symbol, arguments);
         si
 
-        to_string() -> String is
+        to_string() -> string is
             let result = new System.Text.StringBuilder();
 
             if arguments.count == 2 then
@@ -525,7 +529,7 @@ namespace Semantic.Type is
             return new TUPLE(location, symbol, arguments);
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             "(" + new Shim.JOIN[Type.BASE](arguments) + ")";
     si
 
@@ -546,7 +550,7 @@ namespace Semantic.Type is
             return new Type.ARRAY(location, symbol, arguments);
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             arguments[0].to_string() + "[]";
     si
 
@@ -567,7 +571,7 @@ namespace Semantic.Type is
             return new Type.POINTER(location, symbol, arguments);
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             arguments[0].to_string() + " ptr";
     si
 
@@ -588,7 +592,7 @@ namespace Semantic.Type is
             return new Type.REFERENCE(location, symbol, arguments);
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             arguments[0].to_string() + " ref";
     si
 
@@ -609,7 +613,7 @@ namespace Semantic.Type is
             return new Type.ENUM(location, symbol, arguments);
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             arguments[0].to_string();
     si
 
@@ -755,11 +759,11 @@ namespace Semantic.Type is
     si
 
     class FUNCTION_GROUP: BASE is
-        name: String;
+        name: string;
 
         function_group: Symbol.FUNCTION_GROUP;
 
-        init(name: String, function_group: Symbol.FUNCTION_GROUP) is
+        init(name: string, function_group: Symbol.FUNCTION_GROUP) is
             super.init();
 
             self.name = name;
@@ -773,7 +777,7 @@ namespace Semantic.Type is
             fi
         si
 
-        to_string() -> String =>
+        to_string() -> string =>
             name + "(...)";
     si
 si

--- a/src/source/location.ghul
+++ b/src/source/location.ghul
@@ -1,5 +1,9 @@
 
 namespace Source is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
 
     class LOCATION is
@@ -13,7 +17,7 @@ namespace Source is
             return _dummy;
         si
 
-        file_name: String;
+        file_name: string;
 
         // line << 12 + column - easier to compare
         start: int;
@@ -24,7 +28,7 @@ namespace Source is
         is_internal: bool => self == dummy;
 
         init(
-            file_name: String,
+            file_name: string,
 
             start_line: int,
             start_column: int,
@@ -40,7 +44,7 @@ namespace Source is
                 end_line < 0 || end_column < 0
             then
                 throw new BoundsException(
-                    String.format("invalid location {0},{0}..{0},{0}", [start_line, start_column, end_line, end_column]: Object)
+                    string.format("invalid location {0},{0}..{0},{0}", [start_line, start_column, end_line, end_column]: object)
                 );
             fi
 
@@ -57,7 +61,7 @@ namespace Source is
         si
 
         init(
-            file_name: String,
+            file_name: string,
             start: int,
             end: int
         )
@@ -109,8 +113,8 @@ namespace Source is
                 self.contains(l.end));
 
         @IL.name("ToString")
-        to_string() -> String =>
-            String.format("{0} {1},{2}..{3},{4}", [file_name, start_line, start_column, end_line, end_column]);
+        to_string() -> string =>
+            string.format("{0} {1},{2}..{3},{4}", [file_name, start_line, start_column, end_line, end_column]);
 
         ::(with: LOCATION) -> LOCATION is
             var new_start: int;
@@ -156,7 +160,7 @@ namespace Source is
     si
 
     class LOCATION_CURSOR is
-        _file_name: String;
+        _file_name: string;
 
         _previous_line: int;
         _previous_column: int;
@@ -167,7 +171,7 @@ namespace Source is
         _current_line: int;
         _current_column: int;
 
-        init(file_name: String) is
+        init(file_name: string) is
             _file_name = file_name;
 
             _previous_line = 1;

--- a/src/syntax/parser/base.ghul
+++ b/src/syntax/parser/base.ghul
@@ -1,11 +1,15 @@
 namespace Syntax.Parser is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     trait Parser[T] is
         parse(context: CONTEXT) -> T;
     si
 
-    class BASE[T]: Object, Parser[T] is
+    class BASE[T]: object, Parser[T] is
         _expected_tokens: Collections.MutableList[Lexical.TOKEN];
         parsers: Collections.MAP[Lexical.TOKEN, (CONTEXT) -> T];
 
@@ -16,9 +20,9 @@ namespace Syntax.Parser is
             return _expected_tokens;
         si
 
-        description: String => null;
+        description: string => null;
 
-        syntax_error_message: String is
+        syntax_error_message: string is
             var d = description;
             if d? then
                 return "in " + d;
@@ -33,7 +37,7 @@ namespace Syntax.Parser is
 
         add_parser(p: (CONTEXT) -> T, token: Lexical.TOKEN) is
             if parsers.contains_key(token) then
-                throw new Exception(String.format("{0} already has a parser ({1})", [token, p]));
+                throw new Exception(string.format("{0} already has a parser ({1})", [token, p]));
             fi
 
             parsers[token] = p;
@@ -63,9 +67,9 @@ namespace Syntax.Parser is
 
         other_token(context: CONTEXT) -> T is
             context.error(context.location, 
-                String.format(
+                string.format(
                     "{0}: expected {1} but found {2}",
-                    [syntax_error_message, Lexical.TOKEN_NAMES[expected_tokens], context.current_token_name]: Object
+                    [syntax_error_message, Lexical.TOKEN_NAMES[expected_tokens], context.current_token_name]: object
                 )
             );
         si

--- a/src/syntax/parser/body/node.ghul
+++ b/src/syntax/parser/body/node.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Parser.Body is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
 
     class NODE: BASE[Tree.Body.NODE] is
@@ -7,7 +11,7 @@ namespace Syntax.Parser.Body is
         statement_list_parser: Parser[Tree.Statement.LIST];
         identifier_qualified_parser: Parser[Tree.Identifier.NODE];
 
-        description: String => "function body";
+        description: string => "function body";
 
         init(
             expression_parser: Parser[Tree.Expression.NODE],

--- a/src/syntax/parser/context.ghul
+++ b/src/syntax/parser/context.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Parser is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Logging;
@@ -8,7 +12,7 @@ namespace Syntax.Parser is
         _repeated_error_count_at_eof: int;
 
         last_error_location: LOCATION;
-        last_error_message: String;
+        last_error_message: string;
         speculative_parse_tokens: Collections.MutableList[Lexical.TOKEN_PAIR];
         allow_tuple_element: bool public;
         in_trait: bool public;
@@ -23,9 +27,9 @@ namespace Syntax.Parser is
 
         current_token: Lexical.TOKEN => tokenizer.current.token;
 
-        current_string: String => tokenizer.current.string;
+        current_string: string => tokenizer.current.value_string;
 
-        current_token_name: String is
+        current_token_name: string is
             var result = Lexical.TOKEN_NAMES[current_token];
 
             if result == null then
@@ -87,14 +91,14 @@ namespace Syntax.Parser is
             return result;
         si
 
-        next_token(token: Lexical.TOKEN, message: String) -> bool is
+        next_token(token: Lexical.TOKEN, message: string) -> bool is
             if expect_token(token, message) then
                 next_token();
                 return true;
             fi
         si
 
-        next_token(tokens: Collections.LIST[Lexical.TOKEN], message: String) -> bool is
+        next_token(tokens: Collections.LIST[Lexical.TOKEN], message: string) -> bool is
             if expect_token(tokens, message) then
                 next_token();
                 return true;
@@ -115,7 +119,7 @@ namespace Syntax.Parser is
             return result;
         si
 
-        skip_token(tokens: Collections.LIST[Lexical.TOKEN], message: String) is
+        skip_token(tokens: Collections.LIST[Lexical.TOKEN], message: string) is
             var start = location;
             
             do
@@ -132,15 +136,15 @@ namespace Syntax.Parser is
             od
         si
 
-        skip_token(token: Lexical.TOKEN, message: String) is
+        skip_token(token: Lexical.TOKEN, message: string) is
             var t = new Collections.LIST[Lexical.TOKEN]();
             t.add(token);
             skip_token(t, message);
         si
 
-        expect_token(token: Lexical.TOKEN, message: String) -> bool is
+        expect_token(token: Lexical.TOKEN, message: string) -> bool is
             if current_token != token then
-                error(location, String.format("{0}: expected {1} but found {2}", [message, Lexical.TOKEN_NAMES[token], current_token_name]: Object));
+                error(location, string.format("{0}: expected {1} but found {2}", [message, Lexical.TOKEN_NAMES[token], current_token_name]: object));
 
                 return false;
             else
@@ -152,9 +156,9 @@ namespace Syntax.Parser is
             return expect_token(token, "syntax error");
         si
 
-        expect_token(tokens: Collections.LIST[Lexical.TOKEN], message: String) -> bool is
+        expect_token(tokens: Collections.LIST[Lexical.TOKEN], message: string) -> bool is
             if !tokens.contains(current_token) then
-                error(location, String.format("{0}: expected {1} but found {2}", [message, Lexical.TOKEN_NAMES[tokens], current_token_name]: Object));
+                error(location, string.format("{0}: expected {1} but found {2}", [message, Lexical.TOKEN_NAMES[tokens], current_token_name]: object));
 
                 return false;
             else
@@ -166,7 +170,7 @@ namespace Syntax.Parser is
             return expect_token(tokens, "syntax error");
         si
 
-        error(location: LOCATION, message: String) is
+        error(location: LOCATION, message: string) is
             if location !~ last_error_location || message !~ last_error_message then
                 _repeated_error_count_at_eof = 0;
 

--- a/src/syntax/parser/definition/indexer.ghul
+++ b/src/syntax/parser/definition/indexer.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Parser.Definition is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
         
     use Source;
@@ -9,7 +13,7 @@ namespace Syntax.Parser.Definition is
         modifier_list_parser: Parser[Tree.Modifier.LIST];
         variable_parser: Parser[Tree.Variable.NODE];
         body_parser: Parser[Tree.Body.NODE];
-        description: String => "indexer";
+        description: string => "indexer";
 
         init(
             identifier_parser: Parser[Tree.Identifier.NODE],
@@ -115,7 +119,7 @@ namespace Syntax.Parser.Definition is
                 fi
 
                 if !progress then
-                    System.Console.error.write_line("no progress in indexer: " + context.current_token_name);
+                    STD.error.write_line("no progress in indexer: " + context.current_token_name);
                     return null;
                 fi
 

--- a/src/syntax/parser/definition/list.ghul
+++ b/src/syntax/parser/definition/list.ghul
@@ -1,11 +1,15 @@
 namespace Syntax.Parser.Definition is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Source;
 
     class LIST: BASE[Tree.Definition.LIST] is
         definition_parser: Parser[Tree.Definition.NODE];
-        description: String => "definition list";
+        description: string => "definition list";
 
         init(definition_parser: Parser[Tree.Definition.NODE]) is
             super.init();
@@ -27,7 +31,7 @@ namespace Syntax.Parser.Definition is
                         definitions.add(definition);
                     fi
                 catch e: Exception
-                    IoC.CONTAINER.instance.logger.exception(context.current.location, e, "parse exception"); 
+                    IoC.CONTAINER.instance.logger.exception(context.current.location, e, "parse exception: " + e.message);
 
                     while 
                         !context.is_end_of_file &&

--- a/src/syntax/parser/definition/member.ghul
+++ b/src/syntax/parser/definition/member.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Parser.Definition is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Source;
@@ -7,7 +11,7 @@ namespace Syntax.Parser.Definition is
         function_parser: Parser[Tree.Definition.FUNCTION];
         property_parser: Parser[Tree.Definition.PROPERTY];
         indexer_parser: Parser[Tree.Definition.INDEXER];
-        description: String => "member";
+        description: string => "member";
 
         expected_tokens: Collections.Iterable[Lexical.TOKEN] => property_tokens;
 

--- a/src/syntax/parser/definition/node.ghul
+++ b/src/syntax/parser/definition/node.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Parser.Definition is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Source;
@@ -13,7 +17,7 @@ namespace Syntax.Parser.Definition is
         definition_member_parser: Parser[Tree.Definition.NODE];
         definition_pragma_parser: Parser[Tree.Definition.PRAGMA];
 
-        description: String => "definition";
+        description: string => "definition";
 
         init(
             definition_namespace_parser: Parser[Tree.Definition.NAMESPACE],

--- a/src/syntax/parser/definition/property.ghul
+++ b/src/syntax/parser/definition/property.ghul
@@ -1,4 +1,6 @@
 namespace Syntax.Parser.Definition is
+    use STD = System.Console;
+
     use System;
     use Source;
 
@@ -151,7 +153,7 @@ namespace Syntax.Parser.Definition is
                 return result;
             else
                 if !progress then
-                    System.Console.error.write_line("parsing property: no progress made so consuming next token: " + context.current_token_name);                    
+                    STD.error.write_line("parsing property: no progress made so consuming next token: " + context.current_token_name);                    
                     context.next_token();    
                 fi
                 

--- a/src/syntax/parser/expression/list.ghul
+++ b/src/syntax/parser/expression/list.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Parser.Expression is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Source;
@@ -12,7 +16,7 @@ namespace Syntax.Parser.Expression is
             self.expression_parser = expression_parser;
         si
 
-        description: String => "expression list";
+        description: string => "expression list";
 
         parse(context: CONTEXT) -> Tree.Expression.LIST is
             var start = context.location;

--- a/src/syntax/parser/expression/node.ghul
+++ b/src/syntax/parser/expression/node.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Parser.Expression is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Logging;
@@ -20,15 +24,15 @@ namespace Syntax.Parser.Expression is
     si
 
     class NODE: BASE[Tree.Expression.NODE] is
-        _precedence: Collections.MAP[String,PRECEDENCE];
-        _real_operation: Collections.MAP[String,String];
+        _precedence: Collections.MAP[string,PRECEDENCE];
+        _real_operation: Collections.MAP[string,string];
 
         expression_tertiary_parser: Parser[Tree.Expression.NODE];
 
         init(expression_tertiary_parser: Parser[Tree.Expression.NODE]) is
             super.init();
             self.expression_tertiary_parser = expression_tertiary_parser;
-            _precedence = new Collections.MAP[String,PRECEDENCE]();
+            _precedence = new Collections.MAP[string,PRECEDENCE]();
 
             _precedence["*"] = PRECEDENCE.MULTIPLICATION;
             _precedence["/"] = PRECEDENCE.MULTIPLICATION;
@@ -53,7 +57,7 @@ namespace Syntax.Parser.Expression is
             _precedence["&&"] = PRECEDENCE.BOOLEAN;
             _precedence["||"] = PRECEDENCE.BOOLEAN;
 
-            _real_operation = new Collections.MAP[String,String]();
+            _real_operation = new Collections.MAP[string,string]();
 
             _real_operation["!~"] = "=~";
             _real_operation["=~"] = "=~";
@@ -65,27 +69,27 @@ namespace Syntax.Parser.Expression is
             _real_operation[">="] = "<>";
         si
 
-        description: String => "expression";
+        description: string => "expression";
 
         precedence(context: CONTEXT) -> PRECEDENCE is
             if context.current.token != Lexical.TOKEN.OPERATOR then
                 return PRECEDENCE.NONE;
             fi
 
-            if !_precedence.contains_key(context.current.string) then
+            if !_precedence.contains_key(context.current.value_string) then
                 context.error(context.current.location, 
-                "operator '" + context.current.string + "' has unknown precedence");
+                "operator '" + context.current.value_string + "' has unknown precedence");
                 return PRECEDENCE.UNDEFINED;
             fi
 
-            return _precedence[context.current.string];
+            return _precedence[context.current.value_string];
         si
 
         parse(context: CONTEXT) -> Tree.Expression.NODE is
             try
                 return parse(context, expression_tertiary_parser.parse(context), PRECEDENCE.MIN);                                       
             catch e: Exception
-                IoC.CONTAINER.instance.logger.exception(context.current.location, e, "parse exception"); 
+                IoC.CONTAINER.instance.logger.exception(context.current.location, e, "parse exception: " + e.message); 
 
                 return new Tree.Expression.Literal.NONE(context.location);
             yrt
@@ -102,7 +106,7 @@ namespace Syntax.Parser.Expression is
 
                 let s = left_precedence.to_string();
 
-                let apparent_op = context.current.string;
+                let apparent_op = context.current.value_string;
 
                 let real_op = apparent_op;
 

--- a/src/syntax/parser/expression/primary.ghul
+++ b/src/syntax/parser/expression/primary.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Parser.Expression is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Source;
@@ -10,7 +14,7 @@ namespace Syntax.Parser.Expression is
         expression_list_parser: Parser[Tree.Expression.LIST];
         expression_tuple_parser: Parser[Tree.Expression.TUPLE];
 
-        description: String => "primary expression";
+        description: string => "primary expression";
 
         init(
             identifier_parser: Parser[Tree.Identifier.NODE],
@@ -169,9 +173,9 @@ namespace Syntax.Parser.Expression is
             add_parser(
                 (context: CONTEXT) -> Tree.Expression.NODE is
                     let location = context.location;
-                    let string = context.current.string;
+                    let value_string = context.current.value_string;
                     context.next_token();
-                    return new Tree.Expression.Literal.INTEGER(location, string);
+                    return new Tree.Expression.Literal.INTEGER(location, value_string);
                 si,
                 Lexical.TOKEN.INT_LITERAL
             );
@@ -179,9 +183,9 @@ namespace Syntax.Parser.Expression is
             add_parser(
                 (context: CONTEXT) -> Tree.Expression.NODE is
                     let location = context.location;
-                    let string = context.current.string;
+                    let value_string = context.current.value_string;
                     context.next_token();
-                    return new Tree.Expression.Literal.FLOAT(location, string);
+                    return new Tree.Expression.Literal.FLOAT(location, value_string);
                 si,
                 Lexical.TOKEN.FLOAT_LITERAL
             );
@@ -189,9 +193,9 @@ namespace Syntax.Parser.Expression is
             add_parser(
                 (context: CONTEXT) -> Tree.Expression.NODE is
                     let location = context.location;
-                    let string = context.current.string;
+                    let value_string = context.current.value_string;
                     context.next_token();
-                    return new Tree.Expression.Literal.STRING(location, string);
+                    return new Tree.Expression.Literal.STRING(location, value_string);
                 si,
                 Lexical.TOKEN.STRING_LITERAL
             );
@@ -199,9 +203,9 @@ namespace Syntax.Parser.Expression is
             add_parser(
                 (context: CONTEXT) -> Tree.Expression.NODE is
                     let location = context.location;
-                    let string = context.current.string;
+                    let value_string = context.current.value_string;
                     context.next_token();
-                    return new Tree.Expression.Literal.CHARACTER(location, string);
+                    return new Tree.Expression.Literal.CHARACTER(location, value_string);
                 si,
                 Lexical.TOKEN.CHAR_LITERAL
             );
@@ -209,9 +213,9 @@ namespace Syntax.Parser.Expression is
             add_parser(
                 (context: CONTEXT) -> Tree.Expression.NODE is
                     let location = context.location;
-                    let string = context.current.string;
+                    let value_string = context.current.value_string;
                     context.next_token();
-                    return new Tree.Expression.Literal.BOOLEAN(location, string);
+                    return new Tree.Expression.Literal.BOOLEAN(location, value_string);
                 si,
                 new Collections.LIST[Lexical.TOKEN]([Lexical.TOKEN.TRUE, Lexical.TOKEN.FALSE])
             );

--- a/src/syntax/parser/expression/secondary.ghul
+++ b/src/syntax/parser/expression/secondary.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Parser.Expression is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Source;
@@ -10,7 +14,7 @@ namespace Syntax.Parser.Expression is
         expression_primary_parser: Parser[Tree.Expression.NODE];
         expression_list_parser: Parser[Tree.Expression.LIST];
         body_parser: Parser[Tree.Body.NODE];
-        description: String => "secondary expression";
+        description: string => "secondary expression";
         
         init(
             identifier_parser: Parser[Tree.Identifier.NODE],

--- a/src/syntax/parser/expression/tertiary.ghul
+++ b/src/syntax/parser/expression/tertiary.ghul
@@ -1,11 +1,15 @@
 namespace Syntax.Parser.Expression is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Source;
 
     class TERTIARY: BASE[Tree.Expression.NODE] is
         expression_secondary_parser: Parser[Tree.Expression.NODE];
-        description: String => "tertiary expression";
+        description: string => "tertiary expression";
         
         init(
             expression_secondary_parser: Parser[Tree.Expression.NODE]

--- a/src/syntax/parser/expression/tuple.ghul
+++ b/src/syntax/parser/expression/tuple.ghul
@@ -1,11 +1,15 @@
 namespace Syntax.Parser.Expression is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Source;
     
     class TUPLE : BASE[Tree.Expression.TUPLE]  is
         expression_list_parser: Parser[Tree.Expression.LIST];
-        description: String => "tuple";
+        description: string => "tuple";
 
         init(expression_list_parser: Parser[Tree.Expression.LIST]) is
             super.init();

--- a/src/syntax/parser/identifier/function_name.ghul
+++ b/src/syntax/parser/identifier/function_name.ghul
@@ -1,17 +1,21 @@
 namespace Syntax.Parser.Identifier is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
 
     use Source;
 
     class FUNCTION_NAME: BASE[Tree.Identifier.NODE] is
-        description: String => "function name";
+        description: string => "function name";
 
         init() is
             super.init();
 
             add_parser(
                 (context: CONTEXT) -> Tree.Identifier.NODE is
-                    var name = context.current.string;
+                    var name = context.current.value_string;
                     var result = new Tree.Identifier.NODE(context.location, name);
                     context.next_token();
                     return result;

--- a/src/syntax/parser/identifier/node.ghul
+++ b/src/syntax/parser/identifier/node.ghul
@@ -1,10 +1,14 @@
 namespace Syntax.Parser.Identifier is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
 
     use Source;
 
     class NODE: BASE[Tree.Identifier.NODE] is
-        description: String => "identifier";
+        description: string => "identifier";
 
         init() is
             super.init();
@@ -12,7 +16,7 @@ namespace Syntax.Parser.Identifier is
 
         parse(context: CONTEXT) -> Tree.Identifier.NODE is
             if context.expect_token(Lexical.TOKEN.IDENTIFIER, syntax_error_message) then
-                var name = context.current.string;
+                var name = context.current.value_string;
                 var result = new Tree.Identifier.NODE(context.location, name);
                 context.next_token();
                 

--- a/src/syntax/parser/identifier/qualified.ghul
+++ b/src/syntax/parser/identifier/qualified.ghul
@@ -1,10 +1,14 @@
 namespace Syntax.Parser.Identifier is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
 
     use Source;
 
     class QUALIFIED: BASE[Tree.Identifier.NODE] is
-        description: String => "qualified identifier";
+        description: string => "qualified identifier";
 
         init() is
             super.init();
@@ -14,7 +18,7 @@ namespace Syntax.Parser.Identifier is
             var start = context.location;
             
             if context.expect_token(Lexical.TOKEN.IDENTIFIER, syntax_error_message) then
-                var name = context.current.string;
+                var name = context.current.value_string;
                 var result = new Tree.Identifier.NODE(context.location, name);
 
                 context.next_token();
@@ -24,7 +28,7 @@ namespace Syntax.Parser.Identifier is
                 
                     context.next_token();
                     if context.expect_token(Lexical.TOKEN.IDENTIFIER, syntax_error_message) then
-                        result = new Tree.Identifier.QUALIFIED(start::context.location, result, context.current.string, completion_target_start::context.location);
+                        result = new Tree.Identifier.QUALIFIED(start::context.location, result, context.current.value_string, completion_target_start::context.location);
 
                         context.next_token();
                     else

--- a/src/syntax/parser/lazy_parser.ghul
+++ b/src/syntax/parser/lazy_parser.ghul
@@ -1,6 +1,9 @@
 namespace Syntax.Parser is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
     
-    class LAZY_PARSER[T]: System.Object, Parser[T] is
+    class LAZY_PARSER[T]: object, Parser[T] is
         _parser: System.LAZY[Parser[T]];
 
         create: () -> Parser[T] public

--- a/src/syntax/parser/statement/list.ghul
+++ b/src/syntax/parser/statement/list.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Parser.Statement is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Source;
@@ -6,7 +10,7 @@ namespace Syntax.Parser.Statement is
     class LIST : BASE[Tree.Statement.LIST]  is
         terminators: Collections.LIST[Lexical.TOKEN];
         statement_parser: Parser[Tree.Statement.NODE];
-        description: String => "statement list";
+        description: string => "statement list";
 
         init(terminators: Collections.LIST[Lexical.TOKEN], statement_parser: Parser[Tree.Statement.NODE]) is
             super.init();

--- a/src/syntax/parser/statement/node.ghul
+++ b/src/syntax/parser/statement/node.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Parser.Statement is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     class NODE: BASE[Tree.Statement.NODE] is
@@ -12,7 +16,7 @@ namespace Syntax.Parser.Statement is
         if_parser:  (CONTEXT) -> Tree.Statement.NODE;
         pragma_parser: Parser[Tree.Statement.PRAGMA];
 
-        description: String => "statement";
+        description: string => "statement";
 
         init(
             labellable_statement_tokens: Collections.LIST[Lexical.TOKEN],

--- a/src/syntax/parser/type/node.ghul
+++ b/src/syntax/parser/type/node.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Parser.TypeExpression is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Source;
@@ -6,7 +10,7 @@ namespace Syntax.Parser.TypeExpression is
     class NODE: BASE[Tree.TypeExpression.NODE] is
         identifier_qualified_parser: Parser[Tree.Identifier.NODE];
         type_list_parser: Parser[Tree.TypeExpression.LIST];
-        description: String => "type expression";
+        description: string => "type expression";
 
         init(
             identifier_qualified_parser: Parser[Tree.Identifier.NODE],

--- a/src/syntax/process/add_accessors_for_properties.ghul
+++ b/src/syntax/process/add_accessors_for_properties.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Process is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Source;
@@ -23,7 +27,7 @@ namespace Syntax.Process is
         // FIXME: #500 Pragma handling code is duplicated across multiple visitors
         pre(pragma_: Definition.PRAGMA) -> bool is
             if !pragma_.pragma_? then
-                System.Console.error.write_line("pragma is null");
+                STD.error.write_line("pragma is null");
                 return false;
             fi
 
@@ -38,7 +42,7 @@ namespace Syntax.Process is
 
         visit(pragma_: Definition.PRAGMA) is
             if !pragma_.pragma_? then
-                System.Console.error.write_line("pragma is null");
+                STD.error.write_line("pragma is null");
                 return;
             fi
 
@@ -196,7 +200,7 @@ namespace Syntax.Process is
         si
 
         pre(indexer: Definition.INDEXER) -> bool is
-            var name: String;
+            var name: string;
             var location: LOCATION;
 
             if indexer.name? then

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Process is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
         
     use Logging;
@@ -48,7 +52,7 @@ namespace Syntax.Process is
             root.walk(self);
         si
 
-        get_zero_argument_function(type: Semantic.Type.BASE, name: String) -> Semantic.Symbol.Function is
+        get_zero_argument_function(type: Semantic.Type.BASE, name: string) -> Semantic.Symbol.Function is
             let symbol = type.find_member(name);
 
             if symbol? && isa Semantic.Symbol.FUNCTION_GROUP(symbol) then
@@ -64,10 +68,10 @@ namespace Syntax.Process is
 
         set_iterator_for(for_: Tree.Statement.FOR, type: Semantic.Type.BASE, recursing: bool) -> bool is
             @IF.debug()
-            System.Console.error.write_line("set iterator for: " + type + " recursing: " + recursing);
+            STD.error.write_line("set iterator for: " + type + " recursing: " + recursing);
 
             if !type? then
-                System.Console.error.write_line("set iterator, type is null: " + for_.expression);
+                STD.error.write_line("set iterator, type is null: " + for_.expression);
 
                 return false;
             fi
@@ -75,18 +79,18 @@ namespace Syntax.Process is
             let move_next = get_zero_argument_function(type, "move_next");
 
             @IF.debug()
-            System.Console.error.write_line("set iterator for: " + type + " recursing: " + recursing + ", move next: " + move_next);
+            STD.error.write_line("set iterator for: " + type + " recursing: " + recursing + ", move next: " + move_next);
 
             let next_element = get_zero_argument_function(type, "nextElement");
 
             @IF.debug()
-            System.Console.error.write_line("set iterator for: " + type + " recursing: " + recursing + ", next element: " + next_element);
+            STD.error.write_line("set iterator for: " + type + " recursing: " + recursing + ", next element: " + next_element);
             
             if move_next? then
                 let read_current = get_zero_argument_function(type, "__read_current");
 
                 @IF.debug()
-                System.Console.error.write_line("set iterator for: " + type + " recursing: " + recursing + ", read current: " + read_current);
+                STD.error.write_line("set iterator for: " + type + " recursing: " + recursing + ", read current: " + read_current);
 
                 if !read_current? then
                     _logger.error(for_.expression.location, "incomplete iterator type (has move_next method but no iterator accessor)");
@@ -102,20 +106,20 @@ namespace Syntax.Process is
                 for_.read_current = next_element;
 
                 @IF.debug()
-                System.Console.error.write_line("set iterator for: " + type + " recursing: " + recursing + ", use next element: " + next_element);
+                STD.error.write_line("set iterator for: " + type + " recursing: " + recursing + ", use next element: " + next_element);
 
                 return true;
             elif !recursing then
                 let read_iterator = get_zero_argument_function(type, "__read_iterator");
 
                 @IF.debug()
-                System.Console.error.write_line("set iterator for: " + type + ", read iterator: " + read_iterator);
+                STD.error.write_line("set iterator for: " + type + ", read iterator: " + read_iterator);
 
                 if read_iterator? then
                     for_.read_iterator = read_iterator;
 
                     @IF.debug()
-                    System.Console.error.write_line("set iterator for: " + type + ", have .NET read iterator: " + read_iterator + " recurse to get methods...");
+                    STD.error.write_line("set iterator for: " + type + ", have .NET read iterator: " + read_iterator + " recurse to get methods...");
 
                     return set_iterator_for(for_, read_iterator.return_type, true);
                 fi
@@ -127,14 +131,14 @@ namespace Syntax.Process is
                     for_.read_iterator = read_iterator;
 
                     @IF.debug()
-                    System.Console.error.write_line("set iterator for: " + type + ", have L read iterator: " + read_iterator + " recurse to get methods...");
+                    STD.error.write_line("set iterator for: " + type + ", have L read iterator: " + read_iterator + " recurse to get methods...");
 
                     return set_iterator_for(for_, read_iterator.return_type, true);
                 fi
             fi
 
             @IF.debug()
-            System.Console.error.write_line("set iterator for: " + type + ", could not find anything iterable");
+            STD.error.write_line("set iterator for: " + type + ", could not find anything iterable");
 
             _logger.error(for_.expression.location, "not iterable");
 
@@ -293,7 +297,7 @@ namespace Syntax.Process is
                         .get_string_type()
                         .is_assignable_from(assert__.expression.value.type)
                 then
-                    _logger.error(assert__.message.location, "assertion else must be System.String or System.Exception");
+                    _logger.error(assert__.message.location, "assertion else must be string or System.Exception");
                 fi
             fi
         si
@@ -380,7 +384,7 @@ namespace Syntax.Process is
 
             owning_class.add_closure(closure);
 
-            let argument_names = new Collections.LIST[String]();
+            let argument_names = new Collections.LIST[string]();
             let argument_types = new Collections.LIST[Semantic.Type.BASE]();
 
             if !isa Tree.TypeExpression.INFER(function.type_expression) then
@@ -995,7 +999,7 @@ namespace Syntax.Process is
 
                 let named_type = cast Semantic.Type.NAMED(type);
 
-                var function_name: String;
+                var function_name: string;
                 var arguments: Collections.LIST[Semantic.Graph.Value.BASE];
                 var argument_types: Collections.LIST[Semantic.Type.BASE];
 
@@ -1123,11 +1127,11 @@ namespace Syntax.Process is
                 _search_type = named_type;
 
                 _symbol_loader.find_symbol = 
-                    (name: String) -> Semantic.Symbol.BASE is
+                    (name: string) -> Semantic.Symbol.BASE is
                         let result = _search_type.scope.find_member(name);
 
                         if result == null then
-                            System.Console.error.write_line("property function " + name + " not found in type: " + _search_type + ", scope: " + _search_type.scope);
+                            STD.error.write_line("property function " + name + " not found in type: " + _search_type + ", scope: " + _search_type.scope);
                         fi
 
                         return result;
@@ -1154,11 +1158,11 @@ namespace Syntax.Process is
 
             @IF.debug()
             if symbol? && !isa Semantic.Type.SettableTyped(symbol) then
-                System.Console.error.write_line("case 2: symbol is: " + symbol);
-                System.Console.error.write_line("symbol type: " + symbol.get_type());
-                System.Console.error.write_line("symbol isa settable: " + isa Semantic.Type.SettableTyped(symbol));
-                System.Console.error.write_line("symbol isa variable: " + isa Semantic.Symbol.Variable(symbol));
-                System.Console.error.write_line("symbol isa BASE: " + isa Semantic.Symbol.BASE(symbol));
+                STD.error.write_line("case 2: symbol is: " + symbol);
+                STD.error.write_line("symbol type: " + symbol.get_type());
+                STD.error.write_line("symbol isa settable: " + isa Semantic.Type.SettableTyped(symbol));
+                STD.error.write_line("symbol isa variable: " + isa Semantic.Symbol.Variable(symbol));
+                STD.error.write_line("symbol isa BASE: " + isa Semantic.Symbol.BASE(symbol));
             fi
 
             if symbol? && isa Semantic.Type.SettableTyped(symbol) then
@@ -1196,22 +1200,22 @@ namespace Syntax.Process is
             let type: Semantic.Type.BASE;
             let suffix = "i4";
 
-            let string = integer.string;
-            let conv: String;
+            let value_string = integer.value_string;
+            let conv: string;
 
-            let last_char = string.get_at(string.length-1);
+            let last_char = value_string.get_at(value_string.length-1);
 
             if "bBcCsSiIlLwWuU".contains(last_char) then
                 let is_unsigned = false;
 
-                let cutoff = string.length;
+                let cutoff = value_string.length;
 
                 if last_char == 'u' || last_char == 'U' then
                     is_unsigned = true;
 
                     cutoff = cutoff - 1;
-                elif string.length > 2 then
-                    let sign_char = string.get_at(string.length - 2);
+                elif value_string.length > 2 then
+                    let sign_char = value_string.get_at(value_string.length - 2);
 
                     if sign_char == 'u' || sign_char == 'U' then
                         is_unsigned = true;
@@ -1291,13 +1295,13 @@ namespace Syntax.Process is
                     fi
                 esac
 
-                string = string.substring(0, cutoff);
+                value_string = value_string.substring(0, cutoff);
             else
                 type = _ghul_symbol_lookup.get_int_type();                
             fi 
             
             integer.value = new Semantic.Graph.Value.Literal.NUMBER(
-                string,
+                value_string,
                 type,
                 suffix,
                 conv
@@ -1306,43 +1310,43 @@ namespace Syntax.Process is
 
         visit(float: Tree.Expression.Literal.FLOAT) is
             let type: Semantic.Type.BASE;
-            let suffix: String;
+            let suffix: string;
 
-            let string = float.string;
+            let value_string = float.value_string;
 
             if
-                string.ends_with('D') ||
-                string.ends_with('d')
+                value_string.ends_with('D') ||
+                value_string.ends_with('d')
             then
-                type = _ghul_symbol_lookup.get_type("double");
+                type = _ghul_symbol_lookup.get_double_type();
                 suffix = "r8";
             else
-                type = _ghul_symbol_lookup.get_type("single");
+                type = _ghul_symbol_lookup.get_single_type();
                 suffix = "r4";
             fi
             
             float.value = new Semantic.Graph.Value.Literal.NUMBER(
-                string.substring(0, string.length -1),
+                value_string.substring(0, value_string.length -1),
                 type,
                 suffix
             );
         si
 
-        visit(string: Tree.Expression.Literal.STRING) is
-            string.value = new Semantic.Graph.Value.Literal.STRING(
-                string.string,
-                _system_symbol_lookup.get_type("String")
+        visit(string_: Tree.Expression.Literal.STRING) is
+            string_.value = new Semantic.Graph.Value.Literal.STRING(
+                string_.value_string,
+                _system_symbol_lookup.get_string_type()
             );
         si        
 
         visit(character: Tree.Expression.Literal.CHARACTER) is
-            let string = character.string;
+            let value_string = character.value_string;
             let c: int = 0;
 
-            if string.length < 1 || string.length > 1 then
+            if value_string.length < 1 || value_string.length > 1 then
                 _logger.error(character.location, "invalid character literal");
             else
-                c = cast int(string.get_at(0));
+                c = cast int(value_string.get_at(0));
             fi
             
             character.value = new Semantic.Graph.Value.Literal.NUMBER(
@@ -1353,16 +1357,16 @@ namespace Syntax.Process is
         si
 
         visit(boolean: Tree.Expression.Literal.BOOLEAN) is
-            let string = boolean.string;
+            let value_string = boolean.value_string;
 
-            let value: System.String;
+            let value: string;
 
-            if string =~ "true" then
+            if value_string =~ "true" then
                 value = "1";
-            elif string =~ "false" then
+            elif value_string =~ "false" then
                 value = "0";
             else
-                throw new System.Exception("invalid value for boolean literal: " + string);
+                throw new System.Exception("invalid value for boolean literal: " + value_string);
             fi
                         
             boolean.value = new Semantic.Graph.Value.Literal.NUMBER(
@@ -1518,10 +1522,10 @@ namespace Syntax.Process is
             if symbol? then
                 _symbol_use_locations.add_symbol_use(identifier.location, symbol);
 
-                // _symbol_loader.find_symbol = (name: String) -> Semantic.Symbol.BASE => find(name);
+                // _symbol_loader.find_symbol = (name: string) -> Semantic.Symbol.BASE => find(name);
 
                 _symbol_loader.find_symbol = 
-                    (name: String) -> Semantic.Symbol.BASE is
+                    (name: string) -> Semantic.Symbol.BASE is
                         let result = find(name);
 
                         return result;

--- a/src/syntax/process/completer.ghul
+++ b/src/syntax/process/completer.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Process is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
         
     use Logging;
@@ -8,7 +12,7 @@ namespace Syntax.Process is
         _target_line: int;
         _target_column: int;
 
-        _results: Collections.MAP[String,Semantic.Symbol.BASE];
+        _results: Collections.MAP[string,Semantic.Symbol.BASE];
 
         _have_hit: bool;
 
@@ -21,13 +25,13 @@ namespace Syntax.Process is
             super.init(logger, symbol_table, namespaces);
         si
 
-        find_completions(root: Tree.NODE, target_line: int, target_column: int) -> Collections.Iterable[Collections.Pair[String,Semantic.Symbol.BASE]] is
+        find_completions(root: Tree.NODE, target_line: int, target_column: int) -> Collections.Iterable[Collections.Pair[string,Semantic.Symbol.BASE]] is
             _have_hit = false;
 
             _target_line = target_line;
             _target_column = target_column;
 
-            _results = new Collections.MAP[String,Semantic.Symbol.BASE]();
+            _results = new Collections.MAP[string,Semantic.Symbol.BASE]();
 
             root.walk(self);
 
@@ -37,8 +41,6 @@ namespace Syntax.Process is
         leave_scope(node: Tree.NODE) is 
             if !_have_hit && node.location.contains(_target_line, _target_column) then
                 find_matches("", _results);
-
-                Console.error.write_line("have results: " + new Shim.JOIN[Collections.Pair[String,Semantic.Symbol.BASE]](_results));
 
                 _have_hit = true;
             fi
@@ -109,10 +111,10 @@ namespace Syntax.Process is
             if isa Semantic.Type.NAMED(member.left.value.type) then
                 type = cast Semantic.Type.NAMED(member.left.value.type);
             elif isa Semantic.Type.GENERIC(member.left.value.type) then
-                System.Console.error.write_line("oops: expected type to be specialized by now: " + member.left.value.type);
+                STD.error.write_line("oops: expected type to be specialized by now: " + member.left.value.type);
                 return;
             else
-                System.Console.error.write_line("oops: not sure how to complete member of type: " + member.left.value.type);
+                STD.error.write_line("oops: not sure how to complete member of type: " + member.left.value.type);
                 return;
             fi
 

--- a/src/syntax/process/conditional_compilation.ghul
+++ b/src/syntax/process/conditional_compilation.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Process is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     use Collections.Iterable;
 
@@ -7,17 +11,17 @@ namespace Syntax.Process is
     use Tree;
 
     class CONDITIONAL_COMPILATION: Visitor is
-        _flags: Collections.MAP[String,bool];
+        _flags: Collections.MAP[string,bool];
 
         is_analysis: bool;
 
         init() is
             super.init();
 
-            _flags = new Collections.MAP[String,bool]();
+            _flags = new Collections.MAP[string,bool]();
         si
 
-        set_is_enabled(names: Iterable[String]) is
+        set_is_enabled(names: Iterable[string]) is
             for name in names do
                 set_is_enabled(name, true);
             od
@@ -26,16 +30,17 @@ namespace Syntax.Process is
             set_is_enabled("dotnet", true);
         si
 
-        set_is_enabled(name: String, value: bool) is
+        set_is_enabled(name: string, value: bool) is
             _flags[name] = value;
         si
 
-        get_is_enabled(name: String) -> bool is
+        get_is_enabled(name: string) -> bool is
             let not_result = false;
             let result = false;
 
             if name.starts_with("not.") then
                 name = name.substring(4);
+
                 not_result = true;
             fi            
 

--- a/src/syntax/process/declare_symbols.ghul
+++ b/src/syntax/process/declare_symbols.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Process is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Logging;
@@ -33,7 +37,7 @@ namespace Syntax.Process is
             node.walk(self);
         si
 
-        next_anon_name() -> String is
+        next_anon_name() -> string is
             let result = "__anon_" + _anon_index;
             _anon_index = _anon_index + 1;
             return result;
@@ -42,7 +46,7 @@ namespace Syntax.Process is
         // FIXME: #500 Pragma handling code is duplicated across multiple visitors
         pre(pragma_: Definition.PRAGMA) -> bool is
             if !pragma_.pragma_? then
-                System.Console.error.write_line("pragma is null");
+                STD.error.write_line("pragma is null");
                 return false;
             fi
 
@@ -57,7 +61,7 @@ namespace Syntax.Process is
 
         visit(pragma_: Definition.PRAGMA) is
             if !pragma_.pragma_? then
-                System.Console.error.write_line("pragma is null");
+                STD.error.write_line("pragma is null");
                 return;
             fi
 
@@ -85,7 +89,7 @@ namespace Syntax.Process is
                     return;
                 fi
 
-                let il_name = cast Expression.Literal.STRING(argument).string;
+                let il_name = cast Expression.Literal.STRING(argument).value_string;
 
                 let definition = pragma_.definition;
 
@@ -132,8 +136,8 @@ namespace Syntax.Process is
             leave_namespace(namespace_.name);
         si
 
-        get_generic_arguments(arguments: Tree.TypeExpression.LIST) -> Collections.LIST[String] is
-            let result = new Collections.LIST[String]();
+        get_generic_arguments(arguments: Tree.TypeExpression.LIST) -> Collections.LIST[string] is
+            let result = new Collections.LIST[string]();
 
             if arguments? then
                 // FIXME: this is a bodge - generic class definition arguments are not type expressions, they're
@@ -262,13 +266,13 @@ namespace Syntax.Process is
         si
 
         pre(enum_member: Definition.ENUM_MEMBER) -> bool is
-            let value: String;
+            let value: string;
 
             if enum_member.initializer? then
                 let i = enum_member.initializer;
 
                 if isa Tree.Expression.Literal.NODE(i) then
-                    value = cast Tree.Expression.Literal.NODE(i).string;
+                    value = cast Tree.Expression.Literal.NODE(i).value_string;
                 else
                     _logger.error(i.location, "enum member initializer must be an integer literal");
                 fi

--- a/src/syntax/process/generate_il.ghul
+++ b/src/syntax/process/generate_il.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Process is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
         
     use Logging;
@@ -76,11 +80,11 @@ namespace Syntax.Process is
             root.walk(self);
         si
 
-        println(value: Object) is
+        println(value: object) is
             _context.write_line(value);
         si
 
-        println_comment(value: Object) is
+        println_comment(value: object) is
             _context.write_comment_line(value);
         si
 
@@ -383,7 +387,7 @@ namespace Syntax.Process is
 
         process_pragma(pragma_: Pragma.NODE, is_enter: bool) is
             if !pragma_? then
-                System.Console.error.write_line("pragma is null");
+                STD.error.write_line("pragma is null");
                 return;
             fi
 
@@ -402,7 +406,7 @@ namespace Syntax.Process is
                     return;
                 fi
 
-                let file_name = cast Expression.Literal.STRING(argument).string;
+                let file_name = cast Expression.Literal.STRING(argument).value_string;
 
                 if is_enter then
                     _il_output_depth = _il_output_depth + 1;
@@ -950,7 +954,7 @@ namespace Syntax.Process is
         is_in_finally: bool public;
         is_loop: bool => !is_try;
 
-        name: String;
+        name: string;
         start: IR.LABEL;
         middle: IR.LABEL;
         end: IR.LABEL;
@@ -958,7 +962,7 @@ namespace Syntax.Process is
         return_needed: IR.TEMP;
         return_value: IR.TEMP;
 
-        init(name: String) is
+        init(name: string) is
             is_try = false;
             self.name = name;
             start = new IR.LABEL();
@@ -974,11 +978,11 @@ namespace Syntax.Process is
             end = new IR.LABEL();
         si
 
-        matches(name: String) -> bool => self.name? && self.name =~ name;
+        matches(name: string) -> bool => self.name? && self.name =~ name;
     si
 
     class LOOP_LABEL_STACK is
-        _next_name: String;
+        _next_name: string;
 
         loops: Collections.LIST[LOOP_LABELS];
         is_in_loop: bool => get_current_loop() != null;
@@ -1016,13 +1020,13 @@ namespace Syntax.Process is
             loops = new Collections.LIST[LOOP_LABELS]();
         si
         
-        next_name(name: String) is
+        next_name(name: string) is
             _next_name = name;
         si
 
-        find(name: String) -> LOOP_LABELS is
+        find(name: string) -> LOOP_LABELS is
             for i in loops.count..0 do
-                System.Console.error.write_line("try loop " + i + " out of " + loops.count);
+                STD.error.write_line("try loop " + i + " out of " + loops.count);
 
                 let loop = loops[i];
 

--- a/src/syntax/process/printer/base.ghul
+++ b/src/syntax/process/printer/base.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Process.Printer is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     use Tree;
     use Source;
@@ -22,18 +26,18 @@ namespace Syntax.Process.Printer is
             _current_line = 1;
         si
 
-        result: String is
+        result: string is
             return _result.to_string();
         si
 
-        write_line(string: String) is
-            write(string);
+        write_line(value: string) is
+            write(value);
             write_line();
         si
 
-        write(string: String) is
+        write(value: string) is
             write_indent();
-            _result.append(string);
+            _result.append(value);
         si
 
         write(c: char) is
@@ -84,7 +88,7 @@ namespace Syntax.Process.Printer is
             node.accept(self);
         si
 
-        write_name(name: String) is
+        write_name(name: string) is
             write(name);
         si
 
@@ -364,13 +368,13 @@ namespace Syntax.Process.Printer is
 
         visit(literal: Expression.Literal.NODE) is
             location(literal);
-            write(literal.string);
+            write(literal.value_string);
         si
 
         write_escape_char(c: char) is
             var ci = cast int(c);
             if ci < 32 then
-                write("\\" + System.String.format("X", ci));
+                write("\\" + string.format("X", ci));
             elif ci == 34 then
                 write("\\");
                 write(cast char(34));
@@ -383,10 +387,10 @@ namespace Syntax.Process.Printer is
             fi
         si
 
-        visit(string: Expression.Literal.STRING) is
-            location(string);
+        visit(string_: Expression.Literal.STRING) is
+            location(string_);
             write(cast char(34));
-            for c in string.string do
+            for c in string_.value_string do
                 write_escape_char(c);
             od
             write(cast char(34));
@@ -394,24 +398,24 @@ namespace Syntax.Process.Printer is
 
         visit(integer: Expression.Literal.INTEGER) is
             location(integer);
-            write(integer.string);
+            write(integer.value_string);
         si        
 
         visit(float: Expression.Literal.FLOAT) is
             location(float);
-            write(float.string);
+            write(float.value_string);
         si
 
         visit(character: Expression.Literal.CHARACTER) is
             location(character);
             write("'");
-            write_escape_char(character.string.get_at(0));
+            write_escape_char(character.value_string.get_at(0));
             write("'");
         si
 
         visit(boolean: Expression.Literal.BOOLEAN) is
             location(boolean);
-            write(boolean.string);
+            write(boolean.value_string);
         si
 
         visit(list: Statement.LIST) is

--- a/src/syntax/process/printer/ghul.ghul
+++ b/src/syntax/process/printer/ghul.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Process.Printer is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
 
     use Tree;

--- a/src/syntax/process/resolve_ancestors.ghul
+++ b/src/syntax/process/resolve_ancestors.ghul
@@ -1,4 +1,6 @@
 namespace Syntax.Process is
+    use STD = System.Console;
+
     use System;
         
     use Logging;
@@ -70,8 +72,8 @@ namespace Syntax.Process is
                 od
             fi
 
-            // FIXME: safer test for Ghul.Object:
-            if !seen_class_ancestor && class_.name.name !~ "Object" then
+            // FIXME: safer test for Ghul.object:
+            if !seen_class_ancestor && class_.name.name !~ "object" then
                 let object_type = _system_symbol_lookup.get_object_type();
 
                 if class_symbol != object_type.symbol then
@@ -112,7 +114,7 @@ namespace Syntax.Process is
                             _logger.error(a.location, "cannot inherit from this");
                         fi
                     else
-                        System.Console.error.write_line("refusing to add ancestor with null type: " + a);
+                        STD.error.write_line("refusing to add ancestor with null type: " + a);
                     fi
                 od
             fi

--- a/src/syntax/process/resolve_explicit_variable_types.ghul
+++ b/src/syntax/process/resolve_explicit_variable_types.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Process is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
         
     use Logging;
@@ -35,7 +39,7 @@ namespace Syntax.Process is
             fi
 
             let types = new Collections.LIST[Semantic.Type.BASE]();
-            let names = new Collections.LIST[String]();
+            let names = new Collections.LIST[string]();
 
             for argument in function.arguments do
                 let type = argument.type_expression.type;
@@ -72,11 +76,11 @@ namespace Syntax.Process is
 
             @IF.debug()
             if f? && !isa Semantic.Type.SettableTyped(f) then
-                System.Console.error.write_line("case 3: symbol is: " + f);
-                System.Console.error.write_line("symbol type: " + f.get_type());
-                System.Console.error.write_line("symbol isa settable: " + isa Semantic.Type.SettableTyped(f));    
-                System.Console.error.write_line("symbol isa variable: " + isa Semantic.Symbol.Variable(f));
-                System.Console.error.write_line("symbol isa BASE: " + isa Semantic.Symbol.BASE(f));
+                STD.error.write_line("case 3: symbol is: " + f);
+                STD.error.write_line("symbol type: " + f.get_type());
+                STD.error.write_line("symbol isa settable: " + isa Semantic.Type.SettableTyped(f));    
+                STD.error.write_line("symbol isa variable: " + isa Semantic.Symbol.Variable(f));
+                STD.error.write_line("symbol isa BASE: " + isa Semantic.Symbol.BASE(f));
             fi
 
             if f == null || !isa Semantic.Type.SettableTyped(f) then
@@ -140,11 +144,11 @@ namespace Syntax.Process is
             var symbol = find(variable.name);
             
             if symbol? && !isa Semantic.Type.SettableTyped(symbol) then
-                System.Console.error.write_line("case 5: symbol is: " + symbol);
-                System.Console.error.write_line("symbol type: " + symbol.get_type());
-                System.Console.error.write_line("symbol isa settable: " + isa Semantic.Type.SettableTyped(symbol));
-                System.Console.error.write_line("symbol isa variable: " + isa Semantic.Symbol.Variable(symbol));
-                System.Console.error.write_line("symbol isa BASE: " + isa Semantic.Symbol.BASE(symbol));
+                STD.error.write_line("case 5: symbol is: " + symbol);
+                STD.error.write_line("symbol type: " + symbol.get_type());
+                STD.error.write_line("symbol isa settable: " + isa Semantic.Type.SettableTyped(symbol));
+                STD.error.write_line("symbol isa variable: " + isa Semantic.Symbol.Variable(symbol));
+                STD.error.write_line("symbol isa BASE: " + isa Semantic.Symbol.BASE(symbol));
             fi
 
             if symbol? && isa Semantic.Type.SettableTyped(symbol) then
@@ -184,7 +188,7 @@ namespace Syntax.Process is
                 type_symbol.ancestor = type.scope;
                 
                 if type.scope? && isa Semantic.Symbol.TYPE(type.scope) then
-                    System.Console.error.write_line("FIXME: ancestor may need to be fixed up: " + type.scope);
+                    STD.error.write_line("FIXME: ancestor may need to be fixed up: " + type.scope);
                 fi                
             fi
         si

--- a/src/syntax/process/resolve_overrides.ghul
+++ b/src/syntax/process/resolve_overrides.ghul
@@ -49,10 +49,10 @@ namespace Syntax.Process is
         visit(class_: Definition.CLASS) is
             let symbol = symbol_for(class_);
 
-            @IF.debug() System.Console.error.write_line("resolve overrides: " + symbol);
+            @IF.debug() STD.error.write_line("resolve overrides: " + symbol);
 
             if symbol? && isa Semantic.Symbol.Classy(symbol) then
-                @IF.debug() @IF.debug() System.Console.error.write_line("from resolve overrides pass: " + symbol);
+                @IF.debug() @IF.debug() STD.error.write_line("from resolve overrides pass: " + symbol);
 
                 cast Semantic.Symbol.Classy(symbol).pull_down_super_symbols();
             fi
@@ -61,10 +61,10 @@ namespace Syntax.Process is
         visit(struct_: Definition.STRUCT) is
             let symbol = symbol_for(struct_);
 
-            @IF.debug() System.Console.error.write_line("resolve overrides: " + symbol);
+            @IF.debug() STD.error.write_line("resolve overrides: " + symbol);
 
             if symbol? && isa Semantic.Symbol.Classy(symbol) then
-                @IF.debug() System.Console.error.write_line("from resolve overrides pass: " + symbol);
+                @IF.debug() STD.error.write_line("from resolve overrides pass: " + symbol);
 
                 cast Semantic.Symbol.Classy(symbol).pull_down_super_symbols();
             fi
@@ -73,10 +73,10 @@ namespace Syntax.Process is
         visit(trait_: Definition.TRAIT) is
             let symbol = symbol_for(trait_);
 
-            @IF.debug() System.Console.error.write_line("resolve overrides: " + symbol);
+            @IF.debug() STD.error.write_line("resolve overrides: " + symbol);
 
             if symbol? && isa Semantic.Symbol.Classy(symbol) then
-                @IF.debug() System.Console.error.write_line("from resolve overrides pass: " + symbol);
+                @IF.debug() STD.error.write_line("from resolve overrides pass: " + symbol);
 
                 cast Semantic.Symbol.Classy(symbol).pull_down_super_symbols();
             fi

--- a/src/syntax/process/resolve_type_expressions.ghul
+++ b/src/syntax/process/resolve_type_expressions.ghul
@@ -1,4 +1,6 @@
 namespace Syntax.Process is
+    use STD = System.Console;
+
     use System;
     
     use Logging;
@@ -123,7 +125,7 @@ namespace Syntax.Process is
         si
 
         visit(structured: Tree.TypeExpression.STRUCTURED) is
-            System.Console.error.write_line("visit TypeExpression.STRUCTURED called");
+            STD.error.write_line("visit TypeExpression.STRUCTURED called");
         si
 
         get_type_or_any(element: Semantic.Type.BASE) -> Semantic.Type.BASE is

--- a/src/syntax/process/scopedvisitor.ghul
+++ b/src/syntax/process/scopedvisitor.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Process is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
         
     use Logging;
@@ -23,11 +27,11 @@ namespace Syntax.Process is
             _symbol_table = symbol_table;
         si
 
-        find(name: String) -> Semantic.Symbol.BASE is
+        find(name: string) -> Semantic.Symbol.BASE is
             return _symbol_table.current_scope.find_enclosing(name);
         si
 
-        find_matches(prefix: String, matches: Collections.MAP[String,Semantic.Symbol.BASE]) is
+        find_matches(prefix: string, matches: Collections.MAP[string,Semantic.Symbol.BASE]) is
             _symbol_table.current_scope.find_enclosing_matches(prefix, matches);
         si
         

--- a/src/syntax/process/scopevisitorbase.ghul
+++ b/src/syntax/process/scopevisitorbase.ghul
@@ -1,4 +1,8 @@
 namespace Syntax is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Logging;

--- a/src/syntax/process/signature_help.ghul
+++ b/src/syntax/process/signature_help.ghul
@@ -172,7 +172,7 @@ namespace Syntax.Process is
             fi
 
             if call.function.value.type == null then
-                System.Console.error.write_line("call.function.value.type is null: " + call);
+                STD.error.write_line("call.function.value.type is null: " + call);
                 return;
             fi
 
@@ -186,7 +186,7 @@ namespace Syntax.Process is
                 var ok = true;
 
                 if function_type_arguments.count != arguments.count + 1 then
-                    _logger.error(call.arguments.location, "expected % arguments but % supplied" % [function_type_arguments.count, arguments.count]: Object);
+                    _logger.error(call.arguments.location, "expected % arguments but % supplied" % [function_type_arguments.count, arguments.count]: object);
                     
                     return;
                 elif function_generic_type.name =~ "FUNCTION_" + arguments.count then
@@ -197,7 +197,7 @@ namespace Syntax.Process is
                         then
                             ok = false;
 
-                            _logger.error(call.arguments.location, "expected argument of type % but % supplied" % [function_type_arguments[i], argument_types[i]]: Object);
+                            _logger.error(call.arguments.location, "expected argument of type % but % supplied" % [function_type_arguments[i], argument_types[i]]: object);
                         fi
                     od
 

--- a/src/syntax/process/strictvisitor.ghul
+++ b/src/syntax/process/strictvisitor.ghul
@@ -1,4 +1,8 @@
 namespace Syntax is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     use Tree;
 
@@ -7,7 +11,7 @@ namespace Syntax is
             super.init();
         si
 
-        throwNotImplemented(name: String, node: NODE) is
+        throwNotImplemented(name: string, node: NODE) is
             throw new NotImplementedException(
                 "Visitor " + self + " does not define a visit method for " + name + " " + node.get_type() + " and/or this node does not accept this visitor" 
             );
@@ -153,8 +157,8 @@ namespace Syntax is
             throwNotImplemented("literal", literal);
         si
 
-        visit(string: Expression.Literal.STRING) is
-            throwNotImplemented("string literal", string);
+        visit(string_: Expression.Literal.STRING) is
+            throwNotImplemented("string literal", string_);
         si
 
         visit(integer: Expression.Literal.INTEGER) is

--- a/src/syntax/process/visitor.ghul
+++ b/src/syntax/process/visitor.ghul
@@ -1,4 +1,8 @@
 namespace Syntax is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
 
     use Tree;
@@ -8,7 +12,7 @@ namespace Syntax is
             super.init();
         si
 
-        throwNotImplemented(name: String, node: NODE) is
+        throwNotImplemented(name: string, node: NODE) is
             throw new NotImplementedException(
                 "Visitor " + self + " does not define a visit method for " + name + " " + node.get_type() + " and/or this node does not accept this visitor"
             );
@@ -293,11 +297,11 @@ namespace Syntax is
         visit(literal: Expression.Literal.NODE) is
         si
 
-        pre(string: Expression.Literal.STRING) -> bool is
+        pre(string_: Expression.Literal.STRING) -> bool is
             return false;
         si
 
-        visit(string: Expression.Literal.STRING) is
+        visit(string_: Expression.Literal.STRING) is
         si
 
         pre(integer: Expression.Literal.INTEGER) -> bool is

--- a/src/syntax/tree/body/block.ghul
+++ b/src/syntax/tree/body/block.ghul
@@ -1,7 +1,6 @@
 namespace Syntax.Tree.Body is
     use Source;
 
-    
     class BLOCK: NODE  is
         is_block: bool => true;
         

--- a/src/syntax/tree/definition/function.ghul
+++ b/src/syntax/tree/definition/function.ghul
@@ -1,6 +1,7 @@
 namespace Syntax.Tree.Definition is
-    use Source;
+    use STD = System.Console;
 
+    use Source;
     
     class FUNCTION: MODIFIABLE  is
         name: Identifier.NODE;
@@ -35,13 +36,13 @@ namespace Syntax.Tree.Definition is
                 if name? then
                     name.walk(visitor);
                 else 
-                    System.Console.error.write_line("function name is null");
+                    STD.error.write_line("function name is null");
                 fi
 
                 if arguments? then
                     arguments.walk(visitor);
                 else 
-                    System.Console.error.write_line("function arguments is null");
+                    STD.error.write_line("function arguments is null");
                 fi
 
                 if type_expression? then

--- a/src/syntax/tree/definition/list.ghul
+++ b/src/syntax/tree/definition/list.ghul
@@ -13,8 +13,10 @@ namespace Syntax.Tree.Definition is
             var result = new Collections.LIST[USE](definitions.count);
 
             for d in definitions do
-                if isa USE(d) then
-                    result.add(cast USE(d));
+                let d_without_pragmas = d.without_pragmas;
+
+                if isa USE(d_without_pragmas) then
+                    result.add(cast USE(d_without_pragmas));
                 fi
             od
             

--- a/src/syntax/tree/definition/node.ghul
+++ b/src/syntax/tree/definition/node.ghul
@@ -2,6 +2,8 @@ namespace Syntax.Tree.Definition is
     use Source;
 
     class NODE: Tree.NODE  is
+        without_pragmas: NODE => self;
+
         init(location: LOCATION) is
             super.init(location);
         si

--- a/src/syntax/tree/definition/pragma.ghul
+++ b/src/syntax/tree/definition/pragma.ghul
@@ -4,6 +4,8 @@ namespace Syntax.Tree.Definition is
     use Source;
 
     class PRAGMA: NODE  is
+        without_pragmas: NODE => definition.without_pragmas;
+
         pragma_: Pragma.NODE;
         definition: NODE public;
         

--- a/src/syntax/tree/expression/binary.ghul
+++ b/src/syntax/tree/expression/binary.ghul
@@ -1,15 +1,20 @@
 namespace Syntax.Tree.Expression is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
+
     use System;
     
     use Source;
 
     class BINARY : NODE is
         operation: Identifier.NODE;
-        actual_operation: String;
+        actual_operation: string;
         left: NODE;
         right: NODE;
 
-        init(location: LOCATION, operation: Identifier.NODE, actual_operation: String, left: NODE, right: NODE) is
+        init(location: LOCATION, operation: Identifier.NODE, actual_operation: string, left: NODE, right: NODE) is
             super.init(location);
             
             self.operation = operation;

--- a/src/syntax/tree/expression/literal/boolean.ghul
+++ b/src/syntax/tree/expression/literal/boolean.ghul
@@ -1,11 +1,15 @@
 namespace Syntax.Tree.Expression.Literal is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+    
     use System;
 
     use Source;
 
     class BOOLEAN: Literal.NODE is
-        init(location: LOCATION, string: String) is
-            super.init(location, string);
+        init(location: LOCATION, value_string: string) is
+            super.init(location, value_string);
         si
 
         accept(visitor: Visitor) is

--- a/src/syntax/tree/expression/literal/character.ghul
+++ b/src/syntax/tree/expression/literal/character.ghul
@@ -1,10 +1,14 @@
 namespace Syntax.Tree.Expression.Literal is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
 
     use Source;
 
     class CHARACTER: Literal.NODE  is
-        init(location: LOCATION, value: String) is
+        init(location: LOCATION, value: string) is
             super.init(location, value);
         si
 

--- a/src/syntax/tree/expression/literal/float.ghul
+++ b/src/syntax/tree/expression/literal/float.ghul
@@ -1,11 +1,15 @@
 namespace Syntax.Tree.Expression.Literal is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+    
     use System;
 
     use Source;
 
     class FLOAT: Literal.NODE is
-        init(location: LOCATION, string: String) is
-            super.init(location, string);
+        init(location: LOCATION, value_string: string) is
+            super.init(location, value_string);
         si
 
         accept(visitor: Visitor) is

--- a/src/syntax/tree/expression/literal/integer.ghul
+++ b/src/syntax/tree/expression/literal/integer.ghul
@@ -1,11 +1,15 @@
 namespace Syntax.Tree.Expression.Literal is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
 
     use Source;
 
     class INTEGER: Literal.NODE is
-        init(location: LOCATION, string: String) is
-            super.init(location, string);
+        init(location: LOCATION, value_string: string) is
+            super.init(location, value_string);
         si
 
         accept(visitor: Visitor) is

--- a/src/syntax/tree/expression/literal/node.ghul
+++ b/src/syntax/tree/expression/literal/node.ghul
@@ -1,15 +1,19 @@
 namespace Syntax.Tree.Expression.Literal is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
 
     use Source;
 
     class NODE: Expression.NODE  is
-        string: String;
+        value_string: string;
 
-        init(location: LOCATION, string: String) is
+        init(location: LOCATION, value: string) is
             super.init(location);
             
-            self.string = string;
+            self.value_string = value;
         si
 
         accept(visitor: Visitor) is

--- a/src/syntax/tree/expression/literal/string.ghul
+++ b/src/syntax/tree/expression/literal/string.ghul
@@ -1,11 +1,15 @@
 namespace Syntax.Tree.Expression.Literal is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+        
     use System;
 
     use Source;
 
     class STRING: Literal.NODE is
-        init(location: LOCATION, string: String) is
-            super.init(location, string);
+        init(location: LOCATION, value_string: string) is
+            super.init(location, value_string);
         si
 
         accept(visitor: Visitor) is

--- a/src/syntax/tree/expression/local_variable.ghul
+++ b/src/syntax/tree/expression/local_variable.ghul
@@ -1,14 +1,18 @@
 namespace Syntax.Tree.Expression is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Source;
 
     class LOCAL_VARIABLE: NODE  is
-        name: String;
+        name: string;
 
         init(
             location: LOCATION,
-            name: String
+            name: string
         )
         is
             super.init(location);

--- a/src/syntax/tree/identifier/identifier.ghul
+++ b/src/syntax/tree/identifier/identifier.ghul
@@ -1,21 +1,25 @@
 namespace Syntax.Tree.Identifier is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Source;
 
-    class NODE: Tree.NODE, Collections.Iterable[String] is
-        name: String;
+    class NODE: Tree.NODE, Collections.Iterable[string] is
+        name: string;
 
         qualifier: NODE => null;
         
-        qualifier_names: Collections.LIST[String] => new Collections.LIST[String](0);
+        qualifier_names: Collections.LIST[string] => new Collections.LIST[string](0);
 
-        names: Collections.LIST[String] => new Collections.LIST[String]([name]); // : String;
+        names: Collections.LIST[string] => new Collections.LIST[string]([name]); // : string;
 
         @IL.name.read("GetEnumerator")
-        iterator: Collections.Iterator[String] => names.iterator;
+        iterator: Collections.Iterator[string] => names.iterator;
 
-        init(location: LOCATION, name: String) is
+        init(location: LOCATION, name: string) is
             super.init(location);
 
             if name == null then
@@ -35,7 +39,7 @@ namespace Syntax.Tree.Identifier is
     si
 
     class NONE: NODE is
-        names: Collections.LIST[String] => new Collections.LIST[String](0);
+        names: Collections.LIST[string] => new Collections.LIST[string](0);
 
         init(location: LOCATION) is
             super.init(location, null);
@@ -51,8 +55,8 @@ namespace Syntax.Tree.Identifier is
             return _qualifier;
         si
 
-        qualifier_names: Collections.LIST[String] is
-            var result = new Collections.LIST[String]();
+        qualifier_names: Collections.LIST[string] is
+            var result = new Collections.LIST[string]();
             var p = qualifier;
 
             while p? do
@@ -63,8 +67,8 @@ namespace Syntax.Tree.Identifier is
             return result;
         si
 
-        names: Collections.LIST[String] is
-            var result = new Collections.LIST[String]();
+        names: Collections.LIST[string] is
+            var result = new Collections.LIST[string]();
 
             result.add(name);
 
@@ -79,8 +83,8 @@ namespace Syntax.Tree.Identifier is
         si
 
         @IL.name.read("GetEnumerator")
-        iterator: Collections.Iterator[String] is
-            var result = new Collections.LIST[String]();
+        iterator: Collections.Iterator[string] is
+            var result = new Collections.LIST[string]();
 
             result.add(name);
 
@@ -94,7 +98,7 @@ namespace Syntax.Tree.Identifier is
             return result.iterator;
         si        
 
-        init(location: LOCATION, qualifier: NODE, name: String, completion_target: LOCATION) is
+        init(location: LOCATION, qualifier: NODE, name: string, completion_target: LOCATION) is
             super.init(location, name);
 
             self._qualifier = qualifier;

--- a/src/syntax/tree/modifier/node.ghul
+++ b/src/syntax/tree/modifier/node.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Tree.Modifier is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
 
     use Source;
@@ -8,7 +12,7 @@ namespace Syntax.Tree.Modifier is
             super.init(location);
         si
 
-        name: String is
+        name: string is
             throw new NotImplementedException("" + self + " does not implement name");
         si
 
@@ -36,7 +40,7 @@ namespace Syntax.Tree.Modifier is
     si
 
     class PUBLIC : ACCESS_MODIFIER  is
-        name: String => "public";
+        name: string => "public";
 
         init(location: LOCATION) is
             super.init(location);
@@ -44,7 +48,7 @@ namespace Syntax.Tree.Modifier is
     si
 
     class PROTECTED : ACCESS_MODIFIER  is
-        name: String => "protected";
+        name: string => "protected";
 
         init(location: LOCATION) is
             super.init(location);
@@ -52,7 +56,7 @@ namespace Syntax.Tree.Modifier is
     si
 
     class PRIVATE : ACCESS_MODIFIER  is
-        name: String => "private";
+        name: string => "private";
 
         init(location: LOCATION) is
             super.init(location);
@@ -60,7 +64,7 @@ namespace Syntax.Tree.Modifier is
     si
 
     class STATIC : STORAGE_CLASS  is
-        name: String => "static";
+        name: string => "static";
 
         init(location: LOCATION) is
             super.init(location);
@@ -68,7 +72,7 @@ namespace Syntax.Tree.Modifier is
     si
 
     class CONST : STORAGE_CLASS  is
-        name: String => "const";
+        name: string => "const";
 
         init(location: LOCATION) is
             super.init(location);

--- a/src/syntax/tree/node.ghul
+++ b/src/syntax/tree/node.ghul
@@ -1,5 +1,9 @@
 // import glist;
 namespace Syntax.Tree is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
     
     use Source;
@@ -62,7 +66,7 @@ namespace Syntax.Tree is
         si        
 
         @IL.name("ToString")
-        to_string() -> String is
+        to_string() -> string is
             var printer = new Process.Printer.GHUL();
             accept(printer);
             return printer.result;

--- a/src/syntax/tree/type/built_in.ghul
+++ b/src/syntax/tree/type/built_in.ghul
@@ -1,4 +1,8 @@
 namespace Syntax.Tree.TypeExpression is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use System;
 
     use Source;
@@ -8,7 +12,7 @@ namespace Syntax.Tree.TypeExpression is
             super.init(location);
         si
 
-        name: String is
+        name: string is
             throw new NotImplementedException("" + self + " does not implement name");
         si
 
@@ -37,7 +41,7 @@ namespace Syntax.Tree.TypeExpression is
             super.init(location);
         si
 
-        name: String is
+        name: string is
             return "void";
         si
 
@@ -49,7 +53,7 @@ namespace Syntax.Tree.TypeExpression is
             poison();
         si
 
-        name: String is
+        name: string is
             return "undefined";
         si
 
@@ -60,7 +64,7 @@ namespace Syntax.Tree.TypeExpression is
             super.init(location);
         si
 
-        name: String is
+        name: string is
             return "none";
         si
     si
@@ -70,7 +74,7 @@ namespace Syntax.Tree.TypeExpression is
             super.init(location);
         si
 
-        name: String is
+        name: string is
             return "infer";
         si
 
@@ -90,7 +94,7 @@ namespace Syntax.Tree.TypeExpression is
             return 1;
         si
 
-        name: String is
+        name: string is
             return "bool";
         si
 
@@ -105,7 +109,7 @@ namespace Syntax.Tree.TypeExpression is
             return 1;
         si
 
-        name: String is
+        name: string is
             return "byte";
         si
 
@@ -120,7 +124,7 @@ namespace Syntax.Tree.TypeExpression is
             return 1;
         si
 
-        name: String is
+        name: string is
             return "char";
         si
 
@@ -135,7 +139,7 @@ namespace Syntax.Tree.TypeExpression is
             return 4;
         si
 
-        name: String is
+        name: string is
             return "int";
         si
 
@@ -150,7 +154,7 @@ namespace Syntax.Tree.TypeExpression is
             return 8;
         si
 
-        name: String is
+        name: string is
             return "word";
         si
 
@@ -165,7 +169,7 @@ namespace Syntax.Tree.TypeExpression is
             return 8;
         si
 
-        name: String is
+        name: string is
             return "long";
         si
     si

--- a/src/system/collections.ghul
+++ b/src/system/collections.ghul
@@ -1,5 +1,9 @@
 namespace Collections is
-    class LIST_REVERSE_ITERATOR[T]: System.Object, Iterator[T] is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
+    class LIST_REVERSE_ITERATOR[T]: object, Iterator[T] is
         _list: LIST[T];
         _index: int;
 

--- a/src/system/lazy.ghul
+++ b/src/system/lazy.ghul
@@ -1,4 +1,8 @@
 namespace System is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     @IL.stub()
 
     @IL.name("class [mscorlib]System.Lazy`1")

--- a/src/system/shim.count.ghul
+++ b/src/system/shim.count.ghul
@@ -1,4 +1,8 @@
 namespace Shim is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use Collections;
 
     class COUNT[T] is

--- a/src/system/shim.filter.ghul
+++ b/src/system/shim.filter.ghul
@@ -1,7 +1,11 @@
 namespace Shim is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use Collections;
 
-    class FILTER[T]: System.Object, Iterable[T] is
+    class FILTER[T]: object, Iterable[T] is
         _iterable: Iterable[T];
         _predicate: (T) -> bool;
 

--- a/src/system/shim.first.ghul
+++ b/src/system/shim.first.ghul
@@ -1,4 +1,8 @@
 namespace Shim is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use Collections.Iterable;
     use Collections.Iterator;
 

--- a/src/system/shim.format.ghul
+++ b/src/system/shim.format.ghul
@@ -1,17 +1,18 @@
 namespace Shim is
-    use System.Object;
-    use System.String;
-
-    class FMT is
-        to_string(object: Object) -> String is
-            if object? then
-                return object.to_string();
-            else
-                return "null";
-            fi            
-        si
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
         
-        to_string(value: char) ->String => cast int(value).to_string("X");
-    si
+    // class FMT is
+    //     to_string(object: object) -> string is
+    //         if object? then
+    //             return object.to_string();
+    //         else
+    //             return "null";
+    //         fi
+    //     si
+        
+    //     to_string(value: char) ->string => cast int(value).to_string("X");
+    // si
     
 si

--- a/src/system/shim.join.ghul
+++ b/src/system/shim.join.ghul
@@ -1,6 +1,9 @@
 namespace Shim is
-    use System.String;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
 
+    
     use System.Text.StringBuilder;
     
     use Collections.Iterable;
@@ -8,9 +11,9 @@ namespace Shim is
 
     class JOIN[T] is
         _values: Iterable[T];
-        _delimiter: String;
+        _delimiter: string;
 
-        result: String is
+        result: string is
             let seen_any = false;
 
             let result = new StringBuilder();
@@ -33,20 +36,20 @@ namespace Shim is
             _delimiter = ",";
         si
 
-        init(values: Iterable[T], delimiter: String) is
+        init(values: Iterable[T], delimiter: string) is
             _values = values;
             _delimiter = delimiter;
         si
         
         @IL.name("ToString")
-        to_string() -> String => result;
+        to_string() -> string => result;
     si
 
     class JOIN_SORTED[T] is
-        result: String;
+        result: string;
 
         init(values: Iterable[T]) is
-            let list = new LIST[String](10);
+            let list = new LIST[string](10);
 
             let required_length = 2;
 
@@ -75,6 +78,6 @@ namespace Shim is
         si
         
         @IL.name("ToString")
-        to_string() -> String => result;
+        to_string() -> string => result;
     si
 si

--- a/src/system/shim.mapper.ghul
+++ b/src/system/shim.mapper.ghul
@@ -1,8 +1,12 @@
 namespace Shim is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use Collections.Iterable;
     use Collections.Iterator;
 
-    class MAPPER[F,T]: System.Object,Iterable[T] is
+    class MAPPER[F,T]: object,Iterable[T] is
         iterable: Iterable[F];
         mapper: (F) -> T;
 
@@ -17,7 +21,7 @@ namespace Shim is
         si
     si
 
-    class MAPPER_ITERATOR[F,T]: System.Object,Iterator[T] is
+    class MAPPER_ITERATOR[F,T]: object,Iterator[T] is
         _iterator: Iterator[F];
         _mapper: (F) -> T;
 

--- a/src/system/shim.object.ghul
+++ b/src/system/shim.object.ghul
@@ -1,9 +1,11 @@
 namespace Shim is
-    use System.Object;
-    use System.String;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
 
+        
     class OBJ is
-        type_name(value: Object) -> String static is
+        type_name(value: object) -> string static is
             if !value? then
                 return "null";
             else
@@ -11,8 +13,8 @@ namespace Shim is
             fi
         si
 
-        hash(value: Object) -> int static => value.get_hash_code();
+        hash(value: object) -> int static => value.get_hash_code();
 
-        shallow_clone(value: Object) -> Object static => value.memberwise_clone();
+        shallow_clone(value: object) -> object static => value.memberwise_clone();
     si
 si

--- a/src/system/shim.only.ghul
+++ b/src/system/shim.only.ghul
@@ -1,4 +1,8 @@
 namespace Shim is
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
+
     use Collections.Iterable;
     use Collections.Iterator;
 

--- a/src/system/shim.sort.ghul
+++ b/src/system/shim.sort.ghul
@@ -1,13 +1,16 @@
 namespace Shim is
-    use System.String;
+    use object = System.Object;
+    use string = System.String;
+    use STD = System.Console;
 
+    
     use System.Text.StringBuilder;
     
     use Collections.Iterable;
     use Collections.Iterator;
     use Collections.LIST;
 
-    class SORT[T]: System.Object, Iterable[T] is
+    class SORT[T]: object, Iterable[T] is
         _values: Collections.LIST[T];
 
         iterator: Iterator[T] => _values.iterator;

--- a/tests/integration/hello-world/test.ghul
+++ b/tests/integration/hello-world/test.ghul
@@ -1,11 +1,11 @@
 namespace Test is
-    use System;
+    use STD = System.Console;
     
     class Main is
         entry() static is
             @IL.entrypoint()
 
-            Console.write_line("hello, world");
+            STD.output.write_line("hello, world");
         si
     si    
 si


### PR DESCRIPTION
Bug fixes:
- Conditional compilation does not work with `use` (closes #618)

Technical:
- Start adding aliases needed to support transition to consuming .NET types from assemblies via reflection (see #491, #610)