### PR TITLE
Fix go to definition on Windows

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.3.4",
+      "version": "0.4.2-alpha.3",
       "commands": [
         "ghul-compiler"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.4.2-alpha.3",
+      "version": "0.4.1",
       "commands": [
         "ghul-compiler"
       ]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.3.5-alpha.107</Version>
+    <Version>0.4.2-alpha.3</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/driver/analyser.ghul
+++ b/src/driver/analyser.ghul
@@ -350,7 +350,7 @@ namespace Driver is
         si
     si
 
-    class DEFINITION_HANDLER: CommandHandler is
+    class DEFINITION_HANDLER: SymbolLocationHandler is
         _watchdog: WATCHDOG;
         _symbol_use_locations: Semantic.SYMBOL_USE_LOCATIONS;
 
@@ -380,11 +380,7 @@ namespace Driver is
                     let symbol = _symbol_use_locations.find_definition_from_use(path, line, column);
                     
                     if symbol? /\ !symbol.is_internal /\ !symbol.is_reflected then
-                        writer.write_line("" + symbol.location.file_name);
-                        writer.write_line("" + symbol.location.start_line);
-                        writer.write_line("" + symbol.location.start_column);
-                        writer.write_line("" + symbol.location.end_line);
-                        writer.write_line("" + symbol.location.end_column);
+                        write_location_list(writer, [symbol.location]);
                     fi
                 fi
             catch e: Exception


### PR DESCRIPTION
Bugs fixed:
- Go to definition doesn't work on Windows (closes degory/ghul-vsce#13)

Notes:
- Requires version 0.5.0 of the language extension or later

Bumps #minor version to 0.5.0