### PR TITLE
Separate README.md for NuGet.org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         VALID_VERSION_REGEX="^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+\.[0-9]+)?$"
 
         if [ "${{ github.actor }}" == "dependabot[bot]" ] ; then
-          VERSION=v0.0.1+dependabot.$(date '+%Y%m%d%H%M%S')
+          VERSION=v0.0.1-dependabot.$(date '+%Y%m%d%H%M%S')
         elif [ ! -z "${MANUAL_VERSION}" ] ; then
           echo "User supplied version: ${MANUAL_VERSION}"
 

--- a/ghul.ghulproj
+++ b/ghul.ghulproj
@@ -40,7 +40,7 @@
     <PackageReference Include="runtime.win-x64.Microsoft.NETCore.ILAsm" Version="6.0.0" />
 
     <!-- Build outputs -->
-    <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="nuget-readme/README.md" Pack="true" PackagePath="\"/>
 
     <Content Include="lib/**/*.*">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/nuget-readme/README.md
+++ b/nuget-readme/README.md
@@ -1,0 +1,33 @@
+# ghūl compiler
+
+## Compiler for the [ghūl programming language](https://ghul.io)
+
+### Host and target
+
+The compiler is hosted on .NET 6.0 and targets .NET 6.0
+
+### Latest release
+
+[Release](https://github.com/degory/ghul/releases/latest)
+
+### Continuous delivery status
+
+[![workflow](https://github.com/degory/ghul/workflows/CI/badge.svg?branch=master)](https://github.com/degory/ghul/actions?query=workflow%3ACI)
+
+
+## Getting started
+
+### Template ghūl application project
+
+To get started creating a ghūl console application, take a look at the [ghūl console template](https://github.com/degory/ghul-console-template) repository
+
+### Development environment
+
+- [Visual Studio Code](https://code.visualstudio.com) will give you rich language support via the [ghūl VSCode language extension](https://marketplace.visualstudio.com/items?itemName=degory.ghul).
+
+### Runtime dependencies for ghūl applications
+- Applications written in ghūl will run on [.NET 6.0](https://dotnet.microsoft.com/download/dotnet/6.0) without any special dependencies
+
+## Gotchas
+
+This is an incomplete compiler for an experimental programming language. The ghūl language is sufficiently expressive and the compiler stable enough for the [compiler itself to be writen in ghūl](https://github.com/degory/ghul). However, there will be [compiler bugs](https://github.com/degory/ghul/issues?q=is%3Aissue+is%3Aopen+label%3Abug) 


### PR DESCRIPTION
Technical:
- Pack a different README.md in the NuGet package for display on nuget.org
- Yet another Dependabot CI workflow version number fix