### PR TITLE
Remove unnecessary anon function argument types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ test_types
 .nfs*
 *.vsix
 
-build.txt
+.build.rsp
 
 obj/
 bin/

--- a/src/driver/main.ghul
+++ b/src/driver/main.ghul
@@ -71,7 +71,7 @@ namespace Driver is
 
             let re = new Regex("(?<=\")[^\"]*(?=\")|[^\" ]+");
 
-            let arguments = re.matches(text) | .map(m: Match => m.value);
+            let arguments = re.matches(text) | .map(m => m.value);
 
             add_arguments(seen_files, result, arguments);
         si

--- a/src/ir/values/value.ghul
+++ b/src/ir/values/value.ghul
@@ -27,7 +27,7 @@ namespace IR.Values is
                 field.set_value(self, value);
             od
 
-            for property in self.get_type().get_properties() | .filter(p: System.Reflection.PropertyInfo => p.can_read /\ p.can_write) do
+            for property in self.get_type().get_properties() | .filter(p => p.can_read /\ p.can_write) do
                 let value = property.get_value(other);
                 property.set_value(self, value);
             od

--- a/src/semantic/dotnet/assembly_references.ghul
+++ b/src/semantic/dotnet/assembly_references.ghul
@@ -21,7 +21,7 @@ namespace Semantic.DotNet is
         si
 
         gen() is            
-            for reference in _references| .filter(reference: REFERENCED_ASSEMBLY => !_assemblies.blocked_assemblies.contains(reference.name)) do
+            for reference in _references| .filter(reference => !_assemblies.blocked_assemblies.contains(reference.name)) do
                 _boilerplate_generator.gen("assembly-reference", [reference.name, reference.version]);
             od
         si        

--- a/src/semantic/overload_resolver.ghul
+++ b/src/semantic/overload_resolver.ghul
@@ -82,9 +82,9 @@ namespace Semantic is
             fi
 
             // FIXME: this could just as well be applied to any parameters of generic type, not just anon functions
-            let needs_second_call = want_infer /\ arguments | .find(a: Type => a? /\ a.is_function_with_any_implicit_argument_types).has_value;
+            let needs_second_call = want_infer /\ arguments | .find(a => a? /\ a.is_function_with_any_implicit_argument_types).has_value;
 
-            @IF.debug() IO.Std.error.write_line("QQQQQQ: funcs to infer: " + arguments | .filter(a: Type => a? /\ a.is_function_with_any_implicit_argument_types));
+            @IF.debug() IO.Std.error.write_line("QQQQQQ: funcs to infer: " + arguments | .filter(a => a? /\ a.is_function_with_any_implicit_argument_types));
 
             let is_ambiguous = false;
 
@@ -169,7 +169,7 @@ namespace Semantic is
             if is_ambiguous then
                 let non_generic_matches = 
                     ambiguous_matches | 
-                        .filter(f: Symbols.Function => !f.is_generic);
+                        .filter(f => !f.is_generic);
 
                 if non_generic_matches | .count() == 1 then
                     result = non_generic_matches | .only();
@@ -213,7 +213,7 @@ namespace Semantic is
 
         get_sorted_function_list_as_string(functions: Collections.Iterable[Symbols.Function]) -> string static =>
             functions |
-                .map(f: Symbols.Function => f.to_string())
+                .map(f => f.to_string())
                 .sort()
                 .to_string();        
 

--- a/src/semantic/symbols/classy.ghul
+++ b/src/semantic/symbols/classy.ghul
@@ -715,7 +715,7 @@ namespace Semantic.Symbols is
             constructor.argument_names = new Collections.LIST[string]();
             constructor.arguments = new Collections.LIST[Type]();
 
-            for field in symbols | .filter(s: Symbol => s.is_variable).map(s: Symbol => cast Variable(s)) do
+            for field in symbols | .filter(s => s.is_variable).map(s => cast Variable(s)) do
                 constructor.argument_names.add(field.name);
                 constructor.arguments.add(field.type);
             od

--- a/src/semantic/symbols/closure.ghul
+++ b/src/semantic/symbols/closure.ghul
@@ -17,7 +17,7 @@ namespace Semantic.Symbols is
         is_delegate: bool;
         is_anon_func_or_delegate: bool => is_delegate \/ !frame?;
 
