### PR TITLE
Code clean-ups

### DIFF
--- a/ghul.ghulproj
+++ b/ghul.ghulproj
@@ -8,7 +8,7 @@
     <PackageId>ghul.compiler</PackageId>
     <Authors>degory</Authors>
     <Company>ghul.io</Company>
-    <Version>0.2.109-alpha.6</Version>
+    <Version>0.2.110-alpha.3</Version>
 
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <RepositoryUrl>https://github.com/degory/ghul</RepositoryUrl>
@@ -33,18 +33,6 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-
-  <Target Name="CreateManifestResourceNames" />
-
-  <!-- FIXME: share this target -->
-  <Target Name="GhulAssembliesJson"  DependsOnTargets="FindReferenceAssembliesForReferences">
-    <PropertyGroup>
-      <Assemblies>{"assemblies": [@(ReferencePathWithRefAssemblies -> '"%(fullpath)"', ',')]}</Assemblies>
-    </PropertyGroup>
-
-    <WriteLinesToFile File=".assemblies.json" Lines="$(Assemblies)" Overwrite="true" Encoding="Utf-8" />
-    <Message Importance="high" Text="updated $(OutputFile) with referenced assemblies" />
-  </Target>  
 
   <!-- FIXME: share this target -->
   <Target Name="CoreCompile" DependsOnTargets="$(CoreCompileDependsOn)"
@@ -79,16 +67,27 @@
       <CommandLine>--v3 --define release @(Compile -> '%(fullpath)', '%20') -o $(IntermediateOutputPath)$(AssemblyName).dll @(ReferencePathWithRefAssemblies -> '--assembly %(fullpath)', '%20')</CommandLine>
     </PropertyGroup>
 
-    <WriteLinesToFile File="build.txt" Lines="$(CommandLine)" Overwrite="true" Encoding="Utf-8" />
+    <WriteLinesToFile File=".build.rsp" Lines="$(CommandLine)" Overwrite="true" Encoding="Utf-8" />
 
     <Message Importance="high" Text="building with $(GhulCompiler)" />
 
     <Message Importance="low" Text="$(CommandLine)" />
 
-    <Exec Command="$(GhulCompiler) $(ReleaseOption) @build.txt" />
+    <Exec Command="$(GhulCompiler) $(ReleaseOption) @.build.rsp" />
 
-    <Delete Files="build.txt" />
+    <Delete Files=".build.rsp" />
 
     <Copy SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(AssemblyName).dll" DestinationFolder="$(ProjectDir)$(IntermediateOutputPath)ref" />
   </Target>
+
+  <Target Name="GenerateAssembliesJson"  DependsOnTargets="FindReferenceAssembliesForReferences">
+    <PropertyGroup>
+      <Assemblies>{"assemblies": [@(ReferencePathWithRefAssemblies -> '"%(fullpath)"', ',')]}</Assemblies>
+    </PropertyGroup>
+
+    <WriteLinesToFile File=".assemblies.json" Lines="$(Assemblies)" Overwrite="true" Encoding="Utf-8" />
+    <Message Importance="high" Text="updated $(OutputFile) with referenced assemblies" />
+  </Target>  
+
+  <Target Name="CreateManifestResourceNames" />
 </Project>

--- a/src/driver/main.ghul
+++ b/src/driver/main.ghul
@@ -12,8 +12,6 @@ namespace Driver is
 
     use System.Text.RegularExpressions.Regex;
     use System.Text.RegularExpressions.Match;
-
-    use Pipes;
     
     use IoC;
     use Logging;
@@ -73,7 +71,7 @@ namespace Driver is
 
             let re = new Regex("(?<=\")[^\"]*(?=\")|[^\" ]+");
 
-            let arguments = Pipe.from(re.matches(text)).map(m: Match => m.value);
+            let arguments = re.matches(text) | .map(m: Match => m.value);
 
             add_arguments(seen_files, result, arguments);
         si

--- a/src/ir/values/value.ghul
+++ b/src/ir/values/value.ghul
@@ -4,8 +4,6 @@ namespace IR.Values is
     use System.NotImplementedException;
     use System.Text.StringBuilder;
 
-    use Pipes;
-
     use TypeTyped = Semantic.Types.Typed;
     use Semantic.Types.Type;
     use SymbolBase = Semantic.Symbols.Symbol;
@@ -77,7 +75,7 @@ namespace IR.Values is
         si
 
         to_string() -> string =>
-            "new:[" + type + "](\"" + constructor.name + "\"," + Pipe.from(arguments).to_string(",") + ")";
+            "new:[" + type + "](\"" + constructor.name + "\"," + arguments | .to_string(",") + ")";
     si
 
     class TYPE_WRAPPER: Value is
@@ -609,27 +607,27 @@ namespace IR.Values is
 
     namespace Load is
         class SELF: Value, TypeTyped is
-            self_: SymbolBase;
+            `self: SymbolBase;
             has_type: bool => type?;
             type: Type;
 
             is_self: bool => true;
             has_address: bool => true;
 
-            init(self_: SymbolBase) is
-                init(self_, null);
+            init(`self: SymbolBase) is
+                init(`self, null);
             si
             
-            init(self_: SymbolBase, type: Type) is
+            init(`self: SymbolBase, type: Type) is
                 super.init();
-                assert self_?;
+                assert `self?;
  
-                self.self_ = self_;
+                self.`self = `self;
 
                 if type? then
                     self.type = type;
-                elif isa TypeTyped(self_) then
-                    self.type = cast TypeTyped(self_).type;
+                elif isa TypeTyped(`self) then
+                    self.type = cast TypeTyped(`self).type;
                 fi
             si
 
@@ -648,12 +646,12 @@ namespace IR.Values is
         class SUPER: SELF is
             is_super: bool => true;
 
-            init(self_: SymbolBase) is
-                init(self_, null);
+            init(`self: SymbolBase) is
+                init(`self, null);
             si
             
-            init(self_: SymbolBase, type: Type) is
-                super.init(self_, type);
+            init(`self: SymbolBase, type: Type) is
+                super.init(`self, type);
             si
 
             to_string() -> string =>

--- a/src/semantic/dotnet/assembly_references.ghul
+++ b/src/semantic/dotnet/assembly_references.ghul
@@ -3,8 +3,6 @@ namespace Semantic.DotNet is
 
     use Collections.SET;
 
-    use Pipes;
-
     class REFERENCED_ASSEMBLIES is
         _boilerplate_generator: IR.BOILERPLATE_GENERATOR;        
         _references: SET[REFERENCED_ASSEMBLY];

--- a/src/semantic/overload_resolver.ghul
+++ b/src/semantic/overload_resolver.ghul
@@ -1,7 +1,5 @@
 namespace Semantic is
     use System.Exception;
-    
-    use Pipes;
 
     use Logging;
     use Source;
@@ -184,15 +182,15 @@ namespace Semantic is
                 if is_ambiguous then
                     _logger.error(
                         location, 
-                        "call is ambiguous " + group.name + "(" + Pipe.from(arguments) + "), tried " + get_sorted_function_list_as_string(ambiguous_matches)
+                        "call is ambiguous " + group.name + "(" + arguments| + "), tried " + get_sorted_function_list_as_string(ambiguous_matches)
                 );
                 elif tried.count > 0 then
                     _logger.error(
                         location, 
-                        "no overload found for " + group.name + "(" + Pipe.from(arguments) + "), tried " + get_sorted_function_list_as_string(tried)
+                        "no overload found for " + group.name + "(" + arguments| + "), tried " + get_sorted_function_list_as_string(tried)
                     );
                 else
-                    _logger.error(location, "no overload found for " + group.name + "(" + Pipe.from(arguments) + ")");
+                    _logger.error(location, "no overload found for " + group.name + "(" + arguments| + ")");
                 fi
             fi
 
@@ -200,8 +198,7 @@ namespace Semantic is
         si
 
         get_sorted_function_list_as_string(functions: Collections.Iterable[Symbols.Function]) -> string static =>
-            Pipe
-                .from(functions)
+            functions |
                 .map(f: Symbols.Function => f.to_string())
                 .sort()
                 .to_string();        
@@ -275,7 +272,7 @@ namespace Semantic is
                     Std.error.write("  ");
                 od
 
-                Std.error.write_line("DDDDDD: " + type + " has ancestor " + a + " " + a.symbol + " (" + a.symbol.get_hash_code() + ") [" + Pipe.from(a.arguments) + "]");
+                Std.error.write_line("DDDDDD: " + type + " has ancestor " + a + " " + a.symbol + " (" + a.symbol.get_hash_code() + ") [" + a.arguments| + "]");
 
                 dump_ancestors(a, depth + 1);
             od

--- a/src/semantic/scope/block_scope.ghul
+++ b/src/semantic/scope/block_scope.ghul
@@ -102,7 +102,7 @@ namespace Semantic is
         declare_function(location: LOCATION, name: string, is_static: bool, is_private: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Symbol =>
             declare_undefined(location, "function", name);
 
-        declare_namespace(location: LOCATION, name: string, namespace_: Symbols.NAMESPACE, symbol_definition_listener: SymbolDefinitionListener) is
+        declare_namespace(location: LOCATION, name: string, `namespace: Symbols.NAMESPACE, symbol_definition_listener: SymbolDefinitionListener) is
             declare_undefined(location, "namespace", name);
         si
 

--- a/src/semantic/scope/namespace_scope.ghul
+++ b/src/semantic/scope/namespace_scope.ghul
@@ -37,8 +37,8 @@ namespace Semantic is
 
         is_trait: bool => false;
 
