### PR TITLE
Visual Studio Code extension improvements

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.3.3",
+      "version": "0.3.4",
       "commands": [
         "ghul-compiler"
       ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -43,7 +43,7 @@
             "command": "dotnet",
             "args": [
                 "pack",
-                // "/property:GhulOptions=\"--define release\"",
+                "/property:GhulOptions=\"--define release\"",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.3.4-alpha.7</Version>
+    <Version>0.3.5-alpha.107</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/driver/analyser.ghul
+++ b/src/driver/analyser.ghul
@@ -42,7 +42,6 @@ namespace Driver is
             build_flags: BUILD_FLAGS
         ) is
             _log = Std.error;
-            _compiler = compiler;
             _timers = timers;
             _symbol_table = symbol_table;
 
@@ -56,11 +55,14 @@ namespace Driver is
 
             let file_edited_handler = new FILE_EDITED_HANDLER(watchdog, compiler, build_flags, library_files, symbol_table);
             let hover_handler = new HOVER_HANDLER(watchdog, symbol_use_locations);
-            let find_definition_handler = new FIND_DEFINITION_HANDLER(watchdog, symbol_use_locations);
+            let definition_handler = new DEFINITION_HANDLER(watchdog, symbol_use_locations);
+            let declaration_handler = new DECLARATION_HANDLER(watchdog, symbol_use_locations);
             let completion_handler = new COMPLETION_HANDLER(watchdog, completer, file_edited_handler);
             let signature_handler = new SIGNATURE_HANDLER(watchdog, signature_help, file_edited_handler);
             let symbols_handler = new SYMBOLS_HANDLER(watchdog, symbol_definition_locations, file_edited_handler);
             let references_handler = new REFERENCES_HANDLER(watchdog, symbol_use_locations);
+            let implementation_handler = new IMPLEMENTATION_HANDLER(watchdog, symbol_use_locations);
+            let rename_request_handler = new RENAME_REQUEST_HANDLER(watchdog, symbol_use_locations);
             let restart_handler = new RESTART_HANDLER();
 
             _despatcher.add_handler(
@@ -72,7 +74,11 @@ namespace Driver is
             );
 
             _despatcher.add_handler(
-                "DEFINITION", find_definition_handler
+                "DEFINITION", definition_handler
+            );
+
+            _despatcher.add_handler(
+                "DECLARATION", declaration_handler
             );
 
             _despatcher.add_handler(
@@ -89,6 +95,14 @@ namespace Driver is
 
             _despatcher.add_handler(
                 "REFERENCES", references_handler
+            );
+
+            _despatcher.add_handler(
+                "IMPLEMENTATION", implementation_handler
+            );
+
+            _despatcher.add_handler(
+                "RENAMEREQUEST", rename_request_handler
             );
 
             _despatcher.add_handler(
@@ -124,7 +138,7 @@ namespace Driver is
                 want_restart = true;
             fi
         si
-
+        
         enable() is
             _is_enabled = true;
         si
@@ -336,7 +350,7 @@ namespace Driver is
         si
     si
 
-    class FIND_DEFINITION_HANDLER: CommandHandler is
+    class DEFINITION_HANDLER: CommandHandler is
         _watchdog: WATCHDOG;
         _symbol_use_locations: Semantic.SYMBOL_USE_LOCATIONS;
 
@@ -380,6 +394,53 @@ namespace Driver is
                 if !written_header then
                     writer.write_line("DEFINITION");                    
                 fi                
+            yrt
+
+            Std.error.flush();
+
+            writer.write("" + cast char(12));
+            writer.flush();
+        si
+    si
+
+    class DECLARATION_HANDLER: SymbolLocationHandler is
+        init(
+            watchdog: WATCHDOG,
+            symbol_use_locations: Semantic.SYMBOL_USE_LOCATIONS
+        )
+        is
+            super.init(watchdog, symbol_use_locations);
+        si
+
+        handle(reader: IO.TextReader, writer: IO.TextWriter) is
+            IoC.CONTAINER.instance.want_tab_delimited_logger(writer);
+
+            let written_header = false;
+
+            try
+                let path = reader.read_line();
+                let line = System.Convert.to_int32(reader.read_line());
+                let column = System.Convert.to_int32(reader.read_line());
+
+                writer.write_line("DECLARATION");
+                written_header = true;
+
+                if !_watchdog.want_restart then
+                    let symbol = _symbol_use_locations.find_definition_from_use(path, line, column);
+
+                    if symbol? then
+                        let locations = _symbol_use_locations.find_declarations_of_symbol(symbol);
+
+                        write_location_list(writer, locations);
+                    fi
+                fi
+
+            catch e: Exception
+                Std.error.write_line("DECLARATION: " + e.get_type() + ": " + e.message);
+
+                if !written_header then
+                    writer.write_line("DECLARATION");
+                fi
             yrt
 
             Std.error.flush();
@@ -690,7 +751,7 @@ namespace Driver is
         si
 
         write_symbol_list_for_file(writer: IO.TextWriter, path: string, symbols: Iterable[Semantic.Symbols.Symbol]) is
-            writer.write_line(path);
+            writer.write_line(path);            
 
             if symbols? then
                 for symbol in symbols | .filter(s => s? /\ !s.is_internal) do
@@ -731,7 +792,7 @@ namespace Driver is
         si
     si
 
-    class REFERENCES_HANDLER: CommandHandler is
+    class SymbolLocationHandler: CommandHandler is
         _watchdog: WATCHDOG;
         _symbol_use_locations: Semantic.SYMBOL_USE_LOCATIONS;
 
@@ -742,6 +803,44 @@ namespace Driver is
         is
             _watchdog = watchdog;
             _symbol_use_locations = symbol_use_locations;
+        si
+
+        handle(reader: IO.TextReader, writer: IO.TextWriter);
+
+        write_location_list(writer: IO.TextWriter, locations: Iterable[LOCATION]) is
+            for location in locations do
+                Std.error.write_line(location);
+                writer.write_line(
+                    format_location(location)
+                );
+            od
+        si
+
+        format_location(location: LOCATION) -> string is
+            let result = new System.Text.StringBuilder();
+
+            result
+                .append(location.file_name)
+                .append('\t')
+                .append(location.start_line)
+                .append('\t')
+                .append(location.start_column)
+                .append('\t')
+                .append(location.end_line)
+                .append('\t')
+                .append(location.end_column);
+
+            return result.to_string();
+        si        
+    si
+
+    class REFERENCES_HANDLER: SymbolLocationHandler is
+        init(
+            watchdog: WATCHDOG,
+            symbol_use_locations: Semantic.SYMBOL_USE_LOCATIONS
+        )
+        is
+            super.init(watchdog, symbol_use_locations);
         si
 
         handle(reader: IO.TextReader, writer: IO.TextWriter) is
@@ -780,16 +879,121 @@ namespace Driver is
             writer.write("" + cast char(12));
             writer.flush();
         si
+    si
 
-        write_location_list(writer: IO.TextWriter, locations: Iterable[LOCATION]) is
+    class IMPLEMENTATION_HANDLER: SymbolLocationHandler is
+        init(
+            watchdog: WATCHDOG,
+            symbol_use_locations: Semantic.SYMBOL_USE_LOCATIONS
+        )
+        is
+            super.init(watchdog, symbol_use_locations);
+        si
+
+        handle(reader: IO.TextReader, writer: IO.TextWriter) is
+            IoC.CONTAINER.instance.want_tab_delimited_logger(writer);
+
+            let written_header = false;
+
+            try
+                let path = reader.read_line();
+                let line = System.Convert.to_int32(reader.read_line());
+                let column = System.Convert.to_int32(reader.read_line());
+
+                writer.write_line("IMPLEMENTATION");
+                written_header = true;
+
+                if !_watchdog.want_restart then
+                    let symbol = _symbol_use_locations.find_definition_from_use(path, line, column);
+
+                    if symbol? then
+                        let locations = _symbol_use_locations.find_implementations_of_symbol(symbol);
+
+                        write_location_list(writer, locations);
+                    fi
+                fi
+
+            catch e: Exception
+                Std.error.write_line("IMPLEMENTATION: " + e.get_type() + ": " + e.message);
+
+                if !written_header then
+                    writer.write_line("IMPLEMENTATION");
+                fi
+            yrt
+
+            Std.error.flush();
+
+            writer.write("" + cast char(12));
+            writer.flush();
+        si
+    si
+
+    class RENAME_REQUEST_HANDLER: CommandHandler is
+        _watchdog: WATCHDOG;
+        _symbol_use_locations: Semantic.SYMBOL_USE_LOCATIONS;
+
+        init(
+            watchdog: WATCHDOG,
+            symbol_use_locations: Semantic.SYMBOL_USE_LOCATIONS
+        )
+        is
+            _watchdog = watchdog;
+            _symbol_use_locations = symbol_use_locations;
+        si
+
+        handle(reader: IO.TextReader, writer: IO.TextWriter) is
+            IoC.CONTAINER.instance.want_tab_delimited_logger(writer);
+
+            let written_header = false;
+
+            try
+                let path = reader.read_line();
+                let line = System.Convert.to_int32(reader.read_line());
+                let column = System.Convert.to_int32(reader.read_line());
+                let new_name = reader.read_line();
+
+                writer.write_line("RENAMEREQUEST");
+                written_header = true;
+
+                if !_watchdog.want_restart then
+                    let symbol = _symbol_use_locations.find_definition_from_use(path, line, column);
+
+                    if symbol? then
+                        let locations = _symbol_use_locations.find_references_to_symbol_for_rename(symbol);
+
+                        write_edit_list(writer, locations, new_name);
+                    fi
+                fi
+
+            catch e: Exception
+                Std.error.write_line("RENAMEREQUEST: " + e.get_type() + ": " + e.message);
+
+                if !written_header then
+                    writer.write_line("RENAMEREQUEST");
+                fi
+            yrt
+
+            Std.error.flush();
+
+            writer.write("" + cast char(12));
+            writer.flush();
+        si
+
+        write_edit_list(writer: IO.TextWriter, locations: Iterable[LOCATION], new_name: string) is
+            let lines = new Collections.LIST[string]();
+
+            let files = new Collections.SET[string]();
+
             for location in locations do
                 writer.write_line(
-                    format_location(location)
+                    format_edit(location, new_name)
                 );
+
+                files.add(location.file_name);
             od
         si
 
-        format_location(location: LOCATION) -> string is
+        format_edit(location: LOCATION, new_name: string) -> string is
             let result = new System.Text.StringBuilder();
 
             result
@@ -801,11 +1005,13 @@ namespace Driver is
                 .append('\t')
                 .append(location.end_line)
                 .append('\t')
-                .append(location.end_column);
+                .append(location.end_column)
+                .append('\t')
+                .append(new_name);
 
             return result.to_string();
-        si
-    si
+        si        
+    si    
 
     class RESTART_HANDLER: CommandHandler is
         init() is si

--- a/src/semantic/dotnet/symbol_factory.ghul
+++ b/src/semantic/dotnet/symbol_factory.ghul
@@ -32,8 +32,9 @@ namespace Semantic.DotNet is
 
         _non_generic_get_enumerator: MethodInfo;
 
-        _tuple_types: List[TYPE];
+        _void_type: TYPE;
         _object_type: TYPE;
+        _tuple_types: List[TYPE];
 
         _type_source: TypeSource;
 
@@ -59,6 +60,7 @@ namespace Semantic.DotNet is
             let mnt = _type_source.get_type("System.Collections.IEnumerator");
             _non_generic_get_enumerator = mnt.get_method("GetEnumerator");
 
+            _void_type = _type_source.get_type("System.Void");
             _object_type = _type_source.get_type("System.Object");
 
             _tuple_types = _type_source.get_types([
@@ -126,7 +128,7 @@ namespace Semantic.DotNet is
                 result.mark_overrides_resolved();
             elif dotnet_type.is_value_type then
                 result = new Symbols.STRUCT(Source.LOCATION.reflected, Source.LOCATION.reflected, owner, ghul_type_name, arguments, true, owner);
-                result.il_is_primitive_type = dotnet_type.is_primitive \/ dotnet_type == _type_source.get_type("System.Void");
+                result.il_is_primitive_type = dotnet_type.is_primitive \/ dotnet_type == _void_type;
                 
                 result.mark_overrides_resolved();
             elif dotnet_type.is_interface then
@@ -246,7 +248,7 @@ namespace Semantic.DotNet is
             result.argument_names = argument_names;
             result.arguments = argument_types;
 
-            result.return_type = _type_mapper.get_type(_type_source.get_type("System.Void"));
+            result.return_type = _type_mapper.get_type(_void_type);
             
             owner.add_member(result);
         si

--- a/src/semantic/symbol_use_locations.ghul
+++ b/src/semantic/symbol_use_locations.ghul
@@ -32,26 +32,13 @@ namespace Semantic is
         add_symbol_use(location: LOCATION, symbol: Symbols.Symbol) is
             if 
                 symbol? /\ 
-                !symbol.is_internal
+                !symbol.is_internal /\
+                !location.is_internal /\
+                !location.is_reflected
             then
                 _symbol_use_map.put(location, symbol);
 
-                add_symbol_reference(location, symbol);
-            fi
-        si
-
-        add_symbol_reference(location: LOCATION, symbol: Symbols.Symbol) is
-            if symbol.overridees? then
-                for o in symbol.overridees do
-                    add_symbol_reference(location, o);
-                od  
-            fi
-
-            let refs = get_references_set(symbol);
-                
-            if !refs.contains(location) then
-                // FIXME: why is this getting called multiple times for the same symbol and location?
-                refs.add(location);
+                _add_symbol_reference(location, symbol);
             fi
         si
 
@@ -83,24 +70,262 @@ namespace Semantic is
             fi
         si
 
-        find_references_to_symbol(symbol: Symbols.Symbol) -> Collections.Iterable[LOCATION] is
-            return get_references_set(symbol);    
-        si
+        // - include definitions only
+        // - don't include the definition location of the seached symbol itself unless no other matches found
+        // - for methods and properties, include all definitions that override the searched symbol
+        // - for classes and traits, include all definitions that inherit from the searched symbol
+        // - for other symbols, return only the searched symbol
+        find_declarations_of_symbol(symbol: Symbols.Symbol) -> Collections.Iterable[LOCATION] is
+            symbol = symbol.root_specialized_from;
 
-        get_references_set(symbol: Symbols.Symbol) -> Collections.SET[LOCATION] is
-            let result: Collections.SET[LOCATION];
+            let results = new Collections.SET[Symbols.Symbol]();
 
-            let unspecialized_symbol = symbol.root_specialized_from;
-
-            if _symbol_reference_map.try_get_value(unspecialized_symbol, result ref) then
-                return result;                
+            if symbol.is_classy then
+                _get_super_class(symbol, results);                
+            else
+                _get_overridees(symbol, results);
             fi
 
-            result = new Collections.SET[LOCATION]();
+            if results.count == 0 then
+                results.add(symbol);
+            fi
+            
+            return results | .map(s => s.location);            
+        si
 
-            _symbol_reference_map[unspecialized_symbol] = result;
+        // - include definitions only
+        // - include the definition location of the seached symbol itself
+        // - for methods and properties, include all definitions that override the searched symbol
+        // - for classes and traits, include all definitions that inherit from the searched symbol
+        // - for other symbols, return only the searched symbol
+        find_implementations_of_symbol(symbol: Symbols.Symbol) -> Collections.Iterable[LOCATION] is
+            symbol = symbol.root_specialized_from;
 
-            return result;            
+            let results = new Collections.SET[Symbols.Symbol]();
+
+            if symbol.is_classy then
+                _get_all_implementing_symbols(symbol, results);                
+            else
+                _get_all_overriding_symbols(symbol, results);
+            fi
+
+            return results | .filter(s => s != symbol) .map(s => s.location);
+        si
+
+        // - include uses but not definitions
+        // - for methods and properties, include references to all symbols that override the searched symbol
+        // - for classes, traits and other symbols, include only references to the searched symbol
+        find_references_to_symbol(symbol: Symbols.Symbol) -> Collections.Iterable[LOCATION] is
+            symbol = symbol.root_specialized_from;
+
+            let definitions = new Collections.SET[Symbols.Symbol]();
+
+            if symbol.is_classy then
+                definitions.add(symbol);
+            else
+                _get_all_overriding_symbols(symbol, definitions);                
+            fi
+            
+            let results = new Collections.SET[LOCATION]();
+
+            _get_use_locations_for_symbols(definitions, results, false);
+
+            return results;
+        si
+
+        // - include definitions and references
+        // - include references to the seached symbol itself
+        // - for methods and properties, search up the inheritance tree to find the root symbols that are overridden
+        // - include references to all symbols that override the root overridee symbols
+        // - for classes, traits and other symbols, include only references to the searched symbol
+        find_references_to_symbol_for_rename(symbol: Symbols.Symbol) -> Collections.Iterable[LOCATION] is
+            let definitions = new Collections.SET[Symbols.Symbol]();
+
+            if symbol.is_classy then
+                definitions.add(symbol);
+            else
+                let root_overridees = new Collections.SET[Symbols.Symbol]();
+         
+                _get_root_overridees(symbol, root_overridees);
+    
+                for overridee in root_overridees do
+                    _get_all_overriding_symbols(overridee, definitions);
+                od
+            fi
+
+            let results = new Collections.SET[LOCATION]();
+            
+            _get_use_locations_for_symbols(definitions, results, true);
+
+            results.add(symbol.location);
+
+            return results;
+        si
+
+        _add_symbol_reference(location: LOCATION, symbol: Symbols.Symbol) is
+            let refs = _get_references_set(symbol);
+                
+            if !refs.contains(location) then
+                // FIXME: why is this getting called multiple times for the same symbol and location?
+                refs.add(location);
+            fi
+        si
+
+        _get_use_locations_for_symbols(
+            symbols: Collections.Iterable[Symbols.Symbol],
+            into: Collections.SET[LOCATION],
+            include_definitions: bool
+        ) is
+            for d in symbols do
+                let references = _try_get_references_set(d);
+    
+                if !references? then
+                    continue;
+                fi
+
+                for reference in references | .filter(r => r !~ d.location) do
+                    into.add(reference);
+                od
+            od                
+        si
+
+        _get_root_overridees(symbol: Symbols.Symbol, results: Collections.SET[Symbols.Symbol]) is
+            assert symbol?;
+            assert results?;
+
+            if results.contains(symbol) then
+                return;
+            fi
+
+            let overridees = symbol.overridees;
+
+            if !overridees? \/ overridees | .count() == 0 \/ overridees | .find(o => o.is_reflected).has_value then
+                results.add(symbol);
+                return;
+            fi
+
+            for overridee in overridees do
+                _get_root_overridees(overridee, results);
+            od
+        si
+
+        _get_overridees(symbol: Symbols.Symbol, results: Collections.SET[Symbols.Symbol]) is
+            assert symbol?;
+            assert results?;
+
+            let overridees = symbol.overridees;
+
+            if !overridees? then
+                return;
+            fi
+
+            for overridee in overridees | .filter(overridee => !overridee.is_internal /\ !overridee.is_reflected) do
+                results.add(overridee);
+            od
+        si
+
+        _get_super_class(symbol: Symbols.Symbol, results: Collections.SET[Symbols.Symbol]) is
+            assert symbol?;
+            assert results?;
+
+            let ancestors = symbol.ancestors;
+
+            if !ancestors? \/ ancestors.count == 0 then
+                return;
+            fi
+
+            let result = ancestors[0].symbol;
+
+            if result? /\ !result.is_internal /\ !result.is_reflected then
+                results.add(result);
+            fi            
+        si
+
+        // walk down the tree adding overriding methods
+        _get_all_overriding_symbols(symbol: Symbols.Symbol, results: Collections.SET[Symbols.Symbol]) is
+            if results.contains(symbol) then
+                return;
+            fi
+
+            results.add(symbol);
+ 
+            let overriders = symbol.overriders;
+
+            if !overriders? \/ overriders | .count() == 0 then
+                return;
+            fi
+
+            for overrider in overriders do
+                _get_all_overriding_symbols(overrider, results);
+            od
+        si
+
+        // walk down the tree adding implementing classes
+        _get_all_implementing_symbols(symbol: Symbols.Symbol, results: Collections.SET[Symbols.Symbol]) is
+            if results.contains(symbol) then
+                return;
+            fi
+
+            results.add(symbol);
+
+            let implementors = symbol.implementors;
+
+            if !implementors? \/ implementors | .count() == 0 then
+                return;
+            fi
+ 
+            for implementor in implementors do
+                _get_all_implementing_symbols(implementor, results);
+            od
+        si
+
+        _get_symbol_references_for_rename(symbol: Symbols.Symbol) -> Collections.SET[LOCATION] is
+            let all_definitions = new Collections.SET[Symbols.Symbol]();
+
+            let root_overridees = new Collections.SET[Symbols.Symbol]();
+
+            _get_root_overridees(symbol, root_overridees);
+
+            for root_overridee in root_overridees do
+                _get_all_overriding_symbols(root_overridee, all_definitions);
+            od
+            
+            let results = new Collections.SET[LOCATION]();
+
+            for d in all_definitions do
+                let references = _try_get_references_set(d);
+
+                if !references? then
+                    continue;
+                fi
+
+                for reference in references do
+                    results.add(reference);
+                od
+            od
+
+            return results;
+        si        
+
+        _try_get_references_set(symbol: Symbols.Symbol) -> Collections.SET[LOCATION] is
+            let results: Collections.SET[LOCATION];                
+
+            _symbol_reference_map.try_get_value(symbol, results ref);
+
+            return results;
+        si
+
+        _get_references_set(symbol: Symbols.Symbol) -> Collections.SET[LOCATION] is
+            // FIXME: is this correct in all cases?
+            symbol = symbol.root_specialized_from;
+            let results: Collections.SET[LOCATION];                
+
+            if !_symbol_reference_map.try_get_value(symbol, results ref) then
+                results = new Collections.SET[LOCATION]();
+                _symbol_reference_map[symbol] = results;
+            fi
+
+            return results;
         si
     si
 

--- a/src/semantic/symbols/classy.ghul
+++ b/src/semantic/symbols/classy.ghul
@@ -15,6 +15,7 @@ namespace Semantic.Symbols is
 
     class Classy: ScopedWithEnclosingScope, ClosureContext is
         _ancestors: Collections.LIST[Type];
+        _implementors: Collections.LIST[Symbol];
         _enclosing_symbols: Collections.MAP[string,Symbol];
         _closures: Collections.SET[Closure];
 
@@ -30,6 +31,8 @@ namespace Semantic.Symbols is
 
         // FIXME: not safe to expose unspecialized ancestors
         ancestors: Collections.List[Type] => _ancestors;
+
+        implementors: Collections.Iterable[Symbol] => _implementors;
 
         il_assembly_name: string public;
 
@@ -66,6 +69,14 @@ namespace Semantic.Symbols is
             _ancestors.add(ancestor);
         si
 
+        add_implementor(symbol: Symbol) is
+            if !_implementors? then
+                _implementors = new Collections.LIST[Symbol]();
+            fi
+            
+            _implementors.add(symbol);
+        si
+        
         push_ancestor(ancestor: Type) is
             let na = new Collections.LIST[Type]();
 
@@ -179,6 +190,7 @@ namespace Semantic.Symbols is
 
                 if symbol? then
                     symbol.pull_down_super_symbols();
+                    symbol.add_implementor(self);
                 fi
             od
 

--- a/src/semantic/symbols/function.ghul
+++ b/src/semantic/symbols/function.ghul
@@ -29,6 +29,7 @@ namespace Semantic.Symbols is
             return _override_class;
         si
 
+        _overriders: Collections.MutableList[Symbol];
         _overridees: Collections.MutableList[Symbol];
 
         span: LOCATION;
@@ -46,6 +47,7 @@ namespace Semantic.Symbols is
         symbol_kind: SYMBOL_KIND => SYMBOL_KIND.FUNCTION;
         completion_kind: COMPLETION_KIND => COMPLETION_KIND.FUNCTION;
 
+        is_function: bool => true;
         is_generic: bool public;
         is_abstract: bool => false;
         is_capture_context: bool => true;
@@ -76,6 +78,7 @@ namespace Semantic.Symbols is
             return result.to_string();
         si
         
+        overriders: Collections.Iterable[Symbol] => _overriders;
         overridees: Collections.Iterable[Symbol] => _overridees;
 
         =~(other: Function) -> bool => self == other;
@@ -97,7 +100,15 @@ namespace Semantic.Symbols is
             self.argument_names = argument_names;
         si
 
-        add_overridee(overridee: Function) is
+        add_overrider(overrider: Symbol) is
+            if !_overriders? then
+                _overriders = new Collections.LIST[Symbol]();
+            fi 
+
+            _overriders.add(overrider);
+        si
+
+        add_overridee(overridee: Symbol) is
             if !_overridees? then
                 _overridees = new Collections.LIST[Symbol]();
             fi 

--- a/src/semantic/symbols/generic.ghul
+++ b/src/semantic/symbols/generic.ghul
@@ -24,6 +24,8 @@ namespace Semantic.Symbols is
         arguments: Collections.List[Type];
         ancestors: Collections.List[Type] => symbol.ancestors;
 
+        implementors: Collections.Iterable[Symbol] => symbol.implementors;
+
         symbol: Classy => _symbol;
 
         symbols: Collections.Iterable[Symbol] is
@@ -143,6 +145,10 @@ namespace Semantic.Symbols is
         add_member(symbol: Symbol) -> bool is            
             IoC.CONTAINER.instance.logger.warn(location, "cannot inherit " + symbol + " into to specialized generic " + self);
             return true;
+        si
+
+        add_implementor(implementor: Symbol) is
+            symbol.add_implementor(implementor);
         si
 
         assert_symbols_pulled_down() is

--- a/src/semantic/symbols/method.ghul
+++ b/src/semantic/symbols/method.ghul
@@ -63,6 +63,7 @@ namespace Semantic.Symbols is
             let il_name_matches = overrider.ensure_il_name_matches(into, self, "override", logger);
 
             overrider.add_overridee(self);
+            self.add_overrider(overrider);
         si
 
         try_struct_override_me(into: Classy, overrider: Function, logger: Logger) is
@@ -71,6 +72,7 @@ namespace Semantic.Symbols is
             let il_name_matches = overrider.ensure_il_name_matches(into, self, "override", logger);
 
             overrider.add_overridee(self);
+            self.add_overrider(overrider);
         si
 
         try_abstract_override_me(into: Classy, overrider: Function, logger: Logger) is
@@ -193,6 +195,7 @@ namespace Semantic.Symbols is
             let il_name_matches = overrider.ensure_il_name_matches(into, self, "implement", logger);
 
             overrider.add_overridee(self);
+            self.add_overrider(overrider);
         si
 
         try_struct_override_me(into: Classy, overrider: Function, logger: Logger) is
@@ -201,6 +204,7 @@ namespace Semantic.Symbols is
             let il_name_matches = overrider.ensure_il_name_matches(into, self, "implement", logger);
 
             overrider.add_overridee(self);
+            self.add_overrider(overrider);
         si
 
         try_abstract_override_me(into: Classy, overrider: Function, logger: Logger) =>

--- a/src/semantic/symbols/property.ghul
+++ b/src/semantic/symbols/property.ghul
@@ -10,6 +10,7 @@ namespace Semantic.Symbols is
     use Types.Type;
 
     class Property: Symbol, Types.SettableTyped is
+        _overriders: Collections.MutableList[Symbol];
         _overridees: Collections.MutableList[Symbol];
 
         span: LOCATION;
@@ -29,7 +30,8 @@ namespace Semantic.Symbols is
 
         assign_function: Function public;
         assign_function_il_name_override: string public;
-                    
+
+        overriders: Collections.Iterable[Symbol] => _overriders;
         overridees: Collections.Iterable[Symbol] => _overridees;
 
         init(location: LOCATION, span: LOCATION, owner: Scope, name: string, is_assignable: bool, is_private: bool) is
@@ -40,6 +42,14 @@ namespace Semantic.Symbols is
             self.is_private = is_private;
         si
         
+        add_overrider(overrider: Symbol) is
+            if !_overriders? then
+                _overriders = new Collections.LIST[Symbol]();
+            fi 
+
+            _overriders.add(overrider);
+        si
+
         add_overridee(overridee: Symbol) is
             if !_overridees? then
                 _overridees = new Collections.LIST[Symbol]();

--- a/src/semantic/symbols/symbol.ghul
+++ b/src/semantic/symbols/symbol.ghul
@@ -84,7 +84,10 @@ namespace Semantic.Symbols is
 
         symbols: Collections.Iterable[Symbol] => new Collections.LIST[Symbol]();
 
+        overriders: Collections.Iterable[Symbol] => null;
         overridees: Collections.Iterable[Symbol] => null;
+
+        implementors: Collections.Iterable[Symbol] => null;
 
         unspecialized_symbol: Symbol => self;
 
@@ -104,6 +107,7 @@ namespace Semantic.Symbols is
         is_private: bool => false;
         is_public_readable: bool => true;
         is_assignable: bool => false;
+        is_function: bool => false;
         is_function_group: bool => false;
         
         qualified_name: string is
@@ -189,6 +193,10 @@ namespace Semantic.Symbols is
             throw new System.NotImplementedException("cannot add member to " + self);
         si
 
+        add_implementor(symbol: Symbol) is
+            throw new System.NotImplementedException("cannot add implementor to " + self);            
+        si
+        
         get_ancestor(i: int) -> Type is
             if ancestors.count > 0 then
                 Std.error.write_line("oops: " + self.get_type() + " " + self + " has ancestors but expected none");
@@ -249,6 +257,9 @@ namespace Semantic.Symbols is
         pull_down_super_symbols() is
             throw new System.NotImplementedException("abstract method: implement me");
         si
+
+        add_overrider(overrider: Symbol);
+        add_overridee(overridee: Symbol);
         
         find_direct(name: string) -> Symbol => null;
 

--- a/src/semantic/symbols/symbol_inheritance_resolver.ghul
+++ b/src/semantic/symbols/symbol_inheritance_resolver.ghul
@@ -278,8 +278,9 @@ namespace Semantic is
                                 fi
 
                                 if overrides then
-                                    property_symbol.add_overridee(overridee);                                    
-                                fi                                
+                                    property_symbol.add_overridee(overridee);
+                                    overridee.add_overrider(property_symbol);
+                                fi
                             fi
                         elif !(isa Symbols.Variable(overridee)) then
                             logger.warn(overrider_symbol.location, "" + overrider_symbol + " hides non-property " + overridee_symbols|);                            

--- a/src/syntax/parsers/expressions/secondary.ghul
+++ b/src/syntax/parsers/expressions/secondary.ghul
@@ -118,8 +118,8 @@ namespace Syntax.Parsers.Expressions is
                         let location = context.location;
 
                         let pipes = new Trees.Identifiers.Identifier(location, "Pipes");
-                        let pipe = new Trees.Identifiers.QUALIFIED(location, pipes, "Pipe", location);
-                        let from = new Trees.Identifiers.QUALIFIED(location, pipe, "from", location);
+                        let pipe = new Trees.Identifiers.QUALIFIED(location, pipes, "Pipe", location, location);
+                        let from = new Trees.Identifiers.QUALIFIED(location, pipe, "from", location, location);
 
                         let function = new Trees.Expressions.IDENTIFIER(location, from);
 

--- a/src/syntax/parsers/identifiers/qualified.ghul
+++ b/src/syntax/parsers/identifiers/qualified.ghul
@@ -25,11 +25,25 @@ namespace Syntax.Parsers.Identifiers is
                 
                     context.next_token();
                     if context.expect_token(Lexical.TOKEN.IDENTIFIER, syntax_error_message) then
-                        result = new Trees.Identifiers.QUALIFIED(start::context.location, result, context.current.value_string, completion_target_start::context.location);
+                        result = 
+                            new Trees.Identifiers.QUALIFIED(
+                                start::context.location, 
+                                result, 
+                                context.current.value_string, 
+                                completion_target_start::context.location,
+                                context.location
+                            );
 
                         context.next_token();
                     else
-                        result = new Trees.Identifiers.QUALIFIED(start::context.location, result, null, completion_target_start::context.location);
+                        result =
+                            new Trees.Identifiers.QUALIFIED(
+                                start::context.location, 
+                                result, 
+                                null, 
+                                completion_target_start::context.location,
+                                context.location
+                            );
 
                         result.poison();
 

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -784,7 +784,8 @@ namespace Syntax.Process is
                         s, type
                     );
 
-                _symbol_use_locations.add_symbol_use(`self.location, s);
+                // FIXME: this breaks VSCode rename symbol: 
+                // _symbol_use_locations.add_symbol_use(`self.location, s);
             else
                 _logger.error(`self.location, "cannot access self from non-instance context");
             fi
@@ -806,7 +807,8 @@ namespace Syntax.Process is
                         s, cast Semantic.Symbols.Classy(s).ancestors[0]
                     );
 
-                _symbol_use_locations.add_symbol_use(`super.location, s);
+                // FIXME: breaks VSCode rename symbol:
+                // _symbol_use_locations.add_symbol_use(`super.location, s);
             fi
         si
 
@@ -1005,7 +1007,7 @@ namespace Syntax.Process is
                 _logger.error(`new.location, "cannot call superclass constructor " + function);
             fi
             
-            _symbol_use_locations.add_symbol_use(`new.type_expression.location, function);
+            _symbol_use_locations.add_symbol_use(`new.type_expression.right_location, type_symbol);
 
             `new.value =
                 new NEW(
@@ -1370,7 +1372,7 @@ namespace Syntax.Process is
                     return;
                 fi
 
-                _symbol_use_locations.add_symbol_use(member.location, symbol);
+                _symbol_use_locations.add_symbol_use(member.identifier.right_location, symbol);
 
                 if symbol.is_instance /\ !member.left.value.is_consumable then
                     _logger.error(member.identifier.location, "cannot access instance member " + member.identifier.name + " in " + named_type);                    
@@ -1815,7 +1817,7 @@ namespace Syntax.Process is
 
                     let function = overload_result.function;
 
-                    _symbol_use_locations.add_symbol_use(call.function.location, function);
+                    _symbol_use_locations.add_symbol_use(call.function.right_location, function);
 
                     call.value = function.call(call.function.location, load.from, arguments, null, _function_caller);
 
@@ -1902,7 +1904,7 @@ namespace Syntax.Process is
             let symbol = find(identifier.identifier);
 
             if symbol? then
-                _symbol_use_locations.add_symbol_use(identifier.location, symbol);
+                _symbol_use_locations.add_symbol_use(identifier.right_location, symbol);
 
                 _symbol_loader.find_symbol = (name: string) => find(name);
 

--- a/src/syntax/process/resolve_ancestors.ghul
+++ b/src/syntax/process/resolve_ancestors.ghul
@@ -1,7 +1,6 @@
 namespace Syntax.Process is
     use IO.Std;
 
-        
     use Logging;
 
     class RESOLVE_ANCESTORS: ScopedVisitor is
@@ -37,9 +36,6 @@ namespace Syntax.Process is
 
             let class_symbol = cast Semantic.Symbols.CLASS(scope_for(`class));
 
-            // exit class scope before looking up ancestors:
-            // super.visit(`class);            
-
             let seen_class_ancestor = false;
             let is_first = true;
 
@@ -69,8 +65,7 @@ namespace Syntax.Process is
                 od
             fi
 
-            // FIXME: safer test for Ghul.object:
-            if !seen_class_ancestor /\ `class.name.name !~ "object" then
+            if !seen_class_ancestor then
                 let object_type = _innate_symbol_lookup.get_object_type();
 
                 if class_symbol != object_type.symbol then
@@ -87,9 +82,6 @@ namespace Syntax.Process is
             fi
 
             let trait_symbol = cast Semantic.Symbols.TRAIT(scope_for(`trait));
-
-            // exit class scope before looking up ancestors:
-            // super.visit(`trait);
 
             let seen_valid_ancestor = false;
 

--- a/src/syntax/process/resolve_overrides.ghul
+++ b/src/syntax/process/resolve_overrides.ghul
@@ -57,7 +57,7 @@ namespace Syntax.Process is
             if symbol? /\ isa Semantic.Symbols.Classy(symbol) then
                 _duplicate_method_checker.check(symbol, "duplicate method");
 
-                cast Semantic.Symbols.Classy(symbol).pull_down_super_symbols();
+                symbol.pull_down_super_symbols();
             fi
         si
 
@@ -69,7 +69,7 @@ namespace Syntax.Process is
             if symbol? /\ isa Semantic.Symbols.Classy(symbol) then
                 _duplicate_method_checker.check(symbol, "duplicate method");
 
-                cast Semantic.Symbols.Classy(symbol).pull_down_super_symbols();
+                symbol.pull_down_super_symbols();
             fi
         si
 
@@ -79,7 +79,7 @@ namespace Syntax.Process is
             let symbol = symbol_for(`struct);
 
             if symbol? /\ isa Semantic.Symbols.Classy(symbol) then
-                cast Semantic.Symbols.Classy(symbol).pull_down_super_symbols();
+                symbol.pull_down_super_symbols();
             fi
         si
 
@@ -89,7 +89,7 @@ namespace Syntax.Process is
             let symbol = symbol_for(`enum);
 
             if symbol? /\ isa Semantic.Symbols.Classy(symbol) then
-                cast Semantic.Symbols.Classy(symbol).pull_down_super_symbols();
+                symbol.pull_down_super_symbols();
             fi
         si
     si

--- a/src/syntax/process/resolve_type_expressions.ghul
+++ b/src/syntax/process/resolve_type_expressions.ghul
@@ -57,7 +57,7 @@ namespace Syntax.Process is
 
             if symbol? then
                 if symbol.is_type /\ isa Semantic.Types.Typed(symbol) then
-                    _symbol_use_locations.add_symbol_use(named.name.location, symbol);
+                    _symbol_use_locations.add_symbol_use(named.name.right_location, symbol);
 
                     named.type = cast Semantic.Types.Typed(symbol).type;
                 else
@@ -76,7 +76,7 @@ namespace Syntax.Process is
             let symbol = find(generic.name);
 
             if symbol? then
-                _symbol_use_locations.add_symbol_use(generic.name.location, symbol);
+                _symbol_use_locations.add_symbol_use(generic.name.right_location, symbol);
 
                 if !isa Semantic.Symbols.Classy(symbol) then
                     _logger.error(generic.location, "cannot supply type arguments here");

--- a/src/syntax/process/resolve_uses.ghul
+++ b/src/syntax/process/resolve_uses.ghul
@@ -49,7 +49,7 @@ namespace Syntax.Process is
                 fi
                 
                 if isa Semantic.Symbols.NAMESPACE(used_symbol) then
-                    _symbol_use_locations.add_symbol_use(u.`use.location, used_symbol);
+                    _symbol_use_locations.add_symbol_use(u.`use.right_location, used_symbol);
 
                     if namespace_scope.contains_used_symbol(use_name) then
                         if u.name? then
@@ -73,7 +73,7 @@ namespace Syntax.Process is
                         fi
                     fi
 
-                    _symbol_use_locations.add_symbol_use(u.`use.location, used_symbol.collapse_group_if_single_member());
+                    _symbol_use_locations.add_symbol_use(u.`use.right_location, used_symbol.collapse_group_if_single_member());
 
                     let existing_used_symbol = namespace_scope.get_used_symbol(use_name);
 
@@ -95,7 +95,7 @@ namespace Syntax.Process is
                             _logger.error(u.`use.location, "duplicate use");
                         fi
                     else
-                        _symbol_use_locations.add_symbol_use(u.`use.location, used_symbol);
+                        _symbol_use_locations.add_symbol_use(u.`use.right_location, used_symbol);
                         namespace_scope.add(use_name, used_symbol);
                     fi
                 else

--- a/src/syntax/trees/expressions/call.ghul
+++ b/src/syntax/trees/expressions/call.ghul
@@ -5,6 +5,7 @@ namespace Syntax.Trees.Expressions is
     class CALL: Expression is
         function: Expression;
         arguments: LIST;
+        right_location: LOCATION => function.right_location;
 
         init(location: LOCATION, function: Expression, arguments: LIST) is
             super.init(location);

--- a/src/syntax/trees/expressions/expression.ghul
+++ b/src/syntax/trees/expressions/expression.ghul
@@ -4,6 +4,7 @@ namespace Syntax.Trees.Expressions is
     use IR.Values.Value;
     class Expression: Trees.Node is
         value: Value public;
+        right_location: LOCATION => location;
 
         could_be_formal_argument: bool => false;
 

--- a/src/syntax/trees/expressions/identifier.ghul
+++ b/src/syntax/trees/expressions/identifier.ghul
@@ -4,6 +4,7 @@ namespace Syntax.Trees.Expressions is
 
     class IDENTIFIER: Expression  is
         identifier: Identifiers.Identifier;
+        right_location: LOCATION => identifier.right_location;
 
         could_be_formal_argument: bool => true;
 

--- a/src/syntax/trees/expressions/member.ghul
+++ b/src/syntax/trees/expressions/member.ghul
@@ -6,6 +6,7 @@ namespace Syntax.Trees.Expressions is
         left: Expression;
         identifier: Identifiers.Identifier;
         completion_target: LOCATION;
+        right_location: LOCATION => identifier.right_location;
 
         init(
             location: LOCATION,

--- a/src/syntax/trees/identifiers/identifier.ghul
+++ b/src/syntax/trees/identifiers/identifier.ghul
@@ -14,6 +14,8 @@ namespace Syntax.Trees.Identifiers is
 
         is_qualified: bool => false;
 
+        right_location: LOCATION => location;
+
         @IL.name.read("GetEnumerator")
         iterator: Collections.Iterator[string] => names.iterator;
 
@@ -48,6 +50,7 @@ namespace Syntax.Trees.Identifiers is
         _qualifier: Identifier;
 
         completion_target: LOCATION;
+        right_location: LOCATION;
 
         is_qualified: bool => true;
 
@@ -98,11 +101,18 @@ namespace Syntax.Trees.Identifiers is
             return result.iterator;
         si        
 
-        init(location: LOCATION, qualifier: Identifier, name: string, completion_target: LOCATION) is
+        init(
+            location: LOCATION, 
+            qualifier: Identifier, 
+            name: string, 
+            completion_target: LOCATION,
+            right_location: LOCATION
+        ) is
             super.init(location, name);
 
             _qualifier = qualifier;
             self.completion_target = completion_target;
+            self.right_location = right_location;
 
             poison(qualifier.is_poisoned);
         si
@@ -118,7 +128,8 @@ namespace Syntax.Trees.Identifiers is
                 location,
                 np,
                 name,
-                completion_target
+                completion_target,
+                right_location
             );
         si
 

--- a/src/syntax/trees/type_expressions/array.ghul
+++ b/src/syntax/trees/type_expressions/array.ghul
@@ -14,6 +14,7 @@ namespace Syntax.Trees.TypeExpressions is
             if !visitor.pre(self) then
                 element.walk(visitor);
             fi
+
             accept(visitor);
         si
     si

--- a/src/syntax/trees/type_expressions/named.ghul
+++ b/src/syntax/trees/type_expressions/named.ghul
@@ -4,6 +4,7 @@ namespace Syntax.Trees.TypeExpressions is
 
     class NAMED: TypeExpression is
         name: Identifiers.Identifier;
+        right_location: LOCATION => name.right_location;
 
         size: int => 8;
 

--- a/src/syntax/trees/type_expressions/type_expression.ghul
+++ b/src/syntax/trees/type_expressions/type_expression.ghul
@@ -8,6 +8,7 @@ namespace Syntax.Trees.TypeExpressions is
 
     class TypeExpression: Trees.Node, Semantic.Types.SettableTyped is
         type: Type public;
+        right_location: LOCATION => location;
         is_reference: bool => false;
 
         check_is_not_reference(logger: Logging.Logger, message: string) -> bool is


### PR DESCRIPTION
Bugs fixed:
- Renaming a file in VSC causes false 'redefining symbol error' underlining (fixes degory/ghul-vsce#12)

Enhancements:
- Support cross workspace rename of symbols in VSCode
- Support go to symbol implementations in VSCode

Notes:
- Requires version v0.4.0 of the ghūl VSCore language extension or later

Bump #minor version