### PR TITLE
Fix tests not run on release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,10 +112,10 @@ jobs:
       run: bash ./ghul.run
 
     - name: Install ghul-test
-      run: dotnet tool install --global ghul.test 
+      run: mkdir -p tools ; dotnet tool install ghul.test --tool-path ./tools
 
     - name: Run tests
-      run: bash -c "set -o pipefail ; ghul-test tests | tee test-results.txt"        
+      run: bash -c "set -o pipefail ; ./tools/ghul-test tests | tee test-results.txt"        
 
     - uses: actions/upload-artifact@v2
       if: ${{ always() }}
@@ -184,16 +184,16 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install ghul-test
-      run: dotnet tool install --global ghul.test 
+      run: mkdir -p tools ; dotnet tool install ghul.test --tool-path ./tools
 
     - name: Run tests
-      run: bash -c "set -o pipefail ; ghul-test tests | tee container-test-results.txt"
+      run: bash -c "set -o pipefail ; ./tools/ghul-test tests | tee test-results.txt"        
 
     - uses: actions/upload-artifact@v2
       if: ${{ always() }}
       with:
         name: container-test-results-${{ matrix.host }}-${{ matrix.version }}
-        path: container-test-results.txt
+        path: test-results.txt
 
   tag_containers:
     needs: [version, container_tests]


### PR DESCRIPTION
Bugs fixed:
- Tests are not run on release build because global .NET tools folder is not on the PATH