### PR TITLE
Update project website URL on NuGet.org

### DIFF
--- a/ghul.ghulproj
+++ b/ghul.ghulproj
@@ -20,7 +20,7 @@
     <PackageDescription>compiler for the ghūl programming language</PackageDescription>
     <PackageTags>ghul;ghūl;compiler;dotnet;tool</PackageTags>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <PackageProjectUrl>https://github.com/degory/ghul</PackageProjectUrl>
+    <PackageProjectUrl>https://ghul.dev</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>
 


### PR DESCRIPTION
Documentation:
- Update project website URL on NuGet.org to point at https://ghul.dev