### PR TITLE
Fix incorrect build workflow dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,7 +293,7 @@ jobs:
       run: docker push ghul/devcontainer:dotnet
 
   publish_release_package:
-    needs: [version, tests, container_tests]
+    needs: [version, container_tests]
     name: Publish release package
 
     timeout-minutes: 5
@@ -311,10 +311,10 @@ jobs:
         name: ghul-compiler-package
         path: nupkg
 
-    - name: Publish release package to GitHub
-      run: dotnet nuget push ./nupkg/ghul.compiler.${{ needs.version.outputs.package }}.nupkg -k ${GITHUB_TOKEN} -s https://nuget.pkg.github.com/degory/index.json --skip-duplicate --no-symbols true
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # - name: Publish release package to GitHub
+    #   run: dotnet nuget push ./nupkg/ghul.compiler.${{ needs.version.outputs.package }}.nupkg -k ${GITHUB_TOKEN} -s https://nuget.pkg.github.com/degory/index.json --skip-duplicate --no-symbols true
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Publish release package to NuGet
       run: dotnet nuget push ./nupkg/ghul.compiler.${{ needs.version.outputs.package }}.nupkg -k ${NUGET_TOKEN} -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols true


### PR DESCRIPTION
Fix incorrect build workflow dependency, which prevents the 'publish release package' and 'create release' jobs from executing