-        could_be_delegate: bool => is_self_captured /\ captures.count <= 1;
+        could_be_delegate: bool => is_self_captured /\ captures? /\ captures.count <= 1;
 
         frame: FRAME;
 

--- a/src/semantic/symbols/method_override_map.ghul
+++ b/src/semantic/symbols/method_override_map.ghul
@@ -18,7 +18,7 @@ namespace Semantic is
         name: string;
 
         methods: MAP[METHOD_OVERRIDE_CLASS,METHOD_OVERRIDE_SET];
-        symbols: Iterable[Symbol] => _symbols| .map(w: SYMBOL_WRAPPER => w.symbol);
+        symbols: Iterable[Symbol] => _symbols| .map(w => w.symbol);
 
         iterator: Iterator[METHOD_OVERRIDE_SET] => methods.values.iterator;
 

--- a/src/semantic/symbols/method_override_set.ghul
+++ b/src/semantic/symbols/method_override_set.ghul
@@ -19,7 +19,7 @@ namespace Semantic is
  
         iterable: Iterable[Function] => 
             _set |
-                .map(from: FUNCTION_WRAPPER => from.function);
+                .map(from => from.function);
 
         count: int => _set.count;
 
@@ -59,7 +59,7 @@ namespace Semantic is
  
         iterable: Iterable[Function] => 
             _set |
-                .map(from: FUNCTION_WRAPPER => from.function);
+                .map(from => from.function);
 
         count: int => _set.count;
 

--- a/src/semantic/symbols/symbol_inheritance_resolver.ghul
+++ b/src/semantic/symbols/symbol_inheritance_resolver.ghul
@@ -164,7 +164,7 @@ namespace Semantic is
 
                 all_symbols.add_range(         
                     overridees.iterable |
-                        .map((function: Function) -> Symbol => function)
+                        .map(function -> Symbol => function)
                 );
 
                 all_symbols.add_range(other_overridee_symbols);
@@ -212,7 +212,7 @@ namespace Semantic is
                             into.location, 
                             "cannot inherit multiple symbols with the same name: " + 
                                 overridees.iterable |
-                                    .map(f: Function => f.to_string())
+                                    .map(f => f.to_string())
                                     .sort()                                    
                         );
                     fi
@@ -245,14 +245,14 @@ namespace Semantic is
                     if seen_multiple_concrete then
                         let concretes = 
                             overridees.iterable |
-                                .filter(function: Function => function.is_instance);
+                                .filter(function => function.is_instance);
                         
                         logger
                             .error(
                                 into.location, 
                                 "inherits multiple concrete methods: " + 
                                     concretes
-                                        .map(f: Function => f.to_string())
+                                        .map(f => f.to_string())
                                         .sort()
                             );
 
@@ -273,13 +273,13 @@ namespace Semantic is
                     elif seen_multiple_abstract /\ !into.location.is_internal then
                         let abstracts =
                             overridees.iterable |
-                                .filter(function: Function => function.is_abstract);
+                                .filter(function => function.is_abstract);
 
                         logger.error(
                             into.location,
                             "cannot inherit multiple abstract methods: " + 
                                 abstracts |
-                                    .map(f: Function => f.to_string())
+                                    .map(f => f.to_string())
                                     .sort()
                         );
 
@@ -403,7 +403,7 @@ namespace Semantic is
                         into.location, 
                         "inherit multiple symbols with the same name " + 
                         overridee_symbols |
-                            .map(s: Symbol => s.to_string())
+                            .map(s => s.to_string())
                             .sort()
                     );
 
@@ -416,7 +416,7 @@ namespace Semantic is
                         into.location, 
                         "inherit multiple properties with the same name but different types " + 
                             overridee_symbols |
-                                .map(s: Symbol => s.to_string())
+                                .map(s => s.to_string())
                                 .sort()
                     );
 
@@ -430,7 +430,7 @@ namespace Semantic is
                             into.location, 
                             "did nothing with multiple parent symbols " + 
                                 overridee_symbols |
-                                    .map(s: Symbol => s.to_string())
+                                    .map(s => s.to_string())
                                     .sort()
                         );
                 fi

--- a/src/semantic/symbols/tuple.ghul
+++ b/src/semantic/symbols/tuple.ghul
@@ -2,8 +2,6 @@ namespace Semantic.Symbols is
     use Collections.List;
 
     use IO.Std;