-        init(namespace_: Symbols.NAMESPACE) is
-            _namespace = namespace_;
+        init(`namespace: Symbols.NAMESPACE) is
+            _namespace = `namespace;
             _symbols = new Collections.MAP[string,Symbols.Symbol]();
             _used_symbols = new Collections.MAP[string,Symbols.Symbol]();
             _used_namespaces = new Collections.LIST[Symbols.NAMESPACE]();
@@ -167,12 +167,12 @@ namespace Semantic is
             _namespace.declare_label(location, name, symbol_definition_listener);
         si
         
-        declare_namespace(location: LOCATION, name: string, namespace_: Symbols.NAMESPACE, symbol_definition_listener: SymbolDefinitionListener) is
-            _namespace.declare_namespace(location, name, namespace_, symbol_definition_listener);
+        declare_namespace(location: LOCATION, name: string, `namespace: Symbols.NAMESPACE, symbol_definition_listener: SymbolDefinitionListener) is
+            _namespace.declare_namespace(location, name, `namespace, symbol_definition_listener);
         si
 
-        add(namespace_: Symbols.NAMESPACE) is
-            _used_namespaces.add(namespace_);
+        add(`namespace: Symbols.NAMESPACE) is
+            _used_namespaces.add(`namespace);
         si
 
         add(name: string, symbol: Symbols.Symbol) is

--- a/src/semantic/scope/scope.ghul
+++ b/src/semantic/scope/scope.ghul
@@ -55,6 +55,6 @@ namespace Semantic is
     si
 
     trait NamespaceContext is
-        declare_namespace(location: LOCATION, name: string, namespace_: Symbols.NAMESPACE, symbol_definition_listener: SymbolDefinitionListener);
+        declare_namespace(location: LOCATION, name: string, `namespace: Symbols.NAMESPACE, symbol_definition_listener: SymbolDefinitionListener);
     si
 si

--- a/src/semantic/symbol_use_locations.ghul
+++ b/src/semantic/symbol_use_locations.ghul
@@ -48,11 +48,11 @@ namespace Semantic is
                 od  
             fi
 
-            let set_ = get_references_set(symbol);
+            let refs = get_references_set(symbol);
                 
-            if !set_.contains(location) then
+            if !refs.contains(location) then
                 // FIXME: why is this getting called multiple times for the same symbol and location?
-                set_.add(location);
+                refs.add(location);
             fi
         si
 

--- a/src/semantic/symbols/function_group.ghul
+++ b/src/semantic/symbols/function_group.ghul
@@ -1,7 +1,5 @@
 namespace Semantic.Symbols is
     use System.NotImplementedException;
-
-    use Pipes;
     
     use IoC;
     use Logging;
@@ -85,6 +83,6 @@ namespace Semantic.Symbols is
         si
 
         to_string() -> string =>
-            description + " [" + Pipe.from(functions) + "]";
+            description + " [" + functions| + "]";
     si
 si

--- a/src/semantic/symbols/generic.ghul
+++ b/src/semantic/symbols/generic.ghul
@@ -3,8 +3,6 @@ namespace Semantic.Symbols is
 
     use System.Text.StringBuilder;
 
-    use Pipes;
-    
     use IoC;
     use Logging;
     use Source;

--- a/src/semantic/symbols/method_override_class.ghul
+++ b/src/semantic/symbols/method_override_class.ghul
@@ -9,8 +9,6 @@ namespace Semantic is
     use Collections.MAP;
     use Collections.SET;
 
-    use Pipes;
-
     use Symbols.Function;
 
     use Types.Type;
@@ -60,6 +58,6 @@ namespace Semantic is
             return result;
         si
 
-        to_string() -> string => "(" + Pipe.from(arguments) + ")";
+        to_string() -> string => "(" + arguments| + ")";
     si    
 si

--- a/src/semantic/symbols/method_override_map.ghul
+++ b/src/semantic/symbols/method_override_map.ghul
@@ -9,8 +9,6 @@ namespace Semantic is
     use Collections.MAP;
     use Collections.SET;
 
-    use Pipes;
-
     use Symbols.Symbol;
     use Symbols.Function;
     
@@ -20,7 +18,7 @@ namespace Semantic is
         name: string;
 
         methods: MAP[METHOD_OVERRIDE_CLASS,METHOD_OVERRIDE_SET];
-        symbols: Iterable[Symbol] => Pipe.from(_symbols).map(w: SYMBOL_WRAPPER => w.symbol);
+        symbols: Iterable[Symbol] => _symbols| .map(w: SYMBOL_WRAPPER => w.symbol);
 
         iterator: Iterator[METHOD_OVERRIDE_SET] => methods.values.iterator;
 
@@ -86,7 +84,7 @@ namespace Semantic is
                 result.append(name + ": [" + s.key + ": " + s.value + "]");
             od
 
-            result.append(" others: ").append(Pipe.from(symbols));
+            result.append(" others: ").append(symbols|);
             
             return result.to_string();
         si

--- a/src/semantic/symbols/method_override_set.ghul
+++ b/src/semantic/symbols/method_override_set.ghul
@@ -8,8 +8,6 @@ namespace Semantic is
 
     use Collections.SET;
 
-    use Pipes;
-
     use Symbols.Function;
 
     class DUMMY: object, Iterable[Function] is
@@ -20,8 +18,7 @@ namespace Semantic is
         iterator: Iterator[Function] => iterable.iterator;
  
         iterable: Iterable[Function] => 
-            Pipe
-                .from(_set)
+            _set |
                 .map(from: FUNCTION_WRAPPER => from.function);
 
         count: int => _set.count;
@@ -37,7 +34,7 @@ namespace Semantic is
             _set.add(new FUNCTION_WRAPPER(method));
         si
                   
-        to_string() -> string => "" + override_class + ": " + Pipe.from(_set);
+        to_string() -> string => "" + override_class + ": " + _set|;
 
         get_overrider(into: Symbols.Symbol) -> Function is
             @IF.debug()  Std.error.write_line("get overrider from: " + into);
@@ -49,7 +46,7 @@ namespace Semantic is
                 od
             fi
 
-            return Pipe.from(iterable).first();
+            return iterable| .first();
         si
     si
 
@@ -61,8 +58,7 @@ namespace Semantic is
         iterator: Iterator[Function] => iterable.iterator;
  
         iterable: Iterable[Function] => 
-            Pipe
-                .from(_set)
+            _set |
                 .map(from: FUNCTION_WRAPPER => from.function);
 
         count: int => _set.count;
@@ -78,7 +74,7 @@ namespace Semantic is
             _set.add(new FUNCTION_WRAPPER(method));
         si
                   
-        to_string() -> string => "" + override_class + ": " + Pipe.from(_set);
+        to_string() -> string => "" + override_class + ": " + _set|;
 
         get_overrider(into: Symbols.Symbol) -> Function is
             @IF.debug()  Std.error.write_line("get overrider from: " + into);
@@ -90,7 +86,7 @@ namespace Semantic is
                 od
             fi
 
-            return Pipe.from(iterable).first();
+            return iterable| .first();
         si
     si
 si

--- a/src/semantic/symbols/namespace.ghul
+++ b/src/semantic/symbols/namespace.ghul
@@ -96,12 +96,12 @@ namespace Semantic.Symbols is
             declare(symbol.location, symbol, null);
         si
 
-        declare_namespace(location: LOCATION, name: string, namespace_: Symbols.NAMESPACE, symbol_definition_listener: SymbolDefinitionListener) is
+        declare_namespace(location: LOCATION, name: string, `namespace: Symbols.NAMESPACE, symbol_definition_listener: SymbolDefinitionListener) is
             assert name?;
-            assert namespace_?;
-            assert namespace_.name?;
+            assert `namespace?;
+            assert `namespace.name?;
 
-            declare(location, namespace_, symbol_definition_listener);
+            declare(location, `namespace, symbol_definition_listener);
         si
 
         declare_class(location: LOCATION, name: string, arguments: Collections.LIST[string], is_stub: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Symbol is

--- a/src/semantic/symbols/symbol.ghul
+++ b/src/semantic/symbols/symbol.ghul
@@ -467,7 +467,7 @@ namespace Semantic.Symbols is
             declare_undefined(Source.LOCATION.internal, "internal", symbol.name);
         si
 
-        declare_namespace(location: LOCATION, name: string, namespace_: NAMESPACE, symbol_definition_listener: SymbolDefinitionListener) is
+        declare_namespace(location: LOCATION, name: string, `namespace: NAMESPACE, symbol_definition_listener: SymbolDefinitionListener) is
             declare_undefined(location, "namespace", name);
         si
 
@@ -636,7 +636,7 @@ namespace Semantic.Symbols is
             declare_undefined(Source.LOCATION.internal, "internal", symbol.name);
         si
         
-        declare_namespace(location: LOCATION, name: string, namespace_: NAMESPACE, symbol_definition_listener: SymbolDefinitionListener) is
+        declare_namespace(location: LOCATION, name: string, `namespace: NAMESPACE, symbol_definition_listener: SymbolDefinitionListener) is
             declare_undefined(location, "namespace", name);
         si
 

--- a/src/semantic/symbols/symbol_inheritance_resolver.ghul
+++ b/src/semantic/symbols/symbol_inheritance_resolver.ghul
@@ -8,8 +8,6 @@ namespace Semantic is
 
     use Pair = Collections.KeyValuePair`2;
 
-    use Pipes;
-
     use Symbols.Symbol;
     use Symbols.Classy;
     use Symbols.Function;
@@ -48,7 +46,7 @@ namespace Semantic is
                 overridees_with_this_name.add(symbol);
             od
 
-            @IF.debug() let entries = Pipe.from(overridees).to_string("\n    ");
+            @IF.debug() let entries = overridees| .to_string("\n    ");
 
             @IF.debug() Std.error.write_line("all potential overridees:");
             @IF.debug() Std.error.write_line("    " + entries);
@@ -65,7 +63,7 @@ namespace Semantic is
 
                 @IF.debug() Std.error.write_line("potential overriding method set: " + overriders);
                 
-                let overrider_other_symbol = Pipe.from(overriders.symbols).first();
+                let overrider_other_symbol = overriders.symbols| .first();
 
                 let overridee_other_symbols = overridee_map.symbols;
                 
@@ -116,9 +114,9 @@ namespace Semantic is
             @IF.debug() Std.error.write_line("try inherit A");
             let is_stub = into.is_stub;
 
-            @IF.debug() Std.error.write_line("other overriding symbols: " + new Pipe.from(other_overridee_symbols));
+            @IF.debug() Std.error.write_line("other overriding symbols: " + other_overridee_symbols|);
 
-            let other_overridee_symbols_count = Pipe.from(other_overridee_symbols).count();
+            let other_overridee_symbols_count = other_overridee_symbols| .count();
 
             let overriding_method: Function;
 
@@ -160,19 +158,19 @@ namespace Semantic is
                     od                        
                 fi
             elif other_overridee_symbols_count == 1 /\ overridees.count != 0 then
-                into.add_member(Pipe.from(other_overridee_symbols).first());
+                into.add_member(other_overridee_symbols| .first());
             elif other_overridee_symbols_count > 0 then
                 let all_symbols = new Collections.LIST[Symbol]();
 
                 all_symbols.add_range(         
-                    Pipe
-                        .from(overridees.iterable)
-                        .map((function: Function) -> Symbol => function));
+                    overridees.iterable |
+                        .map((function: Function) -> Symbol => function)
+                );
 
                 all_symbols.add_range(other_overridee_symbols);
 
                 logger.error(into.location, 
-                    "cannot inherit multiple symbols with the same name: " + Pipe.from(all_symbols).sort()
+                    "cannot inherit multiple symbols with the same name: " + all_symbols| .sort()
                 );
             else
                 @IF.debug() Std.error.write_line("no overriders: look for method or other symbol to pull down");
@@ -185,7 +183,7 @@ namespace Semantic is
 
                     // @IF.debug() Std.error.write_line("MO 008 A3: " + into);
 
-                    let first = Pipe.from(overridees.iterable).first();
+                    let first = overridees.iterable| .first();
 
                     first.try_pull_down_into(into, other_overridee_symbols, logger);
                 elif overridees.count == 0 then
@@ -200,7 +198,7 @@ namespace Semantic is
                         // @IF.debug() Std.error.write_line("MO 008 A2: " + into);
                         // exactly one method symbol with this name: pull it down:
 
-                        let first = Pipe.from(other_overridee_symbols).first();
+                        let first = other_overridee_symbols| .first();
 
                         first.try_pull_down_into(into, other_overridee_symbols, logger);
 
@@ -213,8 +211,7 @@ namespace Semantic is
                         logger.error(
                             into.location, 
                             "cannot inherit multiple symbols with the same name: " + 
-                                Pipe
-                                    .from(overridees.iterable)
+                                overridees.iterable |
                                     .map(f: Function => f.to_string())
                                     .sort()                                    
                         );
@@ -247,8 +244,7 @@ namespace Semantic is
 
                     if seen_multiple_concrete then
                         let concretes = 
-                            Pipe
-                                .from(overridees.iterable)
+                            overridees.iterable |
                                 .filter(function: Function => function.is_instance);
                         
                         logger
@@ -276,15 +272,13 @@ namespace Semantic is
                         
                     elif seen_multiple_abstract /\ !into.location.is_internal then
                         let abstracts =
-                            Pipe
-                                .from(overridees.iterable)
+                            overridees.iterable |
                                 .filter(function: Function => function.is_abstract);
 
                         logger.error(
                             into.location,
                             "cannot inherit multiple abstract methods: " + 
-                                Pipe
-                                    .from(abstracts)
+                                abstracts |
                                     .map(f: Function => f.to_string())
                                     .sort()
                         );
@@ -341,7 +335,7 @@ namespace Semantic is
                                 fi                                
                             fi
                         elif !(isa Symbols.Variable(overridee)) then
-                            logger.warn(overrider_symbol.location, "" + overrider_symbol + " hides non-property " + Pipe.from(overridee_symbols));                            
+                            logger.warn(overrider_symbol.location, "" + overrider_symbol + " hides non-property " + overridee_symbols|);                            
                         fi                        
                     od                    
                 else
@@ -353,7 +347,7 @@ namespace Semantic is
                         if !(isa Symbols.Variable(overridee)) then
                             @IF.debug() Std.error.write_line("overridee symbol is not a variable: " + overrider_symbol);
 
-                            logger.warn(overrider_symbol.location, "" + overrider_symbol + " hides (case 3): " + Pipe.from(overridee_symbols));                            
+                            logger.warn(overrider_symbol.location, "" + overrider_symbol + " hides (case 3): " + overridee_symbols|);                            
                         fi
                     od
                 fi
@@ -363,16 +357,16 @@ namespace Semantic is
                 @IF.debug() Std.error.write_line("no overrider symbol");
             fi
 
-            let count = Pipe.from(overridee_symbols).count();
+            let count = overridee_symbols| .count();
             
             if count == 1 then
-                let first = Pipe.from(overridee_symbols).first();
+                let first = overridee_symbols| .first();
 
                 @IF.debug() Std.error.write_line("add sole overridee: " + first);
 
                 into.add_member(first);
             elif count > 1 then
-                @IF.debug() Std.error.write_line("multiple potential overridees: " + Pipe.from(overridee_symbols));
+                @IF.debug() Std.error.write_line("multiple potential overridees: " + overridee_symbols|);
 
                 // FIXME: can we do this in a more OOP way?
 
@@ -408,8 +402,7 @@ namespace Semantic is
                     logger.error(
                         into.location, 
                         "inherit multiple symbols with the same name " + 
-                        Pipe
-                            .from(overridee_symbols)
+                        overridee_symbols |
                             .map(s: Symbol => s.to_string())
                             .sort()
                     );
@@ -422,8 +415,7 @@ namespace Semantic is
                     logger.error(
                         into.location, 
                         "inherit multiple properties with the same name but different types " + 
-                            Pipe
-                                .from(overridee_symbols)
+                            overridee_symbols |
                                 .map(s: Symbol => s.to_string())
                                 .sort()
                     );
@@ -437,8 +429,7 @@ namespace Semantic is
                         .error(
                             into.location, 
                             "did nothing with multiple parent symbols " + 
-                                Pipe
-                                    .from(overridee_symbols)
+                                overridee_symbols |
                                     .map(s: Symbol => s.to_string())
                                     .sort()
                         );

--- a/src/semantic/types/generic_argument_bind_results.ghul
+++ b/src/semantic/types/generic_argument_bind_results.ghul
@@ -3,8 +3,6 @@ namespace Semantic.Types is
 
     use Collections.MAP;
 
-    use Pipes;
-
     class GENERIC_ARGUMENT_BINDING is
         type_argument: FUNCTION_GENERIC_ARGUMENT;
         actual_type: Type;
@@ -86,7 +84,7 @@ namespace Semantic.Types is
             let result = true;
 
             @IF.debug() IO.Std.error.write_line("BR: Bind results: " + self);
-            @IF.debug() IO.Std.error.write_line("BR: Expected arguments: " + Pipe.from(expected_arguments));
+            @IF.debug() IO.Std.error.write_line("BR: Expected arguments: " + expected_arguments|);
 
             for binding in bindings do
                 if binding.value.actual_type.is_none then

--- a/src/semantic/types/tuple.ghul
+++ b/src/semantic/types/tuple.ghul
@@ -1,6 +1,4 @@
 namespace Semantic.Types is
-    use Pipes;
-    
     use Source.LOCATION;
         
     class TUPLE: GENERIC is
@@ -21,6 +19,6 @@ namespace Semantic.Types is
         si
 
         to_string() -> string =>
-            "(" + Pipe.from(arguments) + ")";
+            "(" + arguments| + ")";
     si
 si

--- a/src/syntax/parsers/definitions/pragma.ghul
+++ b/src/syntax/parsers/definitions/pragma.ghul
@@ -53,25 +53,25 @@ namespace Syntax.Parsers.Definitions is
         si
 
         parse(context: CONTEXT) -> Trees.Definitions.PRAGMA is
-            let pragma_ = pragma_parser.parse(context);
+            let pragma = pragma_parser.parse(context);
             
             // FIXME: factor this out
-            if pragma_? /\ !pragma_.is_poisoned then
+            if pragma? /\ !pragma.is_poisoned then
                 let operator_name: string;
                 let precedence_to_restore: PRECEDENCE;
    
                 let restore_status = PRECEDENCE_RESTORE_STATUS.NO_RESTORE_NEEDED;
 
                 if 
-                    pragma_.is_name_equal_to("precedence")
+                    pragma.is_name_equal_to("precedence")
                 then
                     let is_precedence_valid = true;
 
-                    operator_name = pragma_.try_get_string_literal_at(0);
-                    let precedence_name = pragma_.try_get_string_literal_at(1);
+                    operator_name = pragma.try_get_string_literal_at(0);
+                    let precedence_name = pragma.try_get_string_literal_at(1);
 
                     if !operator_name? then
-                        context.error(pragma_.location, "expected operator name argument");
+                        context.error(pragma.location, "expected operator name argument");
 
                         is_precedence_valid = false;
                     fi
@@ -80,7 +80,7 @@ namespace Syntax.Parsers.Definitions is
                     let precedence_to_set: PRECEDENCE;
 
                     if !precedence_name? then
-                        context.error(pragma_.location, "expected operator precedence argument");
+                        context.error(pragma.location, "expected operator precedence argument");
 
                         is_precedence_valid = false;
                     elif !_precedence_names.try_get_value(precedence_name, precedence_to_set ref) then
@@ -93,7 +93,7 @@ namespace Syntax.Parsers.Definitions is
 
                     if is_precedence_valid then
                         if precedence_to_set < PRECEDENCE.USER_1 \/ precedence_to_set > PRECEDENCE.USER_8 then
-                            context.error(pragma_.location, "precedence must be between user-1 and user-8");                            
+                            context.error(pragma.location, "precedence must be between user-1 and user-8");                            
                             is_precedence_valid = false;
                         fi                        
                     fi
@@ -118,7 +118,7 @@ namespace Syntax.Parsers.Definitions is
                 fi                
 
                 if definition? /\ !definition.is_poisoned then
-                    return new Trees.Definitions.PRAGMA(pragma_.location::definition.location, pragma_, definition);
+                    return new Trees.Definitions.PRAGMA(pragma.location::definition.location, pragma, definition);
                 fi
             fi
         si

--- a/src/syntax/parsers/definitions/use.ghul
+++ b/src/syntax/parsers/definitions/use.ghul
@@ -16,32 +16,32 @@ namespace Syntax.Parsers.Definitions is
 
             context.next_token(Lexical.TOKEN.USE);
 
-            let use_ = identifier_qualified_parser.parse(context);
+            let `use = identifier_qualified_parser.parse(context);
 
-            if !use_? then
+            if !`use? then
                 return null;
             fi
 
             if context.current_token == Lexical.TOKEN.ASSIGN then
                 context.next_token();
 
-                let name = use_;
+                let name = `use;
 
                 if name.qualifier? then
                     context.logger.error(name.qualifier.location, "cannot qualify namespace or symbol alias");
                 fi
                 
-                use_ = identifier_qualified_parser.parse(context);
+                `use = identifier_qualified_parser.parse(context);
 
-                if use_ then
+                if `use then
                     context.next_token(Lexical.TOKEN.SEMICOLON);                    
                 fi
                 
-                return new Trees.Definitions.USE(start::context.location, name, use_);
+                return new Trees.Definitions.USE(start::context.location, name, `use);
             else
                 context.next_token(Lexical.TOKEN.SEMICOLON);
 
-                return new Trees.Definitions.USE(start::context.location, null, use_);
+                return new Trees.Definitions.USE(start::context.location, null, `use);
             fi
         si
     si

--- a/src/syntax/parsers/expressions/secondary.ghul
+++ b/src/syntax/parsers/expressions/secondary.ghul
@@ -57,7 +57,7 @@ namespace Syntax.Parsers.Expressions is
 
                     context.next_token();
 
-                    if 
+                    if
                         context.current.token == Lexical.TOKEN.IDENTIFIER
                         // \/ context.current.token == Lexical.TOKEN.OPERATOR
                     then

--- a/src/syntax/parsers/statements/node.ghul
+++ b/src/syntax/parsers/statements/node.ghul
@@ -196,12 +196,12 @@ namespace Syntax.Parsers.Statements is
                         var catch_body = statement_list_parser.parse(context);
                         catches.add(new Trees.Statements.CATCH(catch_start::catch_body.location, catch_variable, catch_body));
                     od
-                    var finally_: Trees.Statements.LIST;
+                    var `finally: Trees.Statements.LIST;
                     if context.current.token == Lexical.TOKEN.FINALLY then
                         context.next_token();
-                        finally_ = statement_list_parser.parse(context);
+                        `finally = statement_list_parser.parse(context);
                     fi
-                    var result = new Trees.Statements.TRY(start::context.location, body, catches, finally_);
+                    var result = new Trees.Statements.TRY(start::context.location, body, catches, `finally);
                     context.next_token(Lexical.TOKEN.YRT);
                     return result;
                 si,

--- a/src/syntax/parsers/statements/pragma.ghul
+++ b/src/syntax/parsers/statements/pragma.ghul
@@ -17,13 +17,13 @@ namespace Syntax.Parsers.Statements is
         si
 
         parse(context: CONTEXT) -> Trees.Statements.PRAGMA is
-            let pragma_ = pragma_parser.parse(context);
+            let pragma = pragma_parser.parse(context);
 
