### PR TITLE
Fixed framework version in runtimeconfig

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.4.1",
+      "version": "0.5.0",
       "commands": [
         "ghul-compiler"
       ]

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "degory.ghul"
+    ]
+}

--- a/src/driver/main.ghul
+++ b/src/driver/main.ghul
@@ -383,7 +383,7 @@ namespace Driver is
             fi
             
             let runtime_config = File.create_text(runtime_config_file);
-            runtime_config.write("{\"runtimeOptions\":{\"tfm\":\"netcoreapp6.0\",\"framework\":{\"name\":\"Microsoft.NETCore.App\",\"version\":\"" + IoC.CONTAINER.instance.assemblies.sdk_version + "\"}}}");
+            runtime_config.write("{\"runtimeOptions\":{\"tfm\":\"netcoreapp6.0\",\"framework\":{\"name\":\"Microsoft.NETCore.App\",\"version\":\"6.0.0\"}}}");
             runtime_config.close();
 
             if !RuntimeInformation.is_o_s_platform(OSPlatform.windows) then


### PR DESCRIPTION
Bugs fixed:
- Example ghul.template build fails (closes #911)

Technical:
- Hardwire framework version in `.runtimeconfig.json` to 6.0.0 rather than trying to detect SDK version
  1. The SDK version detection code wrongly assumes the SDK will always be in `/usr/share` or `c:\Program Files\dotnet`, and fails if it's installed elsewhere
  2. We're already assuming the SDK is .NET 6.0 anyway
  3. In practice '6.0.0' will likely work fine for the entire lifetime of .NET 6.0