### PR TITLE
Escape keywords in reflected member names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ on:
 
   pull_request:
   push:
-    branches:
-      - "main"
+    branches: [master, main]
+
 env:
   CI: true
 


### PR DESCRIPTION
Enhancements:
- Escape reflected type member names that would otherwise conflict with ghūl keywords
- Allow backtick as first character in identifiers

Bugs fixed:
- Release build disabled due to incorrect branch name in workflow yaml

Technical:
- Improved version number validity check in GitHub workflow
- Allow version number to be entered when manually running build workflow