-            if pragma_? /\ !pragma_.is_poisoned then
+            if pragma? /\ !pragma.is_poisoned then
                 let statement = statement_parser.parse(context);
 
                 if statement? /\ !statement.is_poisoned then
-                    return new Trees.Statements.PRAGMA(pragma_.location::statement.location, pragma_, statement);
+                    return new Trees.Statements.PRAGMA(pragma.location::statement.location, pragma, statement);
                 fi
             fi
         si

--- a/src/syntax/process/add_accessors_for_properties.ghul
+++ b/src/syntax/process/add_accessors_for_properties.ghul
@@ -1,6 +1,5 @@
 namespace Syntax.Process is
     use IO.Std;
-
     
     use Source;
     use Trees;
@@ -22,13 +21,13 @@ namespace Syntax.Process is
         si
 
         // FIXME: #500 Pragma handling code is duplicated across multiple visitors
-        pre(pragma_: Definitions.PRAGMA) -> bool is
-            if !pragma_.pragma_? then
+        pre(pragma: Definitions.PRAGMA) -> bool is
+            if !pragma.pragma? then
                 Std.error.write_line("pragma is null");
                 return false;
             fi
 
-            let p = pragma_.pragma_;
+            let p = pragma.pragma;
 
             let name = p.name.to_string();
 
@@ -37,13 +36,13 @@ namespace Syntax.Process is
             fi
         si
 
-        visit(pragma_: Definitions.PRAGMA) is
-            if !pragma_.pragma_? then
+        visit(pragma: Definitions.PRAGMA) is
+            if !pragma.pragma? then
                 Std.error.write_line("pragma is null");
                 return;
             fi
 
-            let p = pragma_.pragma_;
+            let p = pragma.pragma;
 
             let name = p.name.to_string();
 
@@ -84,7 +83,7 @@ namespace Syntax.Process is
 
             let backing_variable_name = "$" + property.name.name;
 
-            let assign_argument_name = "__value";
+            let assign_argument_name = "$$value";
 
             if property.assign_argument != null then
                 assign_argument_name = property.assign_argument.name;
@@ -160,7 +159,7 @@ namespace Syntax.Process is
                     );                
 
                 if !property.assign_argument? then
-                    property.assign_argument = new Identifiers.Identifier(property.location, "__value");
+                    property.assign_argument = new Identifiers.Identifier(property.location, "$$value");
                 fi
 
                 let assign_function = new Definitions.FUNCTION(
@@ -265,43 +264,43 @@ namespace Syntax.Process is
             return true;
         si
 
-        pre(class_: Definitions.CLASS) -> bool is
-            _stack.push(class_.body);
+        pre(`class: Definitions.CLASS) -> bool is
+            _stack.push(`class.body);
 
             return false;
         si
 
-        visit(class_: Definitions.CLASS) is
+        visit(`class: Definitions.CLASS) is
             _stack.pop();
         si
 
-        pre(trait_: Definitions.TRAIT) -> bool is
-            _stack.push(trait_.body);
+        pre(`trait: Definitions.TRAIT) -> bool is
+            _stack.push(`trait.body);
 
             return false;
         si
 
-        visit(trait_: Definitions.TRAIT) is
+        visit(`trait: Definitions.TRAIT) is
             _stack.pop();
         si
 
-        pre(struct_: Definitions.STRUCT) -> bool is
-            _stack.push(struct_.body);
+        pre(`struct: Definitions.STRUCT) -> bool is
+            _stack.push(`struct.body);
 
             return false;
         si
 
-        visit(struct_: Definitions.STRUCT) is
+        visit(`struct: Definitions.STRUCT) is
             _stack.pop();
         si        
 
-        pre(namespace_: Definitions.NAMESPACE) -> bool is
-            _stack.push(namespace_.body);
+        pre(`namespace: Definitions.NAMESPACE) -> bool is
+            _stack.push(`namespace.body);
 
             return false;
         si
 
-        visit(namespace_: Definitions.NAMESPACE) is
+        visit(`namespace: Definitions.NAMESPACE) is
             _stack.pop();
         si        
     si

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -2,8 +2,6 @@ namespace Syntax.Process is
     use System.Exception;
 
     use IO.Std;
-
-    use Pipes;
         
     use Logging;
     use Source;
@@ -82,12 +80,12 @@ namespace Syntax.Process is
             fi
         si
 
-        set_iterator_for(for_: Trees.Statements.FOR, type: Type, recursing: bool) -> bool is
+        set_iterator_for(`for: Trees.Statements.FOR, type: Type, recursing: bool) -> bool is
             @IF.debug()
             Std.error.write_line("set iterator for: " + type + " recursing: " + recursing);
 
             if !type? then
-                Std.error.write_line("set iterator, type is null: " + for_.expression);
+                Std.error.write_line("set iterator, type is null: " + `for.expression);
 
                 return false;
             fi
@@ -113,17 +111,17 @@ namespace Syntax.Process is
                 fi
                 
                 if !read_current? then
-                    _logger.error(for_.expression.location, "incomplete iterator type (has move_next method but no current property)");
+                    _logger.error(`for.expression.location, "incomplete iterator type (has move_next method but no current property)");
                     return false;
                 fi
 
-                for_.move_next = move_next;
-                for_.read_current = read_current;
+                `for.move_next = move_next;
+                `for.read_current = read_current;
 
                 return true;
             elif next_element? then
                 // FIXME
-                for_.read_current = next_element;
+                `for.read_current = next_element;
 
                 @IF.debug()
                 Std.error.write_line("set iterator for: " + type + " recursing: " + recursing + ", use next element: " + next_element);
@@ -136,31 +134,31 @@ namespace Syntax.Process is
                 Std.error.write_line("set iterator for: " + type + ", read iterator: " + read_iterator);
 
                 if read_iterator? then
-                    for_.read_iterator = read_iterator;
+                    `for.read_iterator = read_iterator;
 
                     @IF.debug()
                     Std.error.write_line("set iterator for: " + type + ", have .NET read iterator: " + read_iterator + " recurse to get methods...");
 
-                    return set_iterator_for(for_, read_iterator.return_type, true);
+                    return set_iterator_for(`for, read_iterator.return_type, true);
                 fi
             fi
 
             @IF.debug()
             Std.error.write_line("set iterator for: " + type + ", could not find anything iterable");
 
-            _logger.error(for_.expression.location, "not iterable");
+            _logger.error(`for.expression.location, "not iterable");
 
             return false;
         si
 
         // FIXME: #500 Pragma handling code is duplicated across multiple visitors
-        pre(pragma_: Trees.Definitions.PRAGMA) -> bool is
-            if !pragma_.pragma_? then
+        pre(pragma: Trees.Definitions.PRAGMA) -> bool is
+            if !pragma.pragma? then
                 Std.error.write_line("pragma is null");
                 return false;
             fi
 
-            let p = pragma_.pragma_;
+            let p = pragma.pragma;
 
             let name = p.name.to_string();
 
@@ -171,13 +169,13 @@ namespace Syntax.Process is
             fi
         si
 
-        visit(pragma_: Trees.Definitions.PRAGMA) is
-            if !pragma_.pragma_? then
+        visit(pragma: Trees.Definitions.PRAGMA) is
+            if !pragma.pragma? then
                 Std.error.write_line("pragma is null");
                 return;
             fi
 
-            let p = pragma_.pragma_;
+            let p = pragma.pragma;
 
             let name = p.name.to_string();
 
@@ -188,71 +186,71 @@ namespace Syntax.Process is
             fi
         si
 
-        pre(namespace_: Trees.Definitions.NAMESPACE) -> bool is
-            super.pre(namespace_);
+        pre(`namespace: Trees.Definitions.NAMESPACE) -> bool is
+            super.pre(`namespace);
             return _stub_depth > 0;
         si
 
-        pre(class_: Trees.Definitions.CLASS) -> bool is
-            super.pre(class_);
-            return should_skip(class_);
+        pre(`class: Trees.Definitions.CLASS) -> bool is
+            super.pre(`class);
+            return should_skip(`class);
         si
 
-        pre(trait_: Trees.Definitions.TRAIT) -> bool is
-            super.pre(trait_);
-            return should_skip(trait_);            
+        pre(`trait: Trees.Definitions.TRAIT) -> bool is
+            super.pre(`trait);
+            return should_skip(`trait);            
         si        
 
-        pre(struct_: Trees.Definitions.STRUCT) -> bool is
-            super.pre(struct_);
-            return should_skip(struct_);            
+        pre(`struct: Trees.Definitions.STRUCT) -> bool is
+            super.pre(`struct);
+            return should_skip(`struct);            
         si
 
-        pre(for_: Trees.Statements.FOR) -> bool is
-            super.pre(for_);
+        pre(`for: Trees.Statements.FOR) -> bool is
+            super.pre(`for);
 
             try
-                _pre(for_);
+                _pre(`for);
             catch ex: Exception
-                _logger.exception(for_.location, ex, "exception compiling for");
+                _logger.exception(`for.location, ex, "exception compiling for");
             yrt
             
             return true;
         si
         
-        _pre(for_: Trees.Statements.FOR) -> bool is
-            if !for_.expression? \/ !for_.variable? then
-                _logger.error(for_.location, "incomplete for statement");
+        _pre(`for: Trees.Statements.FOR) -> bool is
+            if !`for.expression? \/ !`for.variable? then
+                _logger.error(`for.location, "incomplete for statement");
             fi
 
-            var symbol = find(for_.variable.name);
+            var symbol = find(`for.variable.name);
 
-            for_.expression.walk(self);
+            `for.expression.walk(self);
 
             if symbol? /\ isa Semantic.Types.SettableTyped(symbol) then
                 var typed_symbol = cast Semantic.Types.SettableTyped(symbol);
 
                 let type: Type;
 
-                if set_iterator_for(for_, for_.expression.value.type, false) then
-                    if for_.variable.type_expression? /\ !isa Trees.TypeExpressions.INFER(for_.variable.type_expression) then
-                        if !for_.variable.type_expression.type.is_assignable_from(for_.read_current.return_type) then
-                            _logger.error(for_.variable.location, "type mismatch");
+                if set_iterator_for(`for, `for.expression.value.type, false) then
+                    if `for.variable.type_expression? /\ !isa Trees.TypeExpressions.INFER(`for.variable.type_expression) then
+                        if !`for.variable.type_expression.type.is_assignable_from(`for.read_current.return_type) then
+                            _logger.error(`for.variable.location, "type mismatch");
                         fi
                         
-                    elif for_.variable.initializer? then
-                        _logger.error(for_.variable.initializer.location, "cannot initialize variable here");
-                    elif !for_.expression? then
-                        _logger.error(for_.location, "expression expected");
+                    elif `for.variable.initializer? then
+                        _logger.error(`for.variable.initializer.location, "cannot initialize variable here");
+                    elif !`for.expression? then
+                        _logger.error(`for.location, "expression expected");
                     else
-                        typed_symbol.set_type(for_.read_current.return_type);
+                        typed_symbol.set_type(`for.read_current.return_type);
                     fi
                 fi
             else
-                _logger.poison(for_.variable.name.location, "couldn't find typed symbol for variable " + for_.variable.name);
+                _logger.poison(`for.variable.name.location, "couldn't find typed symbol for variable " + `for.variable.name);
             fi
 
-            for_.body.walk(self);            
+            `for.body.walk(self);            
         si
         
         pre(assignment: Trees.Statements.ASSIGNMENT) -> bool is
@@ -297,7 +295,7 @@ namespace Syntax.Process is
                     Std.error.write("  ");
                 od
 
-                Std.error.write_line("DDDDDD: " + type + " has ancestor " + a + " " + Pipe.from(a.arguments));
+                Std.error.write_line("DDDDDD: " + type + " has ancestor " + a + " " + a.arguments|);
 
                 dump_ancestors(a, depth + 1);
             od
@@ -347,17 +345,17 @@ namespace Syntax.Process is
             fi
         si
 
-        visit(throw_: Trees.Statements.THROW) is
-            super.visit(throw_);
+        visit(`throw: Trees.Statements.THROW) is
+            super.visit(`throw);
 
-            if !throw_.expression.value? \/ !throw_.expression.value.type? then
+            if !`throw.expression.value? \/ !`throw.expression.value.type? then
                 return;
             fi
 
             let exception_type = _innate_symbol_lookup.get_exception_type();
 
-            if !exception_type.is_assignable_from(throw_.expression.value.type) then
-                _logger.warn(throw_.expression.location, "thrown value is not derived from System.Exception");
+            if !exception_type.is_assignable_from(`throw.expression.value.type) then
+                _logger.warn(`throw.expression.location, "thrown value is not derived from System.Exception");
             fi
         si
 
@@ -392,25 +390,25 @@ namespace Syntax.Process is
             fi
         si
 
-        visit(try_: Trees.Statements.TRY) is
-            super.visit(try_);
+        visit(`try: Trees.Statements.TRY) is
+            super.visit(`try);
 
             if
-                (!try_.catches? \/ try_.catches.count == 0) /\
-                !try_.finally_?    
+                (!`try.catches? \/ `try.catches.count == 0) /\
+                !`try.`finally?    
             then
-                _logger.error(try_.location, "try statement must have at least one catch clause and/or a finally clause");
+                _logger.error(`try.location, "try statement must have at least one catch clause and/or a finally clause");
             fi
         si
         
-        visit(catch_: Trees.Statements.CATCH) is
-            super.visit(catch_);
+        visit(`catch: Trees.Statements.CATCH) is
+            super.visit(`catch);
 
-            if !catch_.variable? \/ !catch_.variable.type_expression? then
+            if !`catch.variable? \/ !`catch.variable.type_expression? then
                 return;
             fi
             
-            let type = catch_.variable.type_expression.type;
+            let type = `catch.variable.type_expression.type;
 
             if !type? then
                 return;
@@ -419,7 +417,7 @@ namespace Syntax.Process is
             let exception_type = _innate_symbol_lookup.get_exception_type();
 
             if !exception_type.is_assignable_from(type) then
-                _logger.error(catch_.variable.type_expression.location, "cannot catch " + type + " because it does not derive from System.Exception");
+                _logger.error(`catch.variable.type_expression.location, "cannot catch " + type + " because it does not derive from System.Exception");
             fi
         si
 
@@ -623,7 +621,7 @@ namespace Syntax.Process is
                 new SEQUENCE(_innate_symbol_lookup.get_array_type(type), type, values);
         si        
 
-        visit(self_: Trees.Expressions.SELF) is
+        visit(`self: Trees.Expressions.SELF) is
             let s = current_instance_context;
 
             let type: Type;
@@ -632,7 +630,7 @@ namespace Syntax.Process is
                 let f = current_function;
                 
                 if !f? \/ !f.is_instance then
-                    _logger.error(self_.location, "cannot access self from non-instance context");
+                    _logger.error(`self.location, "cannot access self from non-instance context");
                 fi
 
                 if s.argument_names.count > 0 then
@@ -648,60 +646,60 @@ namespace Syntax.Process is
                     
                     if arguments.count == s.argument_names.count then
                         type = new Semantic.Types.GENERIC(
-                            self_.location,
+                            `self.location,
                             cast Semantic.Symbols.Classy(s),
                             arguments);
                     fi
                 fi
 
-                self_.value =
+                `self.value =
                     new Load.SELF(
                         s, type
                     );
 
-                _symbol_use_locations.add_symbol_use(self_.location, s);
+                _symbol_use_locations.add_symbol_use(`self.location, s);
             else
-                _logger.error(self_.location, "cannot access self from non-instance context");
+                _logger.error(`self.location, "cannot access self from non-instance context");
             fi
         si
 
-        visit(super_: Trees.Expressions.SUPER) is
+        visit(`super: Trees.Expressions.SUPER) is
             // FIXME:
             let s = _symbol_table.current_instance_context;
 
             if s? then
                 if s.is_trait then
-                    _logger.error(super_.location, "trait " + s.description + " does not have a super class");
+                    _logger.error(`super.location, "trait " + s.description + " does not have a super class");
                     
                     return;
                 fi
                 
-                super_.value =
+                `super.value =
                     new Load.SUPER(
                         s, cast Semantic.Symbols.Classy(s).ancestors[0]
                     );
 
-                _symbol_use_locations.add_symbol_use(super_.location, s);
+                _symbol_use_locations.add_symbol_use(`super.location, s);
             fi
         si
 
