### PR TITLE
Migrate to .NET 6 (part 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       run: echo "${HOME}/.dotnet/tools" >> $GITHUB_PATH
 
     - name: Install stable compiler
-      run: dotnet tool install --global ghul.compiler --version 0.2.135-alpha.1
+      run: dotnet tool install --global ghul.compiler
 
     - name: Bootstrap compiler
       run: ./build/bootstrap.sh

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,5 @@
         "**/*.bc": true,
         "**/*.lh": true
     },
-    "version": "0.2.135-alpha.1"
+    "version": "0.2.136-alpha.1"
 }

--- a/ghul.ghulproj
+++ b/ghul.ghulproj
@@ -8,7 +8,7 @@
     <PackageId>ghul.compiler</PackageId>
     <Authors>degory</Authors>
     <Company>ghul.io</Company>
-    <Version>0.2.135-alpha.1</Version>
+    <Version>0.2.136-alpha.1</Version>
 
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <RepositoryUrl>https://github.com/degory/ghul</RepositoryUrl>


### PR DESCRIPTION
Technical:
- Switch CI pipeline back to using the stable version of the compiler tool to build