### PR TITLE
Fix broken builds on .NET SDK 6.0.200

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.5.9",
+      "version": "0.5.11",
       "commands": [
         "ghul-compiler"
       ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         path: nupkg
 
     - name: Publish beta package to GitHub
-      run: dotnet nuget push ./nupkg/ghul.compiler.${{ needs.version.outputs.package }}.nupkg -k ${GITHUB_TOKEN} -s https://nuget.pkg.github.com/degory/index.json --skip-duplicate --no-symbols true
+      run: dotnet nuget push ./nupkg/ghul.compiler.${{ needs.version.outputs.package }}.nupkg -k ${GITHUB_TOKEN} -s https://nuget.pkg.github.com/degory/index.json --skip-duplicate --no-symbols
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -289,12 +289,12 @@ jobs:
         path: nupkg
 
     - name: Publish release package to GitHub
-      run: dotnet nuget push ./nupkg/ghul.compiler.${{ needs.version.outputs.package }}.nupkg -k ${GITHUB_TOKEN} -s https://nuget.pkg.github.com/degory/index.json --skip-duplicate --no-symbols true
+      run: dotnet nuget push ./nupkg/ghul.compiler.${{ needs.version.outputs.package }}.nupkg -k ${GITHUB_TOKEN} -s https://nuget.pkg.github.com/degory/index.json --skip-duplicate --no-symbols
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Publish release package to NuGet
-      run: dotnet nuget push ./nupkg/ghul.compiler.${{ needs.version.outputs.package }}.nupkg -k ${NUGET_TOKEN} -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols true
+      run: dotnet nuget push ./nupkg/ghul.compiler.${{ needs.version.outputs.package }}.nupkg -k ${NUGET_TOKEN} -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols
       env:
         NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,10 +1,10 @@
 <Project>
   <PropertyGroup>
-    <Version>0.5.10-alpha.134</Version>
+    <Version>0.5.12-alpha.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ghul.targets" Version="1.1.0" />
+    <PackageReference Include="ghul.targets" Version="1.2.0" />
     <PackageReference Include="ghul.pipes" Version="1.0.0" />
     <PackageReference Include="ghul.runtime" Version="1.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Technical:
- Bump ghul.targets to 1.2.0, which fixes issues due to breaking build changes in SDK 6.0.200
- Remove 'true' from nuget push --no-symbols parameter in CI workflow (see NuGet/Home#11601)