-        visit(cast_: Trees.Expressions.CAST) is
-            cast_.value = null;
+        visit(`cast: Trees.Expressions.CAST) is
+            `cast.value = null;
 
-            var type = cast_.type_expression.type;
+            var type = `cast.type_expression.type;
 
             if !type? then
-                _logger.error(cast_.type_expression.location, "cast has no type");                
+                _logger.error(`cast.type_expression.location, "cast has no type");                
                 return;
             fi
 
-            if !cast_.right.value? then
-                _logger.poison(cast_.right.location, "cast has no value");
+            if !`cast.right.value? then
+                _logger.poison(`cast.right.location, "cast has no value");
 
-                cast_.value =
+                `cast.value =
                     new DUMMY(
                         type,
-                        cast_.right.location
+                        `cast.right.location
                     );
 
                 return;
@@ -709,31 +707,31 @@ namespace Syntax.Process is
 
             // type = type.specialize(_generic_cache);
 
-            if type.is_value_type /\ cast_.right.value.type.is_value_type then
+            if type.is_value_type /\ `cast.right.value.type.is_value_type then
                 let instruction = _value_converter.get_instruction(type);
 
                 if !instruction? then
                     let left_type_symbol = type.symbol;
-                    let right_type_symbol = cast_.right.value.type.symbol;
+                    let right_type_symbol = `cast.right.value.type.symbol;
 
                     if 
                         !isa Semantic.Symbols.ENUM_(left_type_symbol) /\
                         !isa Semantic.Symbols.ENUM_(right_type_symbol)
                     then
