### PR TITLE
Fix issue with stable symbols

### DIFF
--- a/src/driver/main.ghul
+++ b/src/driver/main.ghul
@@ -173,6 +173,10 @@ namespace Driver is
                 fi
             od
 
+            if !flags.want_stubs then
+                container.stable_symbols.enable();
+            fi
+            
             container.conditional_compilation.set_is_enabled(conditional_defines);
         si
 

--- a/src/semantic/overload_resolver.ghul
+++ b/src/semantic/overload_resolver.ghul
@@ -238,7 +238,7 @@ namespace Semantic is
                 );
         si
         
-        @IF.not.blah() 
+        @IF.debug() 
         dump_ancestors(type: Type, depth: int) static is
             for i in 0..depth do
                 Std.error.write("  ");

--- a/src/semantic/stable_symbols.ghul
+++ b/src/semantic/stable_symbols.ghul
@@ -24,6 +24,7 @@ namespace Semantic is
     class STABLE_SYMBOLS is
         _generation: int;
         _symbols: MAP[Node,STABLE_SYMBOL];
+        _is_enabled: bool;
 
         [node: Node] -> Scope is
             let result: STABLE_SYMBOL;
@@ -37,9 +38,17 @@ namespace Semantic is
             _symbols = new MAP[Node,STABLE_SYMBOL]();
         si
 
+        enable() is
+            _is_enabled = true;
+        si
+
         is_stable(node: Node) -> bool is
             let symbol: STABLE_SYMBOL;
 
+            if !_is_enabled then
+                return false;
+            fi
+            
             if _symbols.try_get_value(node, symbol ref) then
                 @IF.debug() Std.error.write_line("SSSSSS: is stable: " + symbol + " vs " + _generation + ": " + (_generation > symbol.generation));
 
@@ -48,10 +57,18 @@ namespace Semantic is
         si
         
         try_get_symbol(node: Node, result: STABLE_SYMBOL ref) -> bool is
+            if !_is_enabled then
+                return false;
+            fi
+
             return _symbols.try_get_value(node, result);
         si
 
         add(node: Node, scope: Scope) is
+            if !_is_enabled then
+                return;
+            fi
+            
             _symbols[node] = new STABLE_SYMBOL(_generation, scope);
         si
 

--- a/src/semantic/symbol/symbol.ghul
+++ b/src/semantic/symbol/symbol.ghul
@@ -89,7 +89,7 @@ namespace Semantic.Symbols is
 
         name: string => _name;
 
-        is_internal: bool => _name.starts_with("__");
+        is_internal: bool => _name.starts_with("__") || location == Source.LOCATION._dummy;
 
         qualified_name: string is
             // assert owner? else "" + get_type() + " " + name + " has no qualified name because owner is null";
@@ -514,7 +514,6 @@ namespace Semantic.Symbols is
                 let existing = _symbols[member.name];
 
                 if existing == member then
-                    // 
                     return true;
                 fi
 
@@ -523,23 +522,26 @@ namespace Semantic.Symbols is
                 fi
                 
                 if isa FUNCTION_GROUP(existing) then
-                    assert isa Function(member) else " cannot inherit function " + member + " over the top of non function member " + existing;
+                    if isa Function(member) then
+                        cast FUNCTION_GROUP(existing).add(cast Function(member));
+                    elif !member.is_internal || !existing.is_internal then                        
+                        throw new Exception("cannot inherit function " + member + " over the top of non function member " + existing);
+                    fi
 
-                    // 
-                    cast FUNCTION_GROUP(existing).add(cast Function(member));
                     return true;
                 elif isa Function(existing) then
-                    // 
-                    assert isa Function(member) else " cannot inherit function " + member + " over the top of non function member " + existing;
+                    if isa Function(member) then
+                        let fg = new FUNCTION_GROUP(location, self, member.name);
 
-                    let fg = new FUNCTION_GROUP(location, self, member.name);
+                        fg.add(cast Function(existing));
+                        fg.add(cast Function(member));
 
-                    fg.add(cast Function(existing));
-                    fg.add(cast Function(member));
-
-                    _symbols[member.name] = fg;
+                        _symbols[member.name] = fg;
+                    elif !member.is_internal || !existing.is_internal then
+                        throw new Exception("cannot inherit function " + member + " over the top of non function member " + existing);
+                    fi
                     return true;
-                else
+                elif !member.is_internal || !existing.is_internal then
                     throw new System.Exception("cannot inherit non-function " + member + " over the top of non-function member " + existing);
                 fi
 
@@ -557,9 +559,7 @@ namespace Semantic.Symbols is
                 _symbols[member.name] = fg;
             else
                 _symbols[member.name] = member;                                    
-            fi            
-
-            // 
+            fi
 
             return true;
         si

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -31,8 +31,6 @@ namespace Syntax.Process is
         _stub_depth: int;
         _keep_depth: int;
 
-        _are_keepers_defined: bool;
-
         init(
             logger: Logger,
             stable_symbols: Semantic.STABLE_SYMBOLS,

--- a/src/syntax/process/declare_symbols.ghul
+++ b/src/syntax/process/declare_symbols.ghul
@@ -260,7 +260,7 @@ namespace Syntax.Process is
             if _keep_depth > 0 then
                 _stable_symbols.add(classy, symbol);
 
-                @IF.not.release() Std.error.write_line("re-define stable symbol " + symbol);
+                @IF.debug() Std.error.write_line("re-define stable symbol " + symbol);
             fi
             
             declare_generic_arguments(classy.arguments);


### PR DESCRIPTION
Bug fixes:
- Fix issue where stable symbols were enabled when not consuming types from stubs (closes #634)

Technical:
- Relax inheritance consistency checks for internal symbols to avoid spurious errors while work on materialization of symbols via reflection is still ongoing