-
-    use IV = Pipes.IndexedValue`1;
     
     use IoC;
     use Logging;
@@ -30,7 +28,7 @@ namespace Semantic.Symbols is
                 return null;
             fi
 
-            let m = names | .index() .find(iv: IV[string] => iv.value =~ name);
+            let m = names | .index() .find(iv => iv.value =~ name);
 
             if !m.has_value then
                 return null;

--- a/src/semantic/types/action.ghul
+++ b/src/semantic/types/action.ghul
@@ -19,7 +19,7 @@ namespace Semantic.Types is
             else
                 result.append('(');
 
-                (0..args.count) | .map(i: int => args[i]).append_to(result);
+                (0..args.count) | .map(i => args[i]).append_to(result);
 
                 result.append(") -> void");
             fi

--- a/src/semantic/types/function.ghul
+++ b/src/semantic/types/function.ghul
@@ -24,7 +24,7 @@ namespace Semantic.Types is
             else
                 result.append('(');
 
-                (0..args.count-1) | .map(i: int => args[i]).append_to(result);
+                (0..args.count-1) | .map(i => args[i]).append_to(result);
 
                 result
                     .append(") -> ")

--- a/src/semantic/types/tuple.ghul
+++ b/src/semantic/types/tuple.ghul
@@ -11,11 +11,11 @@ namespace Semantic.Types is
 
             if names? then
                 return
-                    "(" + (0..args.count) | .map(i: int => names[i] + ": " + args[i].short_description) + ")";
+                    "(" + (0..args.count) | .map(i => names[i] + ": " + args[i].short_description) + ")";
 
             else
                 return
-                    "(" + (0..args.count) | .map(i: int => args[i].short_description) + ")";
+                    "(" + (0..args.count) | .map(i => args[i].short_description) + ")";
             fi
         si
 

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -1486,7 +1486,6 @@ namespace Syntax.Process is
                 _visit(call);
             catch e: Exception
                 call.value = null;
-
                 _logger.exception(call.location, e, "exception compiling call");
             finally
                 _logger.commit();
@@ -1540,7 +1539,6 @@ namespace Syntax.Process is
 
                     if overload_result.score == Semantic.Types.MATCH.PARTIAL then
                         _logger.roll_back();
-                        
                         _logger.speculate();
 
                         is_partial = true;
@@ -1666,14 +1664,7 @@ namespace Syntax.Process is
             if symbol? then
                 _symbol_use_locations.add_symbol_use(identifier.location, symbol);
 
-                // _symbol_loader.find_symbol = (name: string) -> Semantic.Symbols.Symbol => find(name);
-
-                _symbol_loader.find_symbol = 
-                    (name: string) -> Semantic.Symbols.Symbol is
-                        let result = find(name);
-
-                        return result;
-                    si;
+                _symbol_loader.find_symbol = (name: string) => find(name);
 
                 if need_store then
                     let store_value = cast Need.STORE(identifier.value).value;

--- a/src/syntax/process/generate_il.ghul
+++ b/src/syntax/process/generate_il.ghul
@@ -225,7 +225,7 @@ namespace Syntax.Process is
 
         gen_anon_functions(symbol: Semantic.Symbols.Classy) is
             if symbol.closures? then
-                for anon_function in symbol.closures | .filter(c: Semantic.Symbols.Closure => c.is_anon_func_or_delegate) do
+                for anon_function in symbol.closures | .filter(c => c.is_anon_func_or_delegate) do
                     let buffer = new StringBuilder();
                     anon_function.gen_definition_header(buffer);
                     _context.write_line(buffer);
@@ -243,7 +243,7 @@ namespace Syntax.Process is
 
         gen_closures(symbol: Semantic.Symbols.Classy) is
             if symbol.closures? then
-                for closure in symbol.closures | .filter(c: Semantic.Symbols.Closure => !c.is_anon_func_or_delegate) do                   
+                for closure in symbol.closures | .filter(c => !c.is_anon_func_or_delegate) do                   
                     closure.gen_frame(_context, _symbol_loader);
                 od
             fi


### PR DESCRIPTION
Technical:
- Remove explicit types from anonymous function arguments throughout the compiler source, in cases where they can now be inferred