### PR TITLE
Only run CI on pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
   pull_request:
   push:
-    branches: [master, main]
+    branches: [main]
 
 env:
   CI: true


### PR DESCRIPTION
Technical:
- Remove reference to master branch from CI workflow after move to main