-                        _logger.warn(cast_.location, "cannot convert " + cast_.right.value.type + " to " + cast_.type_expression.type);
+                        _logger.warn(`cast.location, "cannot convert " + `cast.right.value.type + " to " + `cast.type_expression.type);
                     fi
 
-                    cast_.value =
+                    `cast.value =
                         new CONVERT(
                             type,
-                            cast_.right.value,
+                            `cast.right.value,
                             "conv.i4"
                         );                    
                else
-                    cast_.value =
+                    `cast.value =
                         new CONVERT(
                             type,
-                            cast_.right.value,
+                            `cast.right.value,
                             instruction
                         );                    
                 fi
@@ -742,77 +740,77 @@ namespace Syntax.Process is
             fi
             
             if type.is_value_type then
-                cast_.value =
+                `cast.value =
                     new TYPE_WRAPPER(
                         type,
                         new UNBOX(
-                            cast_.right.value
+                            `cast.right.value
                         )
                     );
 
                 return;
             fi
             
-            cast_.value =
+            `cast.value =
                 new CAST(
                     type,
-                    cast_.right.value
+                    `cast.right.value
                 );
         si
 
-        visit(isa_: Trees.Expressions.ISA) is
-            isa_.value = null;
+        visit(`isa: Trees.Expressions.ISA) is
+            `isa.value = null;
 
-            let isa_type = isa_.type_expression.type;
+            let isa_type = `isa.type_expression.type;
 
             if isa_type == null then
-                _logger.error(isa_.type_expression.location, "isa has no type");
+                _logger.error(`isa.type_expression.location, "isa has no type");
                 return;
             fi
 
             let bool_type = _innate_symbol_lookup.get_bool_type();
 
-            isa_.value =
+            `isa.value =
                 new ISA(
                     bool_type,
                     isa_type,                     
-                    isa_.right.value
+                    `isa.right.value
                 );
         si
 
-        visit(typeof_: Trees.Expressions.TYPEOF) is
-            typeof_.value = null;
+        visit(`typeof: Trees.Expressions.TYPEOF) is
+            `typeof.value = null;
 
-            let typeof_type = typeof_.type_expression.type;
+            let typeof_type = `typeof.type_expression.type;
 
             if !typeof_type? then
-                _logger.error(typeof_.type_expression.location, "typeof has no type");
+                _logger.error(`typeof.type_expression.location, "typeof has no type");
                 return;
             fi
 
             let type_type = _innate_symbol_lookup.get_type_type();
 
-            typeof_.value =
+            `typeof.value =
                 new TYPEOF(
                     type_type,
                     typeof_type
                 );
         si
 
-        visit(new_: Trees.Expressions.NEW) is
-            new_.value = null;
+        visit(`new: Trees.Expressions.NEW) is
+            `new.value = null;
 
-            var type = new_.type_expression.type;
+            var type = `new.type_expression.type;
 
             if type == null then     
-                _logger.poison(new_.type_expression.location, "new has no type");
+                _logger.poison(`new.type_expression.location, "new has no type");
                 return;
             fi
 
             // type = type.specialize(_generic_cache);
 
             if !isa Semantic.Types.NAMED(type) then
-                _logger.error(new_.type_expression.location, "cannot instantiate this: " + type);
+                _logger.error(`new.type_expression.location, "cannot instantiate this: " + type);
                 return;
             fi
 
@@ -826,7 +824,7 @@ namespace Syntax.Process is
             let arguments = new Collections.LIST[Value]();
             let argument_types = new Collections.LIST[Type]();
 
-            for a in new_.arguments do
+            for a in `new.arguments do
                 if a? /\ a.value? /\ a.value.type? then
                     arguments.add(a.value);
                     argument_types.add(a.value.type);                    
@@ -836,7 +834,7 @@ namespace Syntax.Process is
                     if a? then
                         arguments.add(new DUMMY(type, a.location));
                     else
-                        arguments.add(new DUMMY(type, new_.arguments.location));
+                        arguments.add(new DUMMY(type, `new.arguments.location));
                     fi
                     
                     argument_types.add(t);
@@ -844,24 +842,24 @@ namespace Syntax.Process is
             od
 
             if !function_group? then
-                new_.value =
+                `new.value =
                     new DUMMY(
                         type,
-                        new_.location
+                        `new.location
                     );
 
-                _logger.error(new_.location, "no constructor found init(" + Pipe.from(argument_types) + ")");                
+                _logger.error(`new.location, "no constructor found init(" + argument_types| + ")");                
 
                 return;
             fi
 
-            let overload_result = _overload_resolver.resolve(new_.location, function_group, argument_types, true);
+            let overload_result = _overload_resolver.resolve(`new.location, function_group, argument_types, true);
 
             if overload_result == null then
-                new_.value =
+                `new.value =
                     new DUMMY(
                         type,
-                        new_.location
+                        `new.location
                     );
     
                 return;
@@ -878,12 +876,12 @@ namespace Syntax.Process is
             fi
             
             if !is_directly_owned then
-                _logger.error(new_.location, "cannot call superclass constructor " + function);
+                _logger.error(`new.location, "cannot call superclass constructor " + function);
             fi
             
-            _symbol_use_locations.add_symbol_use(new_.type_expression.location, function);
+            _symbol_use_locations.add_symbol_use(`new.type_expression.location, function);
 
-            new_.value =
+            `new.value =
                 new NEW(
                     type,
                     function,
@@ -1141,7 +1139,7 @@ namespace Syntax.Process is
                     if isa Semantic.Symbols.GENERIC(named_type.scope) then
                         let g = cast Semantic.Symbols.GENERIC(named_type.scope);
 
-                        Std.error.write_line("III: unspecialized: " + Pipe.from(g.symbol.symbols));
+                        Std.error.write_line("III: unspecialized: " + g.symbol.symbols|);
                     fi
                     
                     return;
@@ -1440,9 +1438,9 @@ namespace Syntax.Process is
             );
         si
 
-        visit(string_: Trees.Expressions.Literals.STRING) is
-            string_.value = new Literal.STRING(
-                string_.value_string,
+        visit(`string: Trees.Expressions.Literals.STRING) is
+            `string.value = new Literal.STRING(
+                `string.value_string,
                 _innate_symbol_lookup.get_string_type()
             );
         si        
@@ -1676,8 +1674,8 @@ namespace Syntax.Process is
             reference.value = new ADDRESS(reference.left.value, _innate_symbol_lookup.get_reference_type(reference.left.value.type));
         si
         
-        visit(null_: Trees.Expressions.NULL) is
-            null_.value = new NULL(new Semantic.Types.NULL());
+        visit(`null: Trees.Expressions.NULL) is
+            `null.value = new NULL(new Semantic.Types.NULL());
         si
 
         // Do not descend into properties (otherwise accessor functions will be walked twice)

--- a/src/syntax/process/conditional_compilation.ghul
+++ b/src/syntax/process/conditional_compilation.ghul
@@ -52,12 +52,12 @@ namespace Syntax.Process is
             return result;
         si
 
-        get_is_enabled(pragma_: Pragmas.PRAGMA) -> bool is
-            if !pragma_? \/ !pragma_.name? then
+        get_is_enabled(pragma: Pragmas.PRAGMA) -> bool is
+            if !pragma? \/ !pragma.name? then
                 return true;
             fi
 
-            let name = pragma_.name.to_string();
+            let name = pragma.name.to_string();
 
             if !name.starts_with("IF.") then
                 return true;
@@ -73,23 +73,23 @@ namespace Syntax.Process is
         si
 
         // FIXME: #500 Pragma handling code is duplicated across multiple visitors
-        visit(pragma_: Definitions.PRAGMA) is
-            assert pragma_.pragma_? else "pragma is null";
+        visit(pragma: Definitions.PRAGMA) is
+            assert pragma.pragma? else "pragma is null";
 
-            if !get_is_enabled(pragma_.pragma_) then
-                pragma_.definition =    
+            if !get_is_enabled(pragma.pragma) then
+                pragma.definition =    
                     new Definitions.LIST(
-                        pragma_.definition.location, 
+                        pragma.definition.location, 
                         new Collections.LIST[Definitions.Definition](0)
                     );
             fi            
         si
 
-        visit(pragma_: Statements.PRAGMA) is
-            assert pragma_.pragma_? else "pragma is null";
+        visit(pragma: Statements.PRAGMA) is
+            assert pragma.pragma? else "pragma is null";
 
-            if !get_is_enabled(pragma_.pragma_) then
-                pragma_.statement = null;
+            if !get_is_enabled(pragma.pragma) then
+                pragma.statement = null;
             fi
         si        
     si

--- a/src/syntax/process/declare_symbols.ghul
+++ b/src/syntax/process/declare_symbols.ghul
@@ -47,19 +47,19 @@ namespace Syntax.Process is
         si
 
         next_anon_name() -> string is
-            let result = "__anon_" + _anon_index;
+            let result = "$`anon" + _anon_index;
             _anon_index = _anon_index + 1;
             return result;
         si
 
         // FIXME: #500 Pragma handling code is duplicated across multiple visitors
-        pre(pragma_: Definitions.PRAGMA) -> bool is
-            if !pragma_.pragma_? then
+        pre(pragma: Definitions.PRAGMA) -> bool is
+            if !pragma.pragma? then
                 Std.error.write_line("pragma is null");
                 return false;
             fi
 
-            let p = pragma_.pragma_;
+            let p = pragma.pragma;
 
             let name = p.name.to_string();
 
@@ -70,13 +70,13 @@ namespace Syntax.Process is
             fi
         si
 
-        visit(pragma_: Definitions.PRAGMA) is
-            if !pragma_.pragma_? then
+        visit(pragma: Definitions.PRAGMA) is
+            if !pragma.pragma? then
                 Std.error.write_line("pragma is null");
                 return;
             fi
 
-            let p = pragma_.pragma_;
+            let p = pragma.pragma;
 
             let name = p.name.to_string();
 
@@ -102,7 +102,7 @@ namespace Syntax.Process is
 
                 let il_name = cast Expressions.Literals.STRING(argument).value_string;
 
-                let definition = pragma_.definition;
+                let definition = pragma.definition;
 
                 while isa Definitions.PRAGMA(definition) do
                     definition = cast Definitions.PRAGMA(definition).definition;
@@ -149,12 +149,12 @@ namespace Syntax.Process is
             fi
         si
 
-        pre(namespace_: Definitions.NAMESPACE) -> bool is
-            declare_and_enter_namespace(namespace_.name, _symbol_definition_listener);
+        pre(`namespace: Definitions.NAMESPACE) -> bool is
+            declare_and_enter_namespace(`namespace.name, _symbol_definition_listener);
         si
 
-        visit(namespace_: Definitions.NAMESPACE) is
-            leave_namespace(namespace_.name);
+        visit(`namespace: Definitions.NAMESPACE) is
+            leave_namespace(`namespace.name);
         si
 
         get_generic_arguments(arguments: Trees.TypeExpressions.LIST) -> Collections.LIST[string] is
@@ -286,37 +286,37 @@ namespace Syntax.Process is
         si
 
 
-        pre(class_: Definitions.CLASS) -> bool => _pre(class_);
+        pre(`class: Definitions.CLASS) -> bool => _pre(`class);
 
-        visit(class_: Definitions.CLASS) is
-            leave_scope(class_);
+        visit(`class: Definitions.CLASS) is
+            leave_scope(`class);
         si
 
-        pre(trait_: Definitions.TRAIT) -> bool => _pre(trait_);
+        pre(`trait: Definitions.TRAIT) -> bool => _pre(`trait);
 
-        visit(trait_: Definitions.TRAIT) is
-            leave_scope(trait_);
+        visit(`trait: Definitions.TRAIT) is
+            leave_scope(`trait);
         si
 
-        pre(struct_: Definitions.STRUCT) -> bool => _pre(struct_);
+        pre(`struct: Definitions.STRUCT) -> bool => _pre(`struct);
 
-        visit(struct_: Definitions.STRUCT) is
-            leave_scope(struct_);
+        visit(`struct: Definitions.STRUCT) is
+            leave_scope(`struct);
         si        
 
-        pre(enum_: Definitions.ENUM) -> bool is
+        pre(`enum: Definitions.ENUM) -> bool is
             associate_and_enter_scope(
-                enum_, 
+                `enum, 
                 current_declaration_context.declare_enum(
-                    enum_.name.location, 
-                    enum_.name.name, 
+                    `enum.name.location, 
+                    `enum.name.name, 
                     _symbol_definition_listener
                 )
             );
         si
 
-        visit(enum_: Definitions.ENUM) is
-            leave_scope(enum_);
+        visit(`enum: Definitions.ENUM) is
+            leave_scope(`enum);
         si
 
         pre(enum_member: Definitions.ENUM_MEMBER) -> bool is
@@ -360,14 +360,14 @@ namespace Syntax.Process is
             fi
             
             if is_innate then
-                let innate_ = cast Trees.Bodies.INNATE(function.body);
+                let `innate = cast Trees.Bodies.INNATE(function.body);
 
                 associate_and_enter_scope(
                     function, 
                     current_declaration_context.declare_innate(
                         function.name.location, 
                         function.name.name, 
-                        innate_.name.to_string(),
+                        `innate.name.to_string(),
                         current_scope,_symbol_definition_listener
                     )
                 );
@@ -492,12 +492,12 @@ namespace Syntax.Process is
             leave_scope(if_branch);
         si
 
-        pre(case_: Statements.CASE) -> bool is
-            create_and_enter_block_scope(case_);
+        pre(`case: Statements.CASE) -> bool is
+            create_and_enter_block_scope(`case);
         si
 
-        visit(case_: Statements.CASE) is
-            leave_scope(case_);
+        visit(`case: Statements.CASE) is
+            leave_scope(`case);
         si
 
         pre(case_match: Statements.CASE_MATCH) -> bool is
@@ -508,36 +508,36 @@ namespace Syntax.Process is
             leave_scope(case_match);
         si
 
-        pre(try_: Statements.TRY) -> bool is
-            create_and_enter_block_scope(try_);
+        pre(`try: Statements.TRY) -> bool is
+            create_and_enter_block_scope(`try);
         si
 
-        visit(try_: Statements.TRY) is
-            leave_scope(try_);
+        visit(`try: Statements.TRY) is
+            leave_scope(`try);
         si
 
-        pre(catch_: Statements.CATCH) -> bool is
-            create_and_enter_block_scope(catch_);
+        pre(`catch: Statements.CATCH) -> bool is
+            create_and_enter_block_scope(`catch);
         si
 
-        visit(catch_: Statements.CATCH) is
-            leave_scope(catch_);
+        visit(`catch: Statements.CATCH) is
+            leave_scope(`catch);
         si
 
-        pre(do_: Statements.DO) -> bool is
-            create_and_enter_block_scope(do_);
+        pre(`do: Statements.DO) -> bool is
+            create_and_enter_block_scope(`do);
         si
 
-        visit(do_: Statements.DO) is
-            leave_scope(do_);
+        visit(`do: Statements.DO) is
+            leave_scope(`do);
         si
 
-        pre(for_: Statements.FOR) -> bool is
-            create_and_enter_block_scope(for_);
+        pre(`for: Statements.FOR) -> bool is
+            create_and_enter_block_scope(`for);
         si
 
-        visit(for_: Statements.FOR) is
-            leave_scope(for_);
+        visit(`for: Statements.FOR) is
+            leave_scope(`for);
         si
 
         pre(labelled: Statements.LABELLED) -> bool is

--- a/src/syntax/process/expand_namespaces.ghul
+++ b/src/syntax/process/expand_namespaces.ghul
@@ -13,15 +13,15 @@ namespace Syntax.Process is
             node.walk(self);
         si
 
-        pre(namespace_: Definitions.NAMESPACE) -> bool is
+        pre(`namespace: Definitions.NAMESPACE) -> bool is
             _depth = _depth + 1;
         si
 
-        visit(namespace_: Definitions.NAMESPACE) is
-            var names = namespace_.name.qualifier_names;
+        visit(`namespace: Definitions.NAMESPACE) is
+            var names = `namespace.name.qualifier_names;
 
             if _depth == 1 then
-                namespace_.body.push(
+                `namespace.body.push(
                     new Definitions.USE(
                         Source.LOCATION.internal,
                         null,
@@ -34,9 +34,9 @@ namespace Syntax.Process is
             fi
 
             if names.count > 0 then
-                namespace_.name = new Identifiers.Identifier(namespace_.name.location, namespace_.name.name);
-                var body = namespace_.body;
-                var current = namespace_;
+                `namespace.name = new Identifiers.Identifier(`namespace.name.location, `namespace.name.name);
+                var body = `namespace.body;
+                var current = `namespace;
                 
                 for n in names do
                     current.body = 
@@ -46,7 +46,7 @@ namespace Syntax.Process is
                                 [new Definitions.NAMESPACE(current.location, current.name, current.body)]: Definitions.Definition
                             )
                         );
-                    current.name = new Identifiers.Identifier(namespace_.name.location, n);
+                    current.name = new Identifiers.Identifier(`namespace.name.location, n);
                 od
             fi
 

--- a/src/syntax/process/generate_il.ghul
+++ b/src/syntax/process/generate_il.ghul
@@ -110,16 +110,16 @@ namespace Syntax.Process is
             println("{");            
         si
 
-        pre(namespace_: Definitions.NAMESPACE) -> bool is
-            super.pre(namespace_);
+        pre(`namespace: Definitions.NAMESPACE) -> bool is
+            super.pre(`namespace);
         si
 
-        visit(namespace_: Definitions.NAMESPACE) is
-            super.visit(namespace_);
+        visit(`namespace: Definitions.NAMESPACE) is
+            super.visit(`namespace);
         si
         
-        pre(class_: Definitions.CLASS) -> bool is
-            let symbol = cast Semantic.Symbols.Classy(symbol_for(class_));
+        pre(`class: Definitions.CLASS) -> bool is
+            let symbol = cast Semantic.Symbols.Classy(symbol_for(`class));
 
             @IF.debug() Std.error.write_line("define " + symbol.description);
 
@@ -129,13 +129,13 @@ namespace Syntax.Process is
 
             print_class_def(symbol);
 
-            enter_scope(class_);
+            enter_scope(`class);
 
             _context.indent();
         si
         
-        visit(class_: Definitions.CLASS) is
-            let symbol = cast Semantic.Symbols.Classy(symbol_for(class_));
+        visit(`class: Definitions.CLASS) is
+            let symbol = cast Semantic.Symbols.Classy(symbol_for(`class));
 
             gen_ienumerable_boilerplate(symbol);
             gen_ienumerator_boilerplate(symbol);
@@ -146,11 +146,11 @@ namespace Syntax.Process is
 
             leave_class(symbol);
 
-            leave_scope(class_);
+            leave_scope(`class);
         si
 
-        pre(trait_: Definitions.TRAIT) -> bool is
-            let symbol = cast Semantic.Symbols.Classy(symbol_for(trait_));
+        pre(`trait: Definitions.TRAIT) -> bool is
+            let symbol = cast Semantic.Symbols.Classy(symbol_for(`trait));
             let owner = cast Semantic.Symbols.Symbol(symbol.owner);
 
             @IF.debug() Std.error.write_line("define " + symbol.description);
@@ -159,24 +159,24 @@ namespace Syntax.Process is
 
             print_class_def(symbol);
 
-            enter_scope(trait_);
+            enter_scope(`trait);
 
             _context.indent();
         si
 
-        visit(trait_: Definitions.TRAIT) is
+        visit(`trait: Definitions.TRAIT) is
             _context.outdent();
             println("}");
 
-            let symbol = cast Semantic.Symbols.Classy(symbol_for(trait_));
+            let symbol = cast Semantic.Symbols.Classy(symbol_for(`trait));
 
             leave_class(symbol);
 
-            leave_scope(trait_);
+            leave_scope(`trait);
         si
 
-        pre(struct_: Definitions.STRUCT) -> bool is
-            let symbol = cast Semantic.Symbols.Classy(symbol_for(struct_));
+        pre(`struct: Definitions.STRUCT) -> bool is
+            let symbol = cast Semantic.Symbols.Classy(symbol_for(`struct));
             let owner = cast Semantic.Symbols.Symbol(symbol.owner);
 
             enter_class(symbol);
@@ -185,11 +185,11 @@ namespace Syntax.Process is
 
             _context.indent();
 
-            enter_scope(struct_);            
+            enter_scope(`struct);            
         si
 
-        visit(struct_: Definitions.STRUCT) is
-            let symbol = cast Semantic.Symbols.Classy(symbol_for(struct_));
+        visit(`struct: Definitions.STRUCT) is
+            let symbol = cast Semantic.Symbols.Classy(symbol_for(`struct));
 
             gen_ienumerable_boilerplate(symbol);
             gen_ienumerator_boilerplate(symbol);
@@ -202,7 +202,7 @@ namespace Syntax.Process is
 
             leave_class(symbol);
 
-            leave_scope(struct_);
+            leave_scope(`struct);
         si        
 
         gen_ienumerable_boilerplate(symbol: Semantic.Symbols.Classy) is            
@@ -239,8 +239,8 @@ namespace Syntax.Process is
             fi
         si
 
-        pre(enum_: Definitions.ENUM) -> bool is
-            let symbol = cast Semantic.Symbols.Symbol(symbol_for(enum_));
+        pre(`enum: Definitions.ENUM) -> bool is
+            let symbol = cast Semantic.Symbols.Symbol(symbol_for(`enum));
 
             let owner = cast Semantic.Symbols.Symbol(symbol.owner);
 
@@ -250,21 +250,21 @@ namespace Syntax.Process is
 
             print_class_def(symbol);
 
-            enter_scope(enum_);
+            enter_scope(`enum);
 
             _context.indent();
 
             _context.write_line(".field public specialname rtspecialname int32 value__ ");
         si
 
-        visit(enum_: Definitions.ENUM) is
+        visit(`enum: Definitions.ENUM) is
             _context.outdent();
             println("}");
 
-            @IF.debug() let symbol = cast Semantic.Symbols.Symbol(symbol_for(enum_));
+            @IF.debug() let symbol = cast Semantic.Symbols.Symbol(symbol_for(`enum));
             @IF.debug() debug_leave_file(symbol);
 
-            leave_scope(enum_);
+            leave_scope(`enum);
         si
 
         pre(enum_member: Definitions.ENUM_MEMBER) -> bool is
@@ -368,32 +368,32 @@ namespace Syntax.Process is
         si
        
         // FIXME: #500 Pragma handling code is duplicated across multiple visitors
-        pre(pragma_: Definitions.PRAGMA) -> bool is
-            process_pragma(pragma_.pragma_, true);
+        pre(pragma: Definitions.PRAGMA) -> bool is
+            process_pragma(pragma.pragma, true);
         si
 
-        visit(pragma_: Definitions.PRAGMA) is
-            process_pragma(pragma_.pragma_, false);
+        visit(pragma: Definitions.PRAGMA) is
+            process_pragma(pragma.pragma, false);
         si
 
-        process_pragma(pragma_: Pragmas.PRAGMA, is_enter: bool) is
-            if !pragma_? then
+        process_pragma(pragma: Pragmas.PRAGMA, is_enter: bool) is
+            if !pragma? then
                 Std.error.write_line("pragma is null");
                 return;
             fi
 
-            let name = pragma_.name.to_string();
+            let name = pragma.name.to_string();
 
             if name =~ "IL.output" then
-                if !pragma_.arguments? \/ pragma_.arguments.expressions.count != 1 then
-                    _logger.error(pragma_.arguments.location, "expected 1 argument");
+                if !pragma.arguments? \/ pragma.arguments.expressions.count != 1 then
+                    _logger.error(pragma.arguments.location, "expected 1 argument");
                     return;
                 fi
 
-                let argument = pragma_.arguments.expressions[0];
+                let argument = pragma.arguments.expressions[0];
 
                 if !argument? \/ !isa Expressions.Literals.STRING(argument) then
-                    _logger.error(pragma_.arguments.location, "expected a string literal argument");
+                    _logger.error(pragma.arguments.location, "expected a string literal argument");
                     return;
                 fi
 
@@ -547,37 +547,37 @@ namespace Syntax.Process is
             fi            
         si
 
-        visit(throw_: Statements.THROW) is
-            super.visit(throw_);
+        visit(`throw: Statements.THROW) is
+            super.visit(`throw);
 
             gen(
                 _boxer.box_if_value(
-                    throw_.expression.value
+                    `throw.expression.value
                 )
             );
 
             _context.write_line("throw");
         si
 
-        visit(assert_: Statements.ASSERT) is
-            super.visit(assert_);
+        visit(`assert: Statements.ASSERT) is
+            super.visit(`assert);
 
             let end = new LABEL();
 
             _brancher.branch(
                 BRANCH.NZ,
-                assert_.expression.value,
+                `assert.expression.value,
                 end
             );
 
             let need_exception_wrapper = true;
 
-            if assert_.message? then
-                let message_value = assert_.message.value; 
+            if `assert.message? then
+                let message_value = `assert.message.value; 
                 if !_innate_symbol_lookup.get_exception_type().is_assignable_from(message_value.type) then
                     gen(
                         new Literal.STRING(
-                            "" + assert_.location + ": ",
+                            "" + `assert.location + ": ",
                             _innate_symbol_lookup.get_string_type()
                         )
                     );
@@ -591,7 +591,7 @@ namespace Syntax.Process is
             else
                 gen(
                     new Literal.STRING(
-                        "" + assert_.location + ": " + assert_.expression,
+                        "" + `assert.location + ": " + `assert.expression,
                         _innate_symbol_lookup.get_string_type()
                     )
                 );
@@ -644,21 +644,21 @@ namespace Syntax.Process is
             super.visit(i);
         si
 
-        pre(case_: Statements.CASE) -> bool is
-            super.pre(case_);
+        pre(`case: Statements.CASE) -> bool is
+            super.pre(`case);
 
             return true;
         si
 
-        visit(case_: Statements.CASE) is
-            assert case_.expression?;
-            assert case_.matches?;
+        visit(`case: Statements.CASE) is
+            assert `case.expression?;
+            assert `case.matches?;
 
-            let temp = new TEMP(_context, case_.expression.value);
+            let temp = new TEMP(_context, `case.expression.value);
 
             let labels = _loops.enter_loop();
 
-            for m in case_.matches do
+            for m in `case.matches do
                 let next = new LABEL();
     
                 if m.expressions? then
@@ -691,7 +691,7 @@ namespace Syntax.Process is
 
             _loops.leave_loop();
 
-            super.visit(case_);
+            super.visit(`case);
         si
 
         pre(match: Statements.CASE_MATCH) -> bool is
@@ -706,13 +706,13 @@ namespace Syntax.Process is
             super.visit(match);
         si
 
-        pre(try_: Statements.TRY) -> bool is
-            super.pre(try_);
+        pre(`try: Statements.TRY) -> bool is
+            super.pre(`try);
 
             return true;
         si
 
-        visit(try_: Statements.TRY) is
+        visit(`try: Statements.TRY) is
             let return_type = current_function.return_type;
 
             let return_needed = new TEMP(_context, 1, _innate_symbol_lookup.get_bool_type());
@@ -724,7 +724,7 @@ namespace Syntax.Process is
             
             let label = _loops.enter_try(return_needed, return_value);
 
-            let need_double_try = try_.catches? /\ try_.catches.count > 0 /\ try_.finally_?;
+            let need_double_try = `try.catches? /\ `try.catches.count > 0 /\ `try.`finally?;
 
             if need_double_try then
                 _context.write_line(".try {");
@@ -734,7 +734,7 @@ namespace Syntax.Process is
             _context.write_line(".try {");
             _context.indent();
 
-            try_.body.walk(self);
+            `try.body.walk(self);
 
             _brancher.leave(label.end);
 
@@ -742,7 +742,7 @@ namespace Syntax.Process is
 
             _context.write_line("}");
 
-            for c in try_.catches do
+            for c in `try.catches do
                 c.walk(self);
             od
 
@@ -751,12 +751,12 @@ namespace Syntax.Process is
                 _context.write_line("}");                
             fi
             
-            if try_.finally_? then
+            if `try.`finally? then
                 label.is_in_finally = true;
 
                 _context.write_line("finally {");
                 _context.indent();
-                try_.finally_.walk(self);
+                `try.`finally.walk(self);
 
                 _brancher.label(label.middle);
 
@@ -796,115 +796,115 @@ namespace Syntax.Process is
 
             _brancher.label(label.end);
 
-            super.visit(try_);
+            super.visit(`try);
         si
 
-        pre(catch_: Statements.CATCH) -> bool is
-            super.pre(catch_);
+        pre(`catch: Statements.CATCH) -> bool is
+            super.pre(`catch);
 
             return true;
         si
 
-        visit(catch_: Statements.CATCH) is
-            _context.write_line("catch " + catch_.variable.type_expression.type.get_il_type() + " {");
+        visit(`catch: Statements.CATCH) is
+            _context.write_line("catch " + `catch.variable.type_expression.type.get_il_type() + " {");
             _context.indent();
 
-            catch_.variable.walk(self);
+            `catch.variable.walk(self);
 
-            let symbol = find(catch_.variable.name);
+            let symbol = find(`catch.variable.name);
 
             _context.write_line("stloc " + symbol.get_il_reference());
 
-            catch_.body.walk(self);
+            `catch.body.walk(self);
 
             _brancher.leave(_loops.get_current_try().end);
 
             _context.outdent();
             _context.write_line("}");
 
-            super.visit(catch_);
+            super.visit(`catch);
         si
 
-        pre(do_: Statements.DO) -> bool is
-            super.pre(do_);
+        pre(`do: Statements.DO) -> bool is
+            super.pre(`do);
 
             return true;
         si
 
-        visit(do_: Statements.DO) is
+        visit(`do: Statements.DO) is
             let loop = _loops.enter_loop();
 
             _brancher.label(loop.start);
 
-            if do_.condition? then
-                _brancher.branch(BRANCH.Z, do_.condition.value, loop.end, "while");
+            if `do.condition? then
+                _brancher.branch(BRANCH.Z, `do.condition.value, loop.end, "while");
             fi
 
-            do_.body.walk(self);
+            `do.body.walk(self);
 
             _brancher.branch(loop.start);
 
             _brancher.label(loop.end);
 
-            super.visit(do_);
+            super.visit(`do);
 
             _loops.leave_loop();
         si
 
-        pre(for_: Statements.FOR) -> bool is
-            super.pre(for_);
+        pre(`for: Statements.FOR) -> bool is
+            super.pre(`for);
 
             return true;
         si
 
-        visit(for_: Statements.FOR) is
+        visit(`for: Statements.FOR) is
             let loop = _loops.enter_loop();
 
             let iterator: Value;
 
-            if for_.read_iterator? then
-                iterator = for_.read_iterator.call(for_.expression.location, for_.expression.value, new Collections.LIST[Value](0), null, _function_caller);
+            if `for.read_iterator? then
+                iterator = `for.read_iterator.call(`for.expression.location, `for.expression.value, new Collections.LIST[Value](0), null, _function_caller);
             else
-                iterator = for_.expression.value;
+                iterator = `for.expression.value;
             fi
 
-            for_.variable.walk(self);
+            `for.variable.walk(self);
             
             let temp = new TEMP(_context, iterator);
 
             _brancher.label(loop.start);
 
-            let has_next = for_.move_next.call(for_.expression.location, temp.load(), new Collections.LIST[Value](0), null, _function_caller);
+            let has_next = `for.move_next.call(`for.expression.location, temp.load(), new Collections.LIST[Value](0), null, _function_caller);
 
             _brancher.branch(BRANCH.Z, has_next, loop.end);
 
-            let current = for_.read_current.call(for_.expression.location, temp.load(), new Collections.LIST[Value](0), null, _function_caller);
+            let current = `for.read_current.call(`for.expression.location, temp.load(), new Collections.LIST[Value](0), null, _function_caller);
 
-            var variable = find(for_.variable.name);
+            var variable = find(`for.variable.name);
 
-            let store = variable.store(for_.variable.location, null, current, _symbol_loader);
+            let store = variable.store(`for.variable.location, null, current, _symbol_loader);
 
             store.gen(_context);
 
             // not to generate code for the expression itself, but to capture IL for any anonymous function bodies:
-            for_.expression.walk(self);
+            `for.expression.walk(self);
             
-            for_.body.walk(self);
+            `for.body.walk(self);
 
             _brancher.branch(loop.start);
             _brancher.label(loop.end);
 
-            super.visit(for_);
+            super.visit(`for);
 
             _loops.leave_loop();
         si
 
-        pre(pragma_: Statements.PRAGMA) -> bool is
-            process_pragma(pragma_.pragma_, true);
+        pre(pragma: Statements.PRAGMA) -> bool is
+            process_pragma(pragma.pragma, true);
         si
 
-        visit(pragma_: Statements.PRAGMA) is
-            process_pragma(pragma_.pragma_, false);
+        visit(pragma: Statements.PRAGMA) is
+            process_pragma(pragma.pragma, false);
         si
 
         pre(labelled: Statements.LABELLED) -> bool is
@@ -921,9 +921,9 @@ namespace Syntax.Process is
             super.visit(labelled);
         si
 
-        visit(break_: Statements.BREAK) is
+        visit(`break: Statements.BREAK) is
             if !_loops.is_in_loop then
-                _logger.error(break_.location, "break outside of loop");
+                _logger.error(`break.location, "break outside of loop");
 
                 return;
             fi
@@ -935,9 +935,9 @@ namespace Syntax.Process is
             fi            
         si
 
-        visit(continue_: Statements.CONTINUE) is
+        visit(`continue: Statements.CONTINUE) is
             if !_loops.is_in_loop then
-                _logger.error(continue_.location, "continue outside of loop");
+                _logger.error(`continue.location, "continue outside of loop");
 
                 return;
             fi

--- a/src/syntax/process/printer/base.ghul
+++ b/src/syntax/process/printer/base.ghul
@@ -144,14 +144,14 @@ namespace Syntax.Process.Printer is
             od
         si
 
-        visit(enum_: Definitions.ENUM) is
-            location(enum_);
+        visit(`enum: Definitions.ENUM) is
+            location(`enum);
             write("enum ");
-            enum_.name.accept(self);
+            `enum.name.accept(self);
             write_line(" is");
             indent();
             var seen_any = false;
-            for member in enum_.members do
+            for member in `enum.members do
                 if seen_any then
                     write_line(",");
                 fi
@@ -181,18 +181,18 @@ namespace Syntax.Process.Printer is
             outdent();
         si
         
-        visit(pragma_: Pragmas.PRAGMA) is
+        visit(pragma: Pragmas.PRAGMA) is
             write("@");
 
-            pragma_.name.accept(self);
+            pragma.name.accept(self);
             write("(");
 
-            pragma_.arguments.accept(self);
+            pragma.arguments.accept(self);
             write_line(")");
         si
 
-        visit(pragma_: Definitions.PRAGMA) is
-            pragma_.definition.accept(self);
+        visit(pragma: Definitions.PRAGMA) is
+            pragma.definition.accept(self);
         si
 
         visit(type_expression: TypeExpressions.INFER) is
@@ -257,8 +257,8 @@ namespace Syntax.Process.Printer is
             od
         si
 
-        visit(none_: Expressions.Literals.NONE) is
-            location(none_);
+        visit(`none: Expressions.Literals.NONE) is
+            location(`none);
             write("none");
         si
 
@@ -267,42 +267,42 @@ namespace Syntax.Process.Printer is
             identifier.identifier.accept(self);
         si
 
-        visit(super_: Expressions.SUPER) is
-            location(super_);
+        visit(`super: Expressions.SUPER) is
+            location(`super);
             write("super");
         si
 
-        visit(new_: Expressions.NEW) is
-            location(new_);
+        visit(`new: Expressions.NEW) is
+            location(`new);
             write("new ");
-            new_.type_expression.accept(self);
+            `new.type_expression.accept(self);
             write('(');
-            new_.arguments.accept(self);
+            `new.arguments.accept(self);
             write(')');
         si
 
-        visit(cast_: Expressions.CAST) is
-            location(cast_);
+        visit(`cast: Expressions.CAST) is
+            location(`cast);
             write("cast ");
-            cast_.type_expression.accept(self);
+            `cast.type_expression.accept(self);
             write('(');
-            cast_.right.accept(self);
+            `cast.right.accept(self);
             write(')');
         si
 
-        visit(isa_: Expressions.ISA) is
-            location(isa_);
+        visit(`isa: Expressions.ISA) is
+            location(`isa);
             write("isa ");
-            isa_.type_expression.accept(self);
+            `isa.type_expression.accept(self);
             write('(');
-            isa_.right.accept(self);
+            `isa.right.accept(self);
             write(')');
         si
 
-        visit(typeof_: Expressions.TYPEOF) is
-            location(typeof_);
+        visit(`typeof: Expressions.TYPEOF) is
+            location(`typeof);
             write("typeof ");
-            typeof_.type_expression.accept(self);
+            `typeof.type_expression.accept(self);
         si
 
         visit(tuple: Expressions.TUPLE) is
@@ -384,10 +384,10 @@ namespace Syntax.Process.Printer is
             fi
         si
 
-        visit(string_: Expressions.Literals.STRING) is
-            location(string_);
+        visit(`string: Expressions.Literals.STRING) is
+            location(`string);
             write(cast char(34));
-            for c in string_.value_string do
+            for c in `string.value_string do
                 write_escape_char(c);
             od
             write(cast char(34));
@@ -515,12 +515,12 @@ namespace Syntax.Process.Printer is
             write_line("fi");
         si
 
-        visit(case_: Statements.CASE) is
-            location(case_);
+        visit(`case: Statements.CASE) is
+            location(`case);
             write("case ");
-            case_.expression.accept(self);
+            `case.expression.accept(self);
             write_line();
-            for m in case_.matches do
+            for m in `case.matches do
                 m.accept(self);
             od
             write_line("esac");
@@ -540,44 +540,44 @@ namespace Syntax.Process.Printer is
             outdent();
         si
 
-        visit(try_: Statements.TRY) is
-            location(try_);
+        visit(`try: Statements.TRY) is
+            location(`try);
             write_line("try");
             indent();
-            try_.body.accept(self);
+            `try.body.accept(self);
             outdent();
-            for c in try_.catches do
+            for c in `try.catches do
                 c.accept(self);
             od
-            if try_.finally_? then
+            if `try.`finally? then
                 write_line("finally");
                 indent();
-                try_.finally_.accept(self);
+                `try.`finally.accept(self);
                 outdent();
             fi
             write_line("yrt");
         si
 
-        visit(catch_: Statements.CATCH) is
-            location(catch_);
+        visit(`catch: Statements.CATCH) is
+            location(`catch);
             write("catch ");
-            catch_.variable.accept(self);
+            `catch.variable.accept(self);
             write_line();
             indent();
-            catch_.body.accept(self);
+            `catch.body.accept(self);
             outdent();
         si
 
-        visit(do_: Statements.DO) is
-            location(do_);
-            if do_.condition? then
+        visit(`do: Statements.DO) is
+            location(`do);
+            if `do.condition? then
                 write("while ");
-                do_.condition.accept(self);
+                `do.condition.accept(self);
                 write(" ");
             fi
             write_line("do");
             indent();
-            do_.body.accept(self);
+            `do.body.accept(self);
             outdent();
             write_line("od");
         si
@@ -589,29 +589,29 @@ namespace Syntax.Process.Printer is
             labelled.statement.accept(self);
         si
 
-        visit(break_: Statements.BREAK) is
-            location(break_);
+        visit(`break: Statements.BREAK) is
+            location(`break);
             write("break");
-            if break_.label? then
+            if `break.label? then
                 write(' ');
-                break_.label.accept(self);
+                `break.label.accept(self);
             fi
             write_line(";");
         si
 
-        visit(continue_: Statements.CONTINUE) is
-            location(continue_);
+        visit(`continue: Statements.CONTINUE) is
+            location(`continue);
             write("continue");
-            if continue_.label? then
+            if `continue.label? then
                 write(' ');
-                continue_.label.accept(self);
+                `continue.label.accept(self);
             fi
             write_line(";");
         si
 
-        visit(pragma_: Statements.PRAGMA) is
-            if pragma_.statement? then
-                pragma_.statement.accept(self);                
+        visit(pragma: Statements.PRAGMA) is
+            if pragma.statement? then
+                pragma.statement.accept(self);                
             fi
         si
 

--- a/src/syntax/process/printer/ghul.ghul
+++ b/src/syntax/process/printer/ghul.ghul
@@ -21,85 +21,85 @@ namespace Syntax.Process.Printer is
             fi
         si
 
-        visit(namespace_: Definitions.NAMESPACE) is
+        visit(`namespace: Definitions.NAMESPACE) is
             write("namespace ");
-            namespace_.name.accept(self);
+            `namespace.name.accept(self);
             write_line(" is");
             indent();
-            namespace_.body.accept(self);
+            `namespace.body.accept(self);
             outdent();
             write_line("si");
         si
 
-        visit(use_: Definitions.USE) is
+        visit(`use: Definitions.USE) is
             write("use ");
             var seen_any = false;
-            if use_.name then
-                use_.name.accept(self);
+            if `use.name then
+                `use.name.accept(self);
                 write(" = ");
             fi
 
-            if use_.use_ then
-                use_.use_.accept(self);                
+            if `use.`use then
+                `use.`use.accept(self);                
             fi
 
             write_line(";");
         si
 
-        visit(class_: Definitions.CLASS) is
+        visit(`class: Definitions.CLASS) is
             write("class ");
-            class_.name.accept(self);
-            if class_.arguments? then
+            `class.name.accept(self);
+            if `class.arguments? then
                 write("[");
-                class_.arguments.accept(self);
+                `class.arguments.accept(self);
                 write("]");
             fi
-            if class_.ancestors? then
+            if `class.ancestors? then
                 write(": ");
-                class_.ancestors.accept(self);
+                `class.ancestors.accept(self);
             fi
-            class_.modifiers.accept(self);
+            `class.modifiers.accept(self);
             write_line(" is");
             indent();
-            class_.body.accept(self);
+            `class.body.accept(self);
             outdent();
             write_line("si");
         si
 
-        visit(trait_: Definitions.TRAIT) is
+        visit(`trait: Definitions.TRAIT) is
             write("trait ");
-            trait_.name.accept(self);
-            if trait_.arguments? then
+            `trait.name.accept(self);
+            if `trait.arguments? then
                 write("[");
-                trait_.arguments.accept(self);
+                `trait.arguments.accept(self);
                 write("]");
             fi
-            if trait_.ancestors? then
+            if `trait.ancestors? then
                 write(": ");
-                trait_.ancestors.accept(self);
+                `trait.ancestors.accept(self);
             fi
-            trait_.modifiers.accept(self);
+            `trait.modifiers.accept(self);
             write_line(" is");
             indent();
-            trait_.body.accept(self);
+            `trait.body.accept(self);
             outdent();
             write_line("si");
         si
 
-        visit(struct_: Definitions.STRUCT) is
+        visit(`struct: Definitions.STRUCT) is
             write("trait ");
-            struct_.name.accept(self);
+            `struct.name.accept(self);
             
-            if struct_.arguments? then
+            if `struct.arguments? then
                 write("[");
-                struct_.arguments.accept(self);
+                `struct.arguments.accept(self);
                 write("]");
             fi
 
-            struct_.modifiers.accept(self);
+            `struct.modifiers.accept(self);
             write_line(" is");
             indent();
-            struct_.body.accept(self);
+            `struct.body.accept(self);
             outdent();
             write_line("si");
         si        
@@ -240,11 +240,11 @@ namespace Syntax.Process.Printer is
             element.type_expression.accept(self);
         si
 
-        visit(null_: Expressions.NULL) is
+        visit(`null: Expressions.NULL) is
             write("null");
         si
 
-        visit(self_: Expressions.SELF) is
+        visit(`self: Expressions.SELF) is
             write("self");
         si
 
@@ -297,14 +297,14 @@ namespace Syntax.Process.Printer is
             write_line(";");
         si
 
-        visit(for_: Statements.FOR) is
+        visit(`for: Statements.FOR) is
             write_line("for ");
-            for_.variable.accept(self);
+            `for.variable.accept(self);
             write(" in ");
-            for_.expression.accept(self);
+            `for.expression.accept(self);
             write_line(" do");
             indent();
-            for_.body.accept(self);
+            `for.body.accept(self);
             outdent();
             write_line("od");
         si
@@ -322,9 +322,9 @@ namespace Syntax.Process.Printer is
             write("si");
         si
 
-        visit(innate_: Bodies.INNATE) is
+        visit(`innate: Bodies.INNATE) is
             write("innate ");
-            innate_.name.accept(self);
+            `innate.name.accept(self);
         si
     si
 si

--- a/src/syntax/process/resolve_ancestors.ghul
+++ b/src/syntax/process/resolve_ancestors.ghul
@@ -28,23 +28,23 @@ namespace Syntax.Process is
             root.walk(self);
         si
 
-        pre(class_: Trees.Definitions.CLASS) -> bool is
-            super.pre(class_);
+        pre(`class: Trees.Definitions.CLASS) -> bool is
+            super.pre(`class);
 
             return true;
         si
 
-        visit(class_: Trees.Definitions.CLASS) is
+        visit(`class: Trees.Definitions.CLASS) is
             let class_symbol = cast Semantic.Symbols.CLASS(_symbol_table.current_instance_context);
 
             // exit class scope before looking up ancestors:
-            super.visit(class_);            
+            super.visit(`class);            
 
             let seen_class_ancestor = false;
             let is_first = true;
 
-            if class_.ancestors? then
-                for a in class_.ancestors do
+            if `class.ancestors? then
+                for a in `class.ancestors do
                     var ancestor_type = a.type; 
 
                     if ancestor_type? then
@@ -70,7 +70,7 @@ namespace Syntax.Process is
             fi
 
             // FIXME: safer test for Ghul.object:
-            if !seen_class_ancestor /\ class_.name.name !~ "object" then
+            if !seen_class_ancestor /\ `class.name.name !~ "object" then
                 let object_type = _innate_symbol_lookup.get_object_type();
 
                 if class_symbol != object_type.symbol then
@@ -79,22 +79,22 @@ namespace Syntax.Process is
             fi
         si
 
-        pre(trait_: Trees.Definitions.TRAIT) -> bool is
-            super.pre(trait_);
+        pre(`trait: Trees.Definitions.TRAIT) -> bool is
+            super.pre(`trait);
 
             return true;
         si
 
-        visit(trait_: Trees.Definitions.TRAIT) is
+        visit(`trait: Trees.Definitions.TRAIT) is
             let trait_symbol = cast Semantic.Symbols.TRAIT(_symbol_table.current_instance_context);
 
             // exit class scope before looking up ancestors:
-            super.visit(trait_);
+            super.visit(`trait);
 
             var seen_valid_ancestor = false;
 
-            if trait_.ancestors? then
-                for a in trait_.ancestors do
+            if `trait.ancestors? then
+                for a in `trait.ancestors do
                     var ancestor_type = a.type;
 
                     if ancestor_type? then
@@ -125,20 +125,20 @@ namespace Syntax.Process is
             // fi
         si
 
-        pre(struct_: Trees.Definitions.STRUCT) -> bool is
-            super.pre(struct_);
+        pre(`struct: Trees.Definitions.STRUCT) -> bool is
+            super.pre(`struct);
 
             return true;
         si
 
-        visit(struct_: Trees.Definitions.STRUCT) is
+        visit(`struct: Trees.Definitions.STRUCT) is
             let struct_symbol = cast Semantic.Symbols.STRUCT(_symbol_table.current_instance_context);
 
             // exit class scope before looking up ancestors:
-            super.visit(struct_);
+            super.visit(`struct);
 
-            if struct_.ancestors? then
-                for a in struct_.ancestors do
+            if `struct.ancestors? then
+                for a in `struct.ancestors do
                     var ancestor_type = a.type; 
 
                     if ancestor_type? then

--- a/src/syntax/process/resolve_explicit_variable_types.ghul
+++ b/src/syntax/process/resolve_explicit_variable_types.ghul
@@ -30,26 +30,26 @@ namespace Syntax.Process is
             root.walk(self);
         si
 
-        pre(class_: Trees.Definitions.CLASS) -> bool is
-            let result = super.pre(class_);
+        pre(`class: Trees.Definitions.CLASS) -> bool is
+            let result = super.pre(`class);
 
-            if is_stable(class_) then
+            if is_stable(`class) then
                 return true;
             fi            
 
-            set_generic_argument_types(class_.arguments);
+            set_generic_argument_types(`class.arguments);
 
             return result;
         si
 
-        pre(trait_: Trees.Definitions.TRAIT) -> bool is
-            super.pre(trait_);
-            return is_stable(trait_);            
+        pre(`trait: Trees.Definitions.TRAIT) -> bool is
+            super.pre(`trait);
+            return is_stable(`trait);            
         si        
 
-        pre(struct_: Trees.Definitions.STRUCT) -> bool is
-            super.pre(struct_);
-            return is_stable(struct_);            
+        pre(`struct: Trees.Definitions.STRUCT) -> bool is
+            super.pre(`struct);
+            return is_stable(`struct);            
         si
         
         visit(function: Trees.Definitions.FUNCTION) is

--- a/src/syntax/process/resolve_overrides.ghul
+++ b/src/syntax/process/resolve_overrides.ghul
@@ -39,23 +39,23 @@ namespace Syntax.Process is
             root.walk(self);
         si
 
-        pre(class_: Trees.Definitions.CLASS) -> bool is
-            super.pre(class_);
+        pre(`class: Trees.Definitions.CLASS) -> bool is
+            super.pre(`class);
             return true;
         si
 
-        pre(trait_: Trees.Definitions.TRAIT) -> bool is
-            super.pre(trait_);
+        pre(`trait: Trees.Definitions.TRAIT) -> bool is
+            super.pre(`trait);
             return true;
         si        
 
-        pre(struct_: Trees.Definitions.STRUCT) -> bool is
-            super.pre(struct_);
+        pre(`struct: Trees.Definitions.STRUCT) -> bool is
+            super.pre(`struct);
             return true;
         si
 
-        visit(class_: Definitions.CLASS) is
-            let symbol = symbol_for(class_);
+        visit(`class: Definitions.CLASS) is
+            let symbol = symbol_for(`class);
 
             @IF.debug() Std.error.write_line("resolve overrides: " + symbol);
 
@@ -66,8 +66,8 @@ namespace Syntax.Process is
             fi
         si
 
-        visit(struct_: Definitions.STRUCT) is
-            let symbol = symbol_for(struct_);
+        visit(`struct: Definitions.STRUCT) is
+            let symbol = symbol_for(`struct);
 
             @IF.debug() Std.error.write_line("resolve overrides: " + symbol);
 
@@ -78,8 +78,8 @@ namespace Syntax.Process is
             fi
         si
 
-        visit(trait_: Definitions.TRAIT) is
-            let symbol = symbol_for(trait_);
+        visit(`trait: Definitions.TRAIT) is
+            let symbol = symbol_for(`trait);
 
             @IF.debug() Std.error.write_line("resolve overrides: " + symbol);
 

--- a/src/syntax/process/resolve_type_expressions.ghul
+++ b/src/syntax/process/resolve_type_expressions.ghul
@@ -35,19 +35,19 @@ namespace Syntax.Process is
             root.walk(self);
         si
 
-        pre(class_: Trees.Definitions.CLASS) -> bool is
-            super.pre(class_);
-            return is_stable(class_);
+        pre(`class: Trees.Definitions.CLASS) -> bool is
+            super.pre(`class);
+            return is_stable(`class);
         si
 
-        pre(trait_: Trees.Definitions.TRAIT) -> bool is
-            super.pre(trait_);
-            return is_stable(trait_);
+        pre(`trait: Trees.Definitions.TRAIT) -> bool is
+            super.pre(`trait);
+            return is_stable(`trait);
         si        
 
-        pre(struct_: Trees.Definitions.STRUCT) -> bool is
-            super.pre(struct_);
-            return is_stable(struct_);            
+        pre(`struct: Trees.Definitions.STRUCT) -> bool is
+            super.pre(`struct);
+            return is_stable(`struct);            
         si
 
         visit(named: Trees.TypeExpressions.NAMED) is

--- a/src/syntax/process/resolve_uses.ghul
+++ b/src/syntax/process/resolve_uses.ghul
@@ -20,19 +20,19 @@ namespace Syntax.Process is
             node.walk(self);
         si
 
-        pre(namespace_: Definitions.NAMESPACE) -> bool is
-            let namespace_scope = enter_namespace(namespace_.name);
+        pre(`namespace: Definitions.NAMESPACE) -> bool is
+            let namespace_scope = enter_namespace(`namespace.name);
 
             // FIXME: these searches probably should start at the scope immediately enclosing the namespace
-            for u in namespace_.body.uses do
-                if !u.use_? then
+            for u in `namespace.body.uses do
+                if !u.`use? then
                     continue;
                 fi                
                 
-                let used_symbol = find_enclosing(u.use_);
+                let used_symbol = find_enclosing(u.`use);
 
                 if !used_symbol? then
-                    _logger.error(u.location, "used identifier " + u.use_ + " is not defined ");
+                    _logger.error(u.location, "used identifier " + u.`use + " is not defined ");
                 elif u.name? then
                     namespace_scope.add(u.name.name, used_symbol);
                 elif isa Semantic.Symbols.NAMESPACE(used_symbol) then
@@ -43,8 +43,8 @@ namespace Syntax.Process is
             od
         si
 
-        visit(namespace_: Definitions.NAMESPACE) is
-            leave_namespace(namespace_.name);
+        visit(`namespace: Definitions.NAMESPACE) is
+            leave_namespace(`namespace.name);
         si
     si
 si

--- a/src/syntax/process/scopedvisitor.ghul
+++ b/src/syntax/process/scopedvisitor.ghul
@@ -66,46 +66,46 @@ namespace Syntax.Process is
 
         is_stable(node: Trees.Node) -> bool => _stable_symbols.is_stable(node);
 
-        pre(namespace_: Definitions.NAMESPACE) -> bool is
-            enter_namespace(namespace_.name);
-            enter_uses(namespace_);
+        pre(`namespace: Definitions.NAMESPACE) -> bool is
+            enter_namespace(`namespace.name);
+            enter_uses(`namespace);
         si
 
-        visit(namespace_: Definitions.NAMESPACE) is
-            leave_uses(namespace_);
-            leave_namespace(namespace_.name);
+        visit(`namespace: Definitions.NAMESPACE) is
+            leave_uses(`namespace);
+            leave_namespace(`namespace.name);
         si
 
-        pre(class_: Definitions.CLASS) -> bool is
-            enter_scope(class_);
+        pre(`class: Definitions.CLASS) -> bool is
+            enter_scope(`class);
         si
 
-        visit(class_: Definitions.CLASS) is
-            leave_scope(class_);
+        visit(`class: Definitions.CLASS) is
+            leave_scope(`class);
         si
 
-        pre(trait_: Definitions.TRAIT) -> bool is
-            enter_scope(trait_);
+        pre(`trait: Definitions.TRAIT) -> bool is
+            enter_scope(`trait);
         si
 
-        visit(trait_: Definitions.TRAIT) is
-            leave_scope(trait_);
+        visit(`trait: Definitions.TRAIT) is
+            leave_scope(`trait);
         si
 
-        pre(struct_: Definitions.STRUCT) -> bool is
-            enter_scope(struct_);
+        pre(`struct: Definitions.STRUCT) -> bool is
+            enter_scope(`struct);
         si
 
-        visit(struct_: Definitions.STRUCT) is
-            leave_scope(struct_);
+        visit(`struct: Definitions.STRUCT) is
+            leave_scope(`struct);
         si        
 
-        pre(enum_: Definitions.ENUM) -> bool is
-            enter_scope(enum_);
+        pre(`enum: Definitions.ENUM) -> bool is
+            enter_scope(`enum);
         si
 
-        visit(enum_: Definitions.ENUM) is
-            leave_scope(enum_);
+        visit(`enum: Definitions.ENUM) is
+            leave_scope(`enum);
         si
 
         pre(function: Definitions.FUNCTION) -> bool is
@@ -142,12 +142,12 @@ namespace Syntax.Process is
             leave_scope(if_branch);
         si
 
-        pre(case_: Statements.CASE) -> bool is
-            enter_scope(case_);
+        pre(`case: Statements.CASE) -> bool is
+            enter_scope(`case);
         si
 
-        visit(case_: Statements.CASE) is
-            leave_scope(case_);
+        visit(`case: Statements.CASE) is
+            leave_scope(`case);
         si
 
         pre(case_match: Statements.CASE_MATCH) -> bool is
@@ -158,36 +158,36 @@ namespace Syntax.Process is
             leave_scope(case_match);
         si
 
-        pre(try_: Statements.TRY) -> bool is
-            enter_scope(try_);
+        pre(`try: Statements.TRY) -> bool is
+            enter_scope(`try);
         si
 
-        visit(try_: Statements.TRY) is
-            leave_scope(try_);
+        visit(`try: Statements.TRY) is
+            leave_scope(`try);
         si
 
-        pre(catch_: Statements.CATCH) -> bool is
-            enter_scope(catch_);
+        pre(`catch: Statements.CATCH) -> bool is
+            enter_scope(`catch);
         si
 
-        visit(catch_: Statements.CATCH) is
-            leave_scope(catch_);
+        visit(`catch: Statements.CATCH) is
+            leave_scope(`catch);
         si
 
-        pre(do_: Statements.DO) -> bool is
-            enter_scope(do_);
+        pre(`do: Statements.DO) -> bool is
+            enter_scope(`do);
         si
 
-        visit(do_: Statements.DO) is
-            leave_scope(do_);
+        visit(`do: Statements.DO) is
+            leave_scope(`do);
         si
 
-        pre(for_: Statements.FOR) -> bool is
-            enter_scope(for_);
+        pre(`for: Statements.FOR) -> bool is
+            enter_scope(`for);
         si
 
-        visit(for_: Statements.FOR) is
-            leave_scope(for_);
+        visit(`for: Statements.FOR) is
+            leave_scope(`for);
         si
 
         pre(labelled: Statements.LABELLED) -> bool is

--- a/src/syntax/process/scopevisitorbase.ghul
+++ b/src/syntax/process/scopevisitorbase.ghul
@@ -148,11 +148,11 @@ namespace Syntax is
             _namespaces.leave_namespace(identifier.location, identifier.name);
         si
 
-        enter_uses(namespace_: Definitions.NAMESPACE) is
+        enter_uses(`namespace: Definitions.NAMESPACE) is
             // FIXME: remove me
         si
 
-        leave_uses(namespace_: Definitions.NAMESPACE) is
+        leave_uses(`namespace: Definitions.NAMESPACE) is
             // FIXME: remove me
         si
     si

--- a/src/syntax/process/signature_help.ghul
+++ b/src/syntax/process/signature_help.ghul
@@ -57,29 +57,29 @@ namespace Syntax.Process is
             fi
         si
 
-        visit(new_: Trees.Expressions.NEW) is
-            if new_.arguments == null then
+        visit(`new: Trees.Expressions.NEW) is
+            if `new.arguments == null then
                 return;
             fi
 
             if !(_results?) then
                 if
-                    !new_.location.contains(_target_line, _target_column) \/
+                    !`new.location.contains(_target_line, _target_column) \/
                     new LOCATION(
-                        new_.location.file_name,
-                        new_.location.start_line,
-                        new_.location.start_column,
-                        new_.type_expression.location.end_line,
-                        new_.type_expression.location.end_column
+                        `new.location.file_name,
+                        `new.location.start_line,
+                        `new.location.start_column,
+                        `new.type_expression.location.end_line,
+                        `new.type_expression.location.end_column
                     ).contains(_target_line, _target_column)
                 then
                     return;
                 fi
                 
-                _results = help_for(new_);
+                _results = help_for(`new);
                 
                 if _results? then
-                    _results.current_parameter_index = get_current_parameter_index(new_.location, new Collections.LIST[Trees.Expressions.Expression](new_.arguments));
+                    _results.current_parameter_index = get_current_parameter_index(`new.location, new Collections.LIST[Trees.Expressions.Expression](`new.arguments));
                 fi
             fi
         si
@@ -223,12 +223,12 @@ namespace Syntax.Process is
             */
         si
 
-        help_for(new_: Trees.Expressions.NEW) -> Semantic.OVERLOAD_MATCHES_RESULT is
+        help_for(`new: Trees.Expressions.NEW) -> Semantic.OVERLOAD_MATCHES_RESULT is
             if _results? then
                 return null;
             fi
 
-            let type = new_.type_expression.type;
+            let type = `new.type_expression.type;
 
             if type == null then
                 return null;
@@ -246,7 +246,7 @@ namespace Syntax.Process is
 
             let argument_types = new Collections.LIST[Type]();
 
-            for a in new_.arguments do
+            for a in `new.arguments do
                 if a? /\ a.value? /\ a.value.type? then
                     argument_types.add(a.value.type);                    
                 else

--- a/src/syntax/process/strictvisitor.ghul
+++ b/src/syntax/process/strictvisitor.ghul
@@ -44,28 +44,28 @@ namespace Syntax is
             throwNotImplemented("definition list", definitions);
         si
 
-        visit(namespace_: Definitions.NAMESPACE) is
-            throwNotImplemented("namespace", namespace_);
+        visit(`namespace: Definitions.NAMESPACE) is
+            throwNotImplemented("namespace", `namespace);
         si
 
-        visit(use_: Definitions.USE) is
-            throwNotImplemented("use", use_);
+        visit(`use: Definitions.USE) is
+            throwNotImplemented("use", `use);
         si
 
-        visit(class_: Definitions.CLASS) is
-            throwNotImplemented("class", class_);
+        visit(`class: Definitions.CLASS) is
+            throwNotImplemented("class", `class);
         si
 
-        visit(trait_: Definitions.TRAIT) is
-            throwNotImplemented("trait", trait_);
+        visit(`trait: Definitions.TRAIT) is
+            throwNotImplemented("trait", `trait);
         si
 
-        visit(struct_: Definitions.STRUCT) is
-            throwNotImplemented("struct", struct_);
+        visit(`struct: Definitions.STRUCT) is
+            throwNotImplemented("struct", `struct);
         si        
 
-        visit(enum_: Definitions.ENUM) is
-            throwNotImplemented("enum", enum_);
+        visit(`enum: Definitions.ENUM) is
+            throwNotImplemented("enum", `enum);
         si
 
         visit(enum_member: Definitions.ENUM_MEMBER) is
@@ -156,8 +156,8 @@ namespace Syntax is
             throwNotImplemented("literal", literal);
         si
 
-        visit(string_: Expressions.Literals.STRING) is
-            throwNotImplemented("string literal", string_);
+        visit(`string: Expressions.Literals.STRING) is
+            throwNotImplemented("string literal", `string);
         si
 
         visit(integer: Expressions.Literals.INTEGER) is
@@ -184,32 +184,32 @@ namespace Syntax is
             throwNotImplemented("none", none);
         si
 
-        visit(null_: Expressions.NULL) is
-            throwNotImplemented("null", null_);
+        visit(`null: Expressions.NULL) is
+            throwNotImplemented("null", `null);
         si
 
-        visit(self_: Expressions.SELF) is
-            throwNotImplemented("self", self_);
+        visit(`self: Expressions.SELF) is
+            throwNotImplemented("self", `self);
         si
 
-        visit(super_: Expressions.SUPER) is
-            throwNotImplemented("super", super_);
+        visit(`super: Expressions.SUPER) is
+            throwNotImplemented("super", `super);
         si
 
-        visit(new_: Expressions.NEW) is
-            throwNotImplemented("new", new_);
+        visit(`new: Expressions.NEW) is
+            throwNotImplemented("new", `new);
         si
 
-        visit(cast_: Expressions.CAST) is
-            throwNotImplemented("cast", cast_);
+        visit(`cast: Expressions.CAST) is
+            throwNotImplemented("cast", `cast);
         si
 
-        visit(isa_: Expressions.ISA) is
-            throwNotImplemented("isa", isa_);
+        visit(`isa: Expressions.ISA) is
+            throwNotImplemented("isa", `isa);
         si
 
-        visit(isa_: Expressions.TYPEOF) is
-            throwNotImplemented("isa", isa_);
+        visit(`isa: Expressions.TYPEOF) is
+            throwNotImplemented("isa", `isa);
         si
 
         visit(function: Syntax.Trees.Expressions.FUNCTION) is
@@ -280,56 +280,56 @@ namespace Syntax is
             throwNotImplemented("expression", expression);
         si
 
-        visit(return_: Statements.RETURN) is
-            throwNotImplemented("return", return_);
+        visit(`return: Statements.RETURN) is
+            throwNotImplemented("return", `return);
         si
 
-        visit(throw_: Statements.THROW) is
-            throwNotImplemented("throw", throw_);
+        visit(`throw: Statements.THROW) is
+            throwNotImplemented("throw", `throw);
         si
 
-        visit(assert_: Statements.ASSERT) is
-            throwNotImplemented("assert", assert_);
+        visit(`assert: Statements.ASSERT) is
+            throwNotImplemented("assert", `assert);
         si
 
-        visit(if_: Statements.IF) is
-            throwNotImplemented("if", if_);
+        visit(`if: Statements.IF) is
+            throwNotImplemented("if", `if);
         si
 
-        visit(case_: Statements.CASE) is
-            throwNotImplemented("case", case_);
+        visit(`case: Statements.CASE) is
+            throwNotImplemented("case", `case);
         si
 
         visit(case_match: Statements.CASE_MATCH) is
             throwNotImplemented("case match", case_match);
         si
 
-        visit(try_: Statements.TRY) is
-            throwNotImplemented("try", try_);
+        visit(`try: Statements.TRY) is
+            throwNotImplemented("try", `try);
         si
 
-        visit(catch_: Statements.CATCH) is
-            throwNotImplemented("catch", catch_);
+        visit(`catch: Statements.CATCH) is
+            throwNotImplemented("catch", `catch);
         si
 
-        visit(do_: Statements.DO) is
-            throwNotImplemented("do", do_);
+        visit(`do: Statements.DO) is
+            throwNotImplemented("do", `do);
         si
 
-        visit(for_: Statements.FOR) is
-            throwNotImplemented("for", for_);
+        visit(`for: Statements.FOR) is
+            throwNotImplemented("for", `for);
         si
 
         visit(labelled: Statements.LABELLED) is
             throwNotImplemented("labelled", labelled);
         si
 
-        visit(break_: Statements.BREAK) is
-            throwNotImplemented("break", break_);
+        visit(`break: Statements.BREAK) is
+            throwNotImplemented("break", `break);
         si
 
-        visit(continue_: Statements.CONTINUE) is
-            throwNotImplemented("continue", continue_);
+        visit(`continue: Statements.CONTINUE) is
+            throwNotImplemented("continue", `continue);
         si
 
         visit(body: Bodies.Body) is

--- a/src/syntax/process/visitor.ghul
+++ b/src/syntax/process/visitor.ghul
@@ -57,11 +57,11 @@ namespace Syntax is
         visit(modifiers: Modifiers.LIST) is
         si
 
-        pre(pragma_: Pragmas.PRAGMA) -> bool is
+        pre(pragma: Pragmas.PRAGMA) -> bool is
             return false;
         si
 
-        visit(pragma_: Pragmas.PRAGMA) is            
+        visit(pragma: Pragmas.PRAGMA) is            
         si
 
         pre(definition: Definitions.Definition) -> bool is
@@ -78,53 +78,53 @@ namespace Syntax is
         visit(definitions: Definitions.LIST) is
         si
 
-        pre(pragma_: Definitions.PRAGMA) -> bool is
+        pre(pragma: Definitions.PRAGMA) -> bool is
             return false;
         si
 
-        visit(pragma_: Definitions.PRAGMA) is            
+        visit(pragma: Definitions.PRAGMA) is            
         si
 
-        pre(namespace_: Definitions.NAMESPACE) -> bool is
+        pre(`namespace: Definitions.NAMESPACE) -> bool is
             return false;
         si
 
-        visit(namespace_: Definitions.NAMESPACE) is
+        visit(`namespace: Definitions.NAMESPACE) is
         si
 
-        pre(use_: Definitions.USE) -> bool is
+        pre(`use: Definitions.USE) -> bool is
             return false;
         si
 
-        visit(use_: Definitions.USE) is
+        visit(`use: Definitions.USE) is
         si
 
-        pre(class_: Definitions.CLASS) -> bool is
+        pre(`class: Definitions.CLASS) -> bool is
             return false;
         si
 
-        visit(class_: Definitions.CLASS) is
+        visit(`class: Definitions.CLASS) is
         si
 
-        pre(trait_: Definitions.TRAIT) -> bool is
+        pre(`trait: Definitions.TRAIT) -> bool is
             return false;
         si
 
-        visit(trait_: Definitions.TRAIT) is
+        visit(`trait: Definitions.TRAIT) is
         si
 
-        pre(struct_: Definitions.STRUCT) -> bool is
+        pre(`struct: Definitions.STRUCT) -> bool is
             return false;
         si
 
-        visit(struct_: Definitions.STRUCT) is
+        visit(`struct: Definitions.STRUCT) is
         si        
 
-        pre(enum_: Definitions.ENUM) -> bool is
+        pre(`enum: Definitions.ENUM) -> bool is
             return false;
         si
 
-        visit(enum_: Definitions.ENUM) is
+        visit(`enum: Definitions.ENUM) is
         si
 
         pre(enum_member: Definitions.ENUM_MEMBER) -> bool is
@@ -295,11 +295,11 @@ namespace Syntax is
         visit(literal: Expressions.Literals.Literal) is
         si
 
-        pre(string_: Expressions.Literals.STRING) -> bool is
+        pre(`string: Expressions.Literals.STRING) -> bool is
             return false;
         si
 
-        visit(string_: Expressions.Literals.STRING) is
+        visit(`string: Expressions.Literals.STRING) is
         si
 
         pre(integer: Expressions.Literals.INTEGER) -> bool is
@@ -344,53 +344,53 @@ namespace Syntax is
         visit(none: Expressions.Literals.NONE) is
         si
 
-        pre(null_: Expressions.NULL) -> bool is
+        pre(`null: Expressions.NULL) -> bool is
             return false;
         si
 
-        visit(null_: Expressions.NULL) is
+        visit(`null: Expressions.NULL) is
         si
 
-        pre(self_: Expressions.SELF) -> bool is
+        pre(`self: Expressions.SELF) -> bool is
             return false;
         si
 
-        visit(self_: Expressions.SELF) is
+        visit(`self: Expressions.SELF) is
         si
 
-        pre(super_: Expressions.SUPER) -> bool is
+        pre(`super: Expressions.SUPER) -> bool is
             return false;
         si
 
-        visit(super_: Expressions.SUPER) is
+        visit(`super: Expressions.SUPER) is
         si
 
-        pre(new_: Expressions.NEW) -> bool is
+        pre(`new: Expressions.NEW) -> bool is
             return false;
         si
 
-        visit(new_: Expressions.NEW) is
+        visit(`new: Expressions.NEW) is
         si
 
-        pre(cast_: Expressions.CAST) -> bool is
+        pre(`cast: Expressions.CAST) -> bool is
             return false;
         si
 
-        visit(cast_: Expressions.CAST) is
+        visit(`cast: Expressions.CAST) is
         si
 
-        pre(isa_: Expressions.ISA) -> bool is
+        pre(`isa: Expressions.ISA) -> bool is
             return false;
         si
 
-        visit(isa_: Expressions.ISA) is
+        visit(`isa: Expressions.ISA) is
         si
 
-        pre(isa_: Expressions.TYPEOF) -> bool is
+        pre(`isa: Expressions.TYPEOF) -> bool is
             return false;
         si
 
-        visit(isa_: Expressions.TYPEOF) is
+        visit(`isa: Expressions.TYPEOF) is
         si
 
         pre(function: Syntax.Trees.Expressions.FUNCTION) -> bool is
@@ -512,18 +512,18 @@ namespace Syntax is
         visit(expression: Statements.EXPRESSION) is
         si
 
-        pre(return_: Statements.RETURN) -> bool is
+        pre(`return: Statements.RETURN) -> bool is
             return false;
         si
 
-        visit(return_: Statements.RETURN) is
+        visit(`return: Statements.RETURN) is
         si
 
-        pre(throw_: Statements.THROW) -> bool is
+        pre(`throw: Statements.THROW) -> bool is
             return false;
         si
 
-        visit(throw_: Statements.THROW) is
+        visit(`throw: Statements.THROW) is
         si
 
         pre(assert__: Statements.ASSERT) -> bool is
@@ -533,11 +533,11 @@ namespace Syntax is
         visit(assert__: Statements.ASSERT) is
         si
 
-        pre(if_: Statements.IF) -> bool is
+        pre(`if: Statements.IF) -> bool is
             return false;
         si
 
-        visit(if_: Statements.IF) is
+        visit(`if: Statements.IF) is
         si
 
         pre(if_branch: Statements.IF_BRANCH) -> bool is
@@ -547,11 +547,11 @@ namespace Syntax is
         visit(if_branch: Statements.IF_BRANCH) is
         si        
 
-        pre(case_: Statements.CASE) -> bool is
+        pre(`case: Statements.CASE) -> bool is
             return false;
         si
 
-        visit(case_: Statements.CASE) is
+        visit(`case: Statements.CASE) is
         si
 
         pre(case_match: Statements.CASE_MATCH) -> bool is
@@ -561,32 +561,32 @@ namespace Syntax is
         visit(case_match: Statements.CASE_MATCH) is
         si
 
-        pre(try_: Statements.TRY) -> bool is
+        pre(`try: Statements.TRY) -> bool is
             return false;
         si
 
-        visit(try_: Statements.TRY) is
+        visit(`try: Statements.TRY) is
         si
 
-        pre(catch_: Statements.CATCH) -> bool is
+        pre(`catch: Statements.CATCH) -> bool is
             return false;
         si
 
-        visit(catch_: Statements.CATCH) is
+        visit(`catch: Statements.CATCH) is
         si
 
-        pre(do_: Statements.DO) -> bool is
+        pre(`do: Statements.DO) -> bool is
             return false;
         si
 
-        visit(do_: Statements.DO) is
+        visit(`do: Statements.DO) is
         si
 
-        pre(for_: Statements.FOR) -> bool is
+        pre(`for: Statements.FOR) -> bool is
             return false;
         si
 
-        visit(for_: Statements.FOR) is
+        visit(`for: Statements.FOR) is
         si
 
         pre(labelled: Statements.LABELLED) -> bool is
@@ -596,25 +596,25 @@ namespace Syntax is
         visit(labelled: Statements.LABELLED) is
         si
 
-        pre(break_: Statements.BREAK) -> bool is
+        pre(`break: Statements.BREAK) -> bool is
             return false;
         si
 
-        visit(break_: Statements.BREAK) is
+        visit(`break: Statements.BREAK) is
         si
 
-        pre(continue_: Statements.CONTINUE) -> bool is
+        pre(`continue: Statements.CONTINUE) -> bool is
             return false;
         si
 
-        visit(continue_: Statements.CONTINUE) is
+        visit(`continue: Statements.CONTINUE) is
         si
 
-        pre(pragma_: Statements.PRAGMA) -> bool is
+        pre(pragma: Statements.PRAGMA) -> bool is
             return false;
         si
 
-        visit(pragma_: Statements.PRAGMA) is            
+        visit(pragma: Statements.PRAGMA) is            
         si
 
         pre(expression: Bodies.EXPRESSION) -> bool is

--- a/src/syntax/trees/definitions/pragma.ghul
+++ b/src/syntax/trees/definitions/pragma.ghul
@@ -4,25 +4,25 @@ namespace Syntax.Trees.Definitions is
     class PRAGMA: Definition  is
         without_pragmas: Definition => definition.without_pragmas;
 
-        pragma_: Pragmas.PRAGMA;
+        pragma: Pragmas.PRAGMA;
         definition: Definition public;
         
         init(
             location: LOCATION,
-            pragma_: Pragmas.PRAGMA,
+            pragma: Pragmas.PRAGMA,
             definition: Definition
         ) is
             super.init(location);
 
-            self.pragma_ = pragma_;
+            self.pragma = pragma;
             self.definition = definition;
         si
 
-        is_name_equal_to(name: string) -> bool => pragma_? /\ pragma_.is_name_equal_to(name);
+        is_name_equal_to(name: string) -> bool => pragma? /\ pragma.is_name_equal_to(name);
 
         try_get_string_literal_at(index: int) -> string is
-            if pragma_? then
-                return pragma_.try_get_string_literal_at(index);
+            if pragma? then
+                return pragma.try_get_string_literal_at(index);
             fi
         si
 
@@ -32,8 +32,8 @@ namespace Syntax.Trees.Definitions is
 
         walk(visitor: Visitor) is
             if !visitor.pre(self) then
-                if pragma_? then
-                    pragma_.walk(visitor);
+                if pragma? then
+                    pragma.walk(visitor);
                 fi
                 
                 if definition? then

--- a/src/syntax/trees/definitions/use.ghul
+++ b/src/syntax/trees/definitions/use.ghul
@@ -4,13 +4,13 @@ namespace Syntax.Trees.Definitions is
 
     class USE: Definition  is
         name: Identifiers.Identifier;
-        use_: Identifiers.Identifier;
+        `use: Identifiers.Identifier;
         
-        init(location: LOCATION, name: Identifiers.Identifier, use_: Identifiers.Identifier) is
+        init(location: LOCATION, name: Identifiers.Identifier, `use: Identifiers.Identifier) is
             super.init(location);
 
             self.name = name;
-            self.use_ = use_;
+            self.`use = `use;
         si
 
         accept(visitor: Visitor) is
@@ -23,8 +23,8 @@ namespace Syntax.Trees.Definitions is
                     name.walk(visitor);
                 fi
 
-                if use_ then
-                    use_.walk(visitor);
+                if `use then
+                    `use.walk(visitor);
                 fi                                
             fi
             

--- a/src/syntax/trees/identifiers/identifier.ghul
+++ b/src/syntax/trees/identifiers/identifier.ghul
@@ -21,7 +21,7 @@ namespace Syntax.Trees.Identifiers is
 
             if name == null then
                 poison();
-                name = "__poisoned";
+                name = "$poisoned";
             fi
 
             self.name = name;

--- a/src/syntax/trees/statements/pragma.ghul
+++ b/src/syntax/trees/statements/pragma.ghul
@@ -3,17 +3,17 @@ namespace Syntax.Trees.Statements is
     use Source;
 
     class PRAGMA: Statement  is
-        pragma_: Pragmas.PRAGMA;
+        pragma: Pragmas.PRAGMA;
         statement: Statement public;
         
         init(
             location: LOCATION,
-            pragma_: Pragmas.PRAGMA,
+            pragma: Pragmas.PRAGMA,
             statement: Statement
         ) is
             super.init(location);
 
-            self.pragma_ = pragma_;
+            self.pragma = pragma;
             self.statement = statement;
         si
 
@@ -23,8 +23,8 @@ namespace Syntax.Trees.Statements is
 
         walk(visitor: Visitor) is
             if !visitor.pre(self) then
-                if pragma_? then
-                    pragma_.walk(visitor);
+                if pragma? then
+                    pragma.walk(visitor);
                 fi
                 
                 if statement? then

--- a/src/syntax/trees/statements/try.ghul
+++ b/src/syntax/trees/statements/try.ghul
@@ -5,19 +5,19 @@ namespace Syntax.Trees.Statements is
         expression: Expressions.Expression;
         body: LIST;
         catches: Collections.LIST[CATCH];
-        finally_: LIST;
+        `finally: LIST;
 
         init(
             location: LOCATION,
             body: LIST, catches: Collections.LIST[CATCH],
-            finally_: LIST
+            `finally: LIST
         )
         is
             super.init(location);
 
             self.body = body;
             self.catches = catches;
-            self.finally_ = finally_;
+            self.`finally = `finally;
         si
 
         accept(visitor: Visitor) is
@@ -32,8 +32,8 @@ namespace Syntax.Trees.Statements is
                     c.walk(visitor);
                 od
 
-                if finally_? then
-                    finally_.walk(visitor);
+                if `finally? then
+                    `finally.walk(visitor);
                 fi
             fi
             accept(visitor);


### PR DESCRIPTION
Technical:
- Use pipe operator `|` in place of `Pipe.from()`
- Use backtick prefix consistently to escape keywords instead of trailing underscore