### PR TITLE
Make GHCR the default container registry

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.5.15",
+      "version": "0.5.23",
       "commands": [
         "ghul-compiler"
       ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,11 @@
 {
-	"image": "ghul/devcontainer:dotnet",
+	"image": "ghcr.io/degory/ghul/devcontainer:dotnet",
 	"containerUser": "vscode",
-	"extensions": [
-		"degory.ghul"
-	]
+	"customizations": {
+		"vscode" : {
+			"extensions": [
+				"degory.ghul"
+			]
+		}
+	}
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,16 +260,16 @@ jobs:
       run: docker push ghcr.io/degory/ghul/devcontainer:dotnet
 
     - name: Docker tag Docker Hub versioned
-      run: docker tag ghcr.io/degory/ghul/devcontainer:dotnet-${{ needs.version.outputs.tag }} ghul/devcontainer:dotnet-${{ needs.version.outputs.tag }}
+      run: docker tag ghcr.io/degory/ghul/devcontainer:dotnet-${{ needs.version.outputs.tag }} degory/ghul-devcontainer:dotnet-${{ needs.version.outputs.tag }}
 
     - name: Docker push Docker Hub versioned
-      run: docker push ghul/devcontainer:dotnet-${{ needs.version.outputs.tag }}
+      run: docker push degory/ghul-devcontainer:dotnet-${{ needs.version.outputs.tag }}
 
     - name: Docker tag Docker Hub stable
-      run: docker tag ghcr.io/degory/ghul/devcontainer:dotnet-${{ needs.version.outputs.tag }} ghul/devcontainer:dotnet
+      run: docker tag ghcr.io/degory/ghul/devcontainer:dotnet-${{ needs.version.outputs.tag }} degory/ghul-devcontainer:dotnet
 
     - name: Docker push Docker Hub stable
-      run: docker push ghul/devcontainer:dotnet
+      run: docker push degory/ghul-devcontainer:dotnet
 
   publish_release_package:
     needs: [version, unit_tests, container_tests]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -134,7 +134,7 @@
                 "-f",
                 "devcontainer-dotnet.dockerfile",
                 "-t",
-                "ghul/devcontainer:$(build/get-version-number.sh)"
+                "degory/ghul-devcontainer:dotnet-$(build/get-version-number.sh)"
             ],
             "presentation": {
                 "reveal": "silent"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.5.13-alpha.1</Version>
+    <Version>0.5.24-alpha.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you create a new GitHub repo from the [ghūl repository template](https://git
 
 ### Use the ghūl development container image
 
-The compiler is pre-installed globally in the [ghūl development container](https://hub.docker.com/r/ghul/devcontainer)
+The compiler is pre-installed globally in the [ghūl development container](https://github.com/users/degory/packages/container/package/ghul%2Fdevcontainer)
 
 ### Install the compiler as a local or global .NET tool
 

--- a/nuget-readme/README.md
+++ b/nuget-readme/README.md
@@ -32,7 +32,7 @@ If you create a new GitHub repo from the [ghūl repository template](https://git
 
 ### Use the ghūl development container image
 
-The compiler is pre-installed globally in the [ghūl development container](https://hub.docker.com/r/ghul/devcontainer)
+The compiler is pre-installed globally in the [ghūl development container](https://github.com/users/degory/packages/container/package/ghul%2Fdevcontainer)
 
 ### Install the compiler as a local or global .NET tool
 


### PR DESCRIPTION
Documentation:
- Update README to reference the GHCR devcontainer image URL

Technical:
- Reference the GHCR image URL in the devcontainer JSON config
- Move Docker Hub image URLs away from ghul organization