### PR TITLE
Bump CI workflow GitHub checkout actions to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       package: ${{ steps.create_version.outputs.package }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Create version
       id: create_version
@@ -50,7 +50,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Restore local .NET tools
       run: dotnet tool restore
@@ -73,7 +73,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Restore local .NET tools
       run: dotnet tool restore
@@ -102,7 +102,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Download ghul.compiler package
       uses: actions/download-artifact@v2
@@ -139,7 +139,7 @@ jobs:
 
     if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Download ghul compiler tool package
       uses: actions/download-artifact@v2
@@ -164,7 +164,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Download ghul.compiler package
       uses: actions/download-artifact@v2
@@ -205,7 +205,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Add .NET tools to PATH
       run: echo "${HOME}/.dotnet/tools" >> $GITHUB_PATH
@@ -235,7 +235,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Docker login to GHCR
       uses: docker/login-action@v1
@@ -282,7 +282,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Download ghul compiler tool package
       uses: actions/download-artifact@v2
@@ -309,7 +309,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || github.repository != 'degory/ghul' }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Download ghul compiler tool package
       uses: actions/download-artifact@v2

--- a/unit-tests/unit-tests.ghulproj
+++ b/unit-tests/unit-tests.ghulproj
@@ -6,10 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ghul.targets" />
-    <PackageReference Include="ghul.pipes" />
-    <PackageReference Include="ghul.runtime" />
-
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />


### PR DESCRIPTION
Technical:
- Bump references to actions/checkout from v2 to v3 as v2 is deprecated
- Remove duplicate assembly references from unit test project