### PR TITLE
Simplify versions generated for Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Create version number
       id: create_version_number
       uses: anothrNick/github-tag-action@1.33.0
-      if: ${{ github.actor != 'dependabot[bot]' }}      
+      if: ${{ github.actor != 'dependabot[bot]' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true


### PR DESCRIPTION
Technical:
- Use a fixed prefix for version numbers generated for Dependabot PRs, rather than trying to derive from Git tags