### PR TITLE
Disable building + testing on Mono

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
     strategy:
       matrix:
-        host: [mono, dotnet]
+        host: [dotnet]
 
     container:
       image: ghcr.io/degory/ghul/devcontainer:${{ matrix.host }}
@@ -87,8 +87,8 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        host: [mono, dotnet]
-        target: [mono, dotnet]
+        host: [dotnet]
+        target: [dotnet]
 
     env:
       HOST: ${{ matrix.host }}
@@ -129,7 +129,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        host: [mono, dotnet]
+        host: [dotnet]
 
     timeout-minutes: 5
 
@@ -164,7 +164,7 @@ jobs:
     timeout-minutes: 6
     strategy:
       matrix:
-        host: [mono, dotnet]
+        host: [dotnet]
 
     container:
       image: ghcr.io/degory/ghul/devcontainer:${{ matrix.host }}-${{ needs.version.outputs.number }}
@@ -196,7 +196,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        host: [mono, dotnet]
+        host: [dotnet]
 
     timeout-minutes: 5
 

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ dkms.conf
 # Emacs backups
 *~
 \#*\#
+tests/integration/hello-world/output.txt


### PR DESCRIPTION
Technical:
- Remove Mono from the GitHub workflow build + test matrixes (see #672)