### PR TITLE
Simplify versions generated for Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         VALID_VERSION_REGEX="^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+\.[0-9]+)?$"
 
         if [ "${{ github.actor }}" == "dependabot[bot]" ] ; then
-          VERSION=$(git describe --tags --abbrev=0)+dependabot.$(date '+%Y%m%d%H%M%S')
+          VERSION=v0.0.1+dependabot.$(date '+%Y%m%d%H%M%S')
         elif [ ! -z "${MANUAL_VERSION}" ] ; then
           echo "User supplied version: ${MANUAL_VERSION}"
 


### PR DESCRIPTION
Technical:
- Use a fixed prefix for version numbers generated for Dependabot PRs, rather than trying to derive from Git tags