### PR TITLE
Fix issues when renaming symbols via the VSCE

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.5.4",
+      "version": "0.5.6",
       "commands": [
         "ghul-compiler"
       ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -43,7 +43,7 @@
             "command": "dotnet",
             "args": [
                 "pack",
-                // "/property:GhulOptions=\"--define release\"",
+                "/property:GhulOptions=\"--define release\"",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.5.5-alpha.1</Version>
+    <Version>0.5.7-alpha.30</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/driver/analyser.ghul
+++ b/src/driver/analyser.ghul
@@ -805,7 +805,6 @@ namespace Driver is
 
         write_location_list(writer: IO.TextWriter, locations: Iterable[LOCATION]) is
             for location in locations do
-                Std.error.write_line(location);
                 writer.write_line(
                     format_location(location)
                 );

--- a/src/semantic/overload_resolver.ghul
+++ b/src/semantic/overload_resolver.ghul
@@ -115,8 +115,6 @@ namespace Semantic is
                             match = f_arg.compare(arg);
 
                             if match == Types.MATCH.DIFFERENT then
-                                // IO.Std.error.write_line("OOOO: arguments not compatible: " + f_arg + " vs " + arg);
-
                                 score = cast int(Types.MATCH.DIFFERENT);
                                 
                                 break;

--- a/src/semantic/symbol_use_locations.ghul
+++ b/src/semantic/symbol_use_locations.ghul
@@ -30,6 +30,10 @@ namespace Semantic is
         si
 
         add_symbol_use(location: LOCATION, symbol: Symbols.Symbol) is
+            if symbol? then
+                symbol = symbol.root_specialized_from;
+            fi
+
             if 
                 symbol? /\ 
                 !symbol.is_internal /\
@@ -109,7 +113,7 @@ namespace Semantic is
                 _get_all_overriding_symbols(symbol, results);
             fi
 
-            return results | .filter(s => s != symbol) .map(s => s.location);
+            return results | .map(s => s.location);
         si
 
         // - include uses but not definitions
@@ -139,6 +143,8 @@ namespace Semantic is
         // - include references to all symbols that override the root overridee symbols
         // - for classes, traits and other symbols, include only references to the searched symbol
         find_references_to_symbol_for_rename(symbol: Symbols.Symbol) -> Collections.Iterable[LOCATION] is
+            symbol = symbol.root_specialized_from;
+            
             let definitions = new Collections.SET[Symbols.Symbol]();
 
             if symbol.is_classy then
@@ -177,14 +183,20 @@ namespace Semantic is
             include_definitions: bool
         ) is
             for d in symbols do
+                if include_definitions then
+                    into.add(d.location);                    
+                fi
+                
                 let references = _try_get_references_set(d);
-    
+
                 if !references? then
                     continue;
                 fi
 
-                for reference in references | .filter(r => r !~ d.location) do
-                    into.add(reference);
+                for reference in references do
+                    if include_definitions \/ reference !~ d.location then
+                        into.add(reference);
+                    fi
                 od
             od                
         si

--- a/src/semantic/symbols/classy.ghul
+++ b/src/semantic/symbols/classy.ghul
@@ -73,7 +73,7 @@ namespace Semantic.Symbols is
             if !_implementors? then
                 _implementors = new Collections.LIST[Symbol]();
             fi
-            
+ 
             _implementors.add(symbol);
         si
         
@@ -176,7 +176,7 @@ namespace Semantic.Symbols is
 
         mark_overrides_resolved() is
             _are_overrides_resolved = true;
-        si       
+        si
 
         pull_down_super_symbols() is
             if _are_overrides_resolved then

--- a/src/semantic/symbols/function.ghul
+++ b/src/semantic/symbols/function.ghul
@@ -101,17 +101,33 @@ namespace Semantic.Symbols is
         si
 
         add_overrider(overrider: Symbol) is
+            let rsf = root_specialized_from;
+            if rsf != self then
+                rsf.add_overrider(overrider);
+                return;
+            fi
+
             if !_overriders? then
                 _overriders = new Collections.LIST[Symbol]();
             fi 
+
+            overrider = overrider.root_specialized_from;
 
             _overriders.add(overrider);
         si
 
         add_overridee(overridee: Symbol) is
+            let rsf = root_specialized_from;
+            if rsf != self then
+                rsf.add_overridee(overridee);
+                return;
+            fi
+
             if !_overridees? then
                 _overridees = new Collections.LIST[Symbol]();
             fi 
+
+            overridee = overridee.root_specialized_from;
 
             _overridees.add(overridee);
         si

--- a/src/semantic/symbols/property.ghul
+++ b/src/semantic/symbols/property.ghul
@@ -43,17 +43,33 @@ namespace Semantic.Symbols is
         si
         
         add_overrider(overrider: Symbol) is
+            let rsf = root_specialized_from;
+            if rsf != self then
+                rsf.add_overrider(overrider);
+                return;
+            fi
+
             if !_overriders? then
                 _overriders = new Collections.LIST[Symbol]();
             fi 
+
+            overrider = overrider.root_specialized_from;
 
             _overriders.add(overrider);
         si
 
         add_overridee(overridee: Symbol) is
+            let rsf = root_specialized_from;
+            if rsf != self then
+                rsf.add_overridee(overridee);
+                return;
+            fi
+
             if !_overridees? then
                 _overridees = new Collections.LIST[Symbol]();
             fi 
+
+            overridee = overridee.root_specialized_from;
 
             _overridees.add(overridee);
         si

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -1009,7 +1009,7 @@ namespace Syntax.Process is
                 _logger.error(`new.location, "cannot call superclass constructor " + function);
             fi
             
-            _symbol_use_locations.add_symbol_use(`new.type_expression.right_location, type_symbol);
+            _symbol_use_locations.add_symbol_use(`new.type_expression.right_location, type_symbol.root_unspecialized_symbol);
 
             `new.value =
                 new NEW(


### PR DESCRIPTION
Bugs fixed:
- Renaming overridden symbols does not work reliably (closes #923)
- Renaming overridden symbols in generic types is not reliable (closes #924)

Enhancements:
- Include the definition of methods and properties in results of go-to implementation