### PR TITLE
Revert stub and stable symbols changes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.6.7-alpha.40</Version>
+    <Version>0.6.8-alpha.28</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/compiler/build_flags.ghul
+++ b/src/compiler/build_flags.ghul
@@ -6,6 +6,7 @@ namespace Compiler is
 
         want_analyse: bool public;
         want_debug: bool public;
+        want_stubs: bool public;
         want_declare_symbols: bool public;
         want_compile_up_to_expressions: bool public;
         want_compile_expressions: bool public;

--- a/src/compiler/compiler.ghul
+++ b/src/compiler/compiler.ghul
@@ -163,6 +163,8 @@ namespace Compiler is
         build() is
             container.ghul_namespace_creator.create_namespaces();
             build(build_passes, source_files);
+
+            container.stable_symbols.next_generation();
         si
 
         build(passes: Collections.Iterable[Pass], source_files: Collections.Iterable[SOURCE_FILE]) is

--- a/src/driver/main.ghul
+++ b/src/driver/main.ghul
@@ -49,7 +49,11 @@ namespace Driver is
         si        
 
         standard_ghul_library_locations: Iterable[string] is
-            return ["dotnet/ghul"];
+            if flags.want_stubs then
+                return ["dotnet/ghul", "dotnet/stubs"];
+            else
+                return ["dotnet/ghul"];
+            fi
         si
 
         entry(arguments: string[]) static is
@@ -171,9 +175,6 @@ namespace Driver is
             si;
 
             let conditional_defines = new Collections.LIST[string]();
-            
-            // always define v3
-            conditional_defines.add("v3");
 
             for s in args_iterator do
                 if s =~ "-A" \/ s =~ "--analyse" then
@@ -197,7 +198,8 @@ namespace Driver is
                 elif s =~ "--define" then
                     conditional_defines.add(get_next_argument(args_iterator));
                 elif s =~ "--v3" then
-                    // do nothing - v3 is always defined
+                    flags.want_stubs = false;
+                    conditional_defines.add("v3");
                 elif s =~ "--test-run" then
                     flags.is_test_run = true;
                 elif s =~ "-N" \/ s =~ "--dotnet" then
@@ -281,6 +283,10 @@ namespace Driver is
             od
 
             flags.mark_valid();
+
+            if !flags.want_stubs then
+                container.stable_symbols.enable();
+            fi
 
             if flags.is_test_run then
                 container.want_human_readable_logger(Std.error);

--- a/src/ioc/container.ghul
+++ b/src/ioc/container.ghul
@@ -71,6 +71,7 @@ namespace IoC is
         type_name_map: Semantic.DotNet.TYPE_NAME_MAP;
         assemblies: Semantic.DotNet.ASSEMBLIES;
 
+        stable_symbols: Semantic.STABLE_SYMBOLS;
         symbol_table: Semantic.SYMBOL_TABLE;
         namespaces: Semantic.NAMESPACES;
         symbol_loader: Semantic.SYMBOL_LOADER;
@@ -343,6 +344,8 @@ namespace IoC is
                     statement_list_parser,
                     identifier_qualified_parser);
 
+            stable_symbols = new Semantic.STABLE_SYMBOLS();
+
             type_details_lookup = new Semantic.DotNet.TYPE_DETAILS_LOOKUP();
 
             symbol_table = new Semantic.SYMBOL_TABLE(logger);
@@ -415,6 +418,7 @@ namespace IoC is
             declare_symbols = 
                 new Syntax.Process.DECLARE_SYMBOLS(
                     logger, 
+                    stable_symbols,
                     symbol_table, 
                     namespaces, 
                     symbol_definition_locations,
@@ -423,11 +427,12 @@ namespace IoC is
             resolve_uses = new Syntax.Process.RESOLVE_USES(logger, symbol_table, namespaces, symbol_use_locations);
 
             resolve_ancestors =
-                new Syntax.Process.RESOLVE_ANCESTORS(logger, symbol_table, namespaces, innate_symbol_lookup);
+                new Syntax.Process.RESOLVE_ANCESTORS(logger, stable_symbols, symbol_table, namespaces, innate_symbol_lookup);
 
             resolve_type_expressions =
                 new Syntax.Process.RESOLVE_TYPE_EXPRESSIONS(
                     logger,
+                    stable_symbols,
                     symbol_table,                    
                     namespaces,
                     symbol_use_locations,
@@ -436,6 +441,7 @@ namespace IoC is
             resolve_explicit_types =
                 new Syntax.Process.RESOLVE_EXPLICIT_TYPES(
                     logger,
+                    stable_symbols,
                     symbol_table,
                     namespaces,
                     innate_symbol_lookup
@@ -444,6 +450,7 @@ namespace IoC is
             compile_expressions =
                 new Syntax.Process.COMPILE_EXPRESSIONS(
                     logger,
+                    stable_symbols,
                     symbol_table,
                     namespaces,
                     symbol_loader,
@@ -458,6 +465,7 @@ namespace IoC is
             resolve_overrides =
                 new Syntax.Process.RESOLVE_OVERRIDES(
                     logger,
+                    stable_symbols,                    
                     symbol_table,
                     namespaces
                 );

--- a/src/ir/innate_operation_generator.ghul
+++ b/src/ir/innate_operation_generator.ghul
@@ -239,6 +239,10 @@ namespace IR is
             gen_arguments(value, context);
 
             let prefix = "['ghul-runtime']";
+
+            if _flags.want_stubs then
+                prefix = "";
+            fi
             
             if value.op_name =~ "inclusive" then
                 context.write_line("newobj instance void valuetype " + prefix + "'Ghul'.'INT_RANGE_INCLUSIVE'::'.ctor'(int32,int32)");

--- a/src/semantic/stable_symbols.ghul
+++ b/src/semantic/stable_symbols.ghul
@@ -1,0 +1,71 @@
+namespace Semantic is
+    use Collections.MAP;
+
+    use Syntax.Trees.Node;
+
+    struct STABLE_SYMBOL is
+        generation: int;
+        symbol: Scope;
+
+        init(generation: int, symbol: Scope) is
+            self.generation = generation;
+            self.symbol = symbol;
+        si
+        
+        to_string() -> string => "" + symbol + " gen " + generation; 
+    si
+
+    class STABLE_SYMBOLS is
+        _generation: int;
+        _symbols: MAP[Node,STABLE_SYMBOL];
+        _is_enabled: bool;
+
+        [node: Node] -> Scope is
+            let result: STABLE_SYMBOL;
+
+            _symbols.try_get_value(node, result ref);
+
+            return result.symbol;
+        si        
+
+        init() is
+            _symbols = new MAP[Node,STABLE_SYMBOL]();
+        si
+
+        enable() is
+            _is_enabled = true;
+        si
+
+        is_stable(node: Node) -> bool is
+            let symbol: STABLE_SYMBOL;
+
+            if !_is_enabled then
+                return false;
+            fi
+            
+            if _symbols.try_get_value(node, symbol ref) then
+                return _generation > symbol.generation;
+            fi
+        si
+        
+        try_get_symbol(node: Node, result: STABLE_SYMBOL ref) -> bool is
+            if !_is_enabled then
+                return false;
+            fi
+
+            return _symbols.try_get_value(node, result);
+        si
+
+        add(node: Node, scope: Scope) is
+            if !_is_enabled then
+                return;
+            fi
+            
+            _symbols[node] = new STABLE_SYMBOL(_generation, scope);
+        si
+
+        next_generation() is
+            _generation = _generation + 1;
+        si        
+    si
+si

--- a/src/semantic/symbols/method_override_class.ghul
+++ b/src/semantic/symbols/method_override_class.ghul
@@ -53,13 +53,7 @@ namespace Semantic is
             let result = 0;
 
             for a in arguments do
-                if !a? then
-                    // FIXME would be better to stop null getting in here in the first place
-
-                    result = result + 1;
-                else
-                    result = result + a.get_hash_code();
-                fi
+                result = result + a.get_hash_code();
             od
 
             return result;

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -35,6 +35,7 @@ namespace Syntax.Process is
 
         init(
             logger: Logger,
+            stable_symbols: Semantic.STABLE_SYMBOLS,
             symbol_table: Semantic.SYMBOL_TABLE,
             namespaces: Semantic.NAMESPACES,
             symbol_loader: Semantic.SYMBOL_LOADER,
@@ -46,7 +47,7 @@ namespace Syntax.Process is
             value_boxer: VALUE_BOXER
         )
         is
-            super.init(logger, symbol_table, namespaces);
+            super.init(logger, stable_symbols, symbol_table, namespaces);
 
             _logger = logger;
             _symbol_table = symbol_table;
@@ -71,6 +72,8 @@ namespace Syntax.Process is
             assert _keep_depth == 0;
             assert _stub_depth == 0;
         si
+
+        should_skip(node: Trees.Node) -> bool => _stub_depth > 0 \/ is_stable(node);
 
         get_zero_argument_function(type: Type, name: string) -> Semantic.Symbols.Function is
             let symbol = type.find_member(name);
@@ -173,17 +176,17 @@ namespace Syntax.Process is
 
         pre(`class: Trees.Definitions.CLASS) -> bool is
             super.pre(`class);
-            return false;
+            return should_skip(`class);
         si
 
         pre(`trait: Trees.Definitions.TRAIT) -> bool is
             super.pre(`trait);
-            return false;
+            return should_skip(`trait);            
         si        
 
         pre(`struct: Trees.Definitions.STRUCT) -> bool is
             super.pre(`struct);
-            return false;
+            return should_skip(`struct);            
         si
         
         pre(`for: Trees.Statements.FOR) -> bool is
@@ -1713,6 +1716,8 @@ namespace Syntax.Process is
         si
 
         visit(call: Trees.Expressions.CALL) is
+            let mark = _logger.mark();
+
             try
                 _logger.speculate();
 
@@ -1726,9 +1731,9 @@ namespace Syntax.Process is
                 _logger.commit();
             catch e: Exception
                 call.value = null;
+                _logger.release(mark);
+ 
                 _logger.exception(call.location, e, "exception compiling call");
-
-                _logger.roll_back();
             yrt
         si
 
@@ -1780,7 +1785,7 @@ namespace Syntax.Process is
                     let function_group = cast Semantic.Symbols.FUNCTION_GROUP(load.symbol);
                     let overload_result = _overload_resolver.resolve(call.arguments.location, function_group, argument_types, true, want_instance);
 
-                    if overload_result == null then                        
+                    if overload_result == null then
                         return;
                     fi
 

--- a/src/syntax/process/completer.ghul
+++ b/src/syntax/process/completer.ghul
@@ -25,7 +25,7 @@ namespace Syntax.Process is
             dotnet_symbol_table: LAZY[Semantic.DotNet.SYMBOL_TABLE]
         )
         is
-            super.init(logger, symbol_table, namespaces);
+            super.init(logger, null, symbol_table, namespaces);
 
             _dotnet_symbol_table = dotnet_symbol_table; 
         si

--- a/src/syntax/process/declare_symbols.ghul
+++ b/src/syntax/process/declare_symbols.ghul
@@ -18,8 +18,11 @@ namespace Syntax.Process is
 
         _local_id_generator: IR.LOCAL_ID_GENERATOR;
 
+        _stable_symbols: Semantic.STABLE_SYMBOLS;
+
         init(
             logger: Logger,
+            stable_symbols: Semantic.STABLE_SYMBOLS,
             symbol_table:Semantic.SYMBOL_TABLE,
             namespaces: Semantic.NAMESPACES,
             symbol_use_listener: Semantic.SymbolDefinitionListener,
@@ -28,6 +31,7 @@ namespace Syntax.Process is
             super.init(symbol_table, namespaces);
 
             _logger = logger;
+            _stable_symbols = stable_symbols;
             _symbol_definition_listener = symbol_use_listener;
             _local_id_generator = local_id_generator;
         si
@@ -226,7 +230,22 @@ namespace Syntax.Process is
         si
 
         _pre(classy: Definitions.Classy) -> bool is
-            let symbol: Semantic.Scope;            
+            let symbol: Semantic.Scope;
+            let stable_symbol: Semantic.STABLE_SYMBOL;
+
+            if _keep_depth > 0 /\ _stable_symbols.try_get_symbol(classy, stable_symbol ref) then
+                symbol = stable_symbol.symbol;
+
+                current_declaration_context.declare_stable(cast Semantic.Symbols.Symbol(symbol));
+
+                associate_and_enter_scope(
+                    classy,
+                    symbol
+                );
+    
+                return true;                
+            fi
+            
             let arguments = get_generic_arguments(classy.arguments);
 
             // FIXME: we could avoid this by passing in an anonymous function
@@ -279,6 +298,10 @@ namespace Syntax.Process is
                 symbol
             );
 
+            if _keep_depth > 0 then
+                _stable_symbols.add(classy, symbol);
+            fi
+            
             declare_generic_arguments(classy.arguments);
         si
 

--- a/src/syntax/process/generate_il.ghul
+++ b/src/syntax/process/generate_il.ghul
@@ -49,7 +49,7 @@ namespace Syntax.Process is
             boxer: VALUE_BOXER
         )
         is
-            super.init(logger, symbol_table, namespaces);
+            super.init(logger, null, symbol_table, namespaces);
 
             _logger = logger;
             _symbol_table = symbol_table;

--- a/src/syntax/process/resolve_ancestors.ghul
+++ b/src/syntax/process/resolve_ancestors.ghul
@@ -10,12 +10,13 @@ namespace Syntax.Process is
 
         init(
             logger: Logger,
+            stable_symbols: Semantic.STABLE_SYMBOLS,
             symbol_table: Semantic.SYMBOL_TABLE,
             namespaces: Semantic.NAMESPACES,
             innate_symbol_lookup: Semantic.Lookups.InnateSymbolLookup
         )
         is
-            super.init(logger, symbol_table, namespaces);
+            super.init(logger, stable_symbols, symbol_table, namespaces);
 
             _logger = logger;
             _symbol_table = symbol_table;
@@ -29,6 +30,10 @@ namespace Syntax.Process is
         pre(`class: Trees.Definitions.CLASS) -> bool => true;
 
         visit(`class: Trees.Definitions.CLASS) is
+            if is_stable(`class) then
+                return;
+            fi
+
             let class_symbol = cast Semantic.Symbols.CLASS(scope_for(`class));
 
             let seen_class_ancestor = false;
@@ -74,6 +79,10 @@ namespace Syntax.Process is
         pre(`trait: Trees.Definitions.TRAIT) -> bool => true;
 
         visit(`trait: Trees.Definitions.TRAIT) is
+            if is_stable(`trait) then
+                return;
+            fi
+
             let trait_symbol = cast Semantic.Symbols.TRAIT(scope_for(`trait));
 
             let seen_valid_ancestor = false;
@@ -111,6 +120,10 @@ namespace Syntax.Process is
         pre(`struct: Trees.Definitions.STRUCT) -> bool => true;
 
         visit(`struct: Trees.Definitions.STRUCT) is
+            if is_stable(`struct) then
+                return;
+            fi
+
             let struct_symbol = cast Semantic.Symbols.STRUCT(scope_for(`struct));
 
             if `struct.ancestors? then

--- a/src/syntax/process/resolve_explicit_variable_types.ghul
+++ b/src/syntax/process/resolve_explicit_variable_types.ghul
@@ -13,12 +13,13 @@ namespace Syntax.Process is
 
         init(
             logger: Logger,
+            stable_symbols: Semantic.STABLE_SYMBOLS,
             symbol_table: Semantic.SYMBOL_TABLE,
             namespaces: Semantic.NAMESPACES,
             innate_symbol_lookup: Semantic.Lookups.InnateSymbolLookup
         )
         is
-            super.init(logger, symbol_table, namespaces);
+            super.init(logger, stable_symbols, symbol_table, namespaces);
 
             _symbol_table = symbol_table;
             _logger = logger;
@@ -32,6 +33,10 @@ namespace Syntax.Process is
         pre(`class: Trees.Definitions.CLASS) -> bool is
             let result = super.pre(`class);
 
+            if is_stable(`class) then
+                return true;
+            fi            
+
             set_generic_argument_types(`class.arguments);
 
             return result;
@@ -39,12 +44,12 @@ namespace Syntax.Process is
 
         pre(`trait: Trees.Definitions.TRAIT) -> bool is
             super.pre(`trait);
-            return false;
+            return is_stable(`trait);            
         si        
 
         pre(`struct: Trees.Definitions.STRUCT) -> bool is
             super.pre(`struct);
-            return false;
+            return is_stable(`struct);            
         si
 
         pre(function: Trees.Definitions.FUNCTION) -> bool is

--- a/src/syntax/process/resolve_overrides.ghul
+++ b/src/syntax/process/resolve_overrides.ghul
@@ -14,11 +14,12 @@ namespace Syntax.Process is
 
         init(
             logger: Logger,
+            stable_symbols: Semantic.STABLE_SYMBOLS,
             symbol_table: Semantic.SYMBOL_TABLE,
             namespaces: Semantic.NAMESPACES
         )
         is
-            super.init(logger, symbol_table, namespaces);
+            super.init(logger, stable_symbols, symbol_table, namespaces);
 
             _logger = logger;
             _symbol_table = symbol_table;

--- a/src/syntax/process/resolve_type_expressions.ghul
+++ b/src/syntax/process/resolve_type_expressions.ghul
@@ -16,13 +16,14 @@ namespace Syntax.Process is
 
         init(
             logger: Logger,
+            stable_symbols: Semantic.STABLE_SYMBOLS,
             symbol_table: Semantic.SYMBOL_TABLE,
             namespaces: Semantic.NAMESPACES,
             symbol_use_locations: Semantic.SYMBOL_USE_LOCATIONS,
             innate_symbol_lookup: Semantic.Lookups.InnateSymbolLookup    
         )
         is
-            super.init(logger, symbol_table, namespaces);
+            super.init(logger, stable_symbols, symbol_table, namespaces);
 
             _logger = logger;
             _symbol_table = symbol_table;
@@ -36,17 +37,17 @@ namespace Syntax.Process is
 
         pre(`class: Trees.Definitions.CLASS) -> bool is
             super.pre(`class);
-            return false;
+            return is_stable(`class);
         si
 
         pre(`trait: Trees.Definitions.TRAIT) -> bool is
             super.pre(`trait);
-            return false;
+            return is_stable(`trait);
         si        
 
         pre(`struct: Trees.Definitions.STRUCT) -> bool is
             super.pre(`struct);
-            return false;
+            return is_stable(`struct);            
         si
 
         visit(named: Trees.TypeExpressions.NAMED) is

--- a/src/syntax/process/scopedvisitor.ghul
+++ b/src/syntax/process/scopedvisitor.ghul
@@ -7,10 +7,12 @@ namespace Syntax.Process is
 
     class ScopedVisitor: ScopeVisitorBase is
         _logger: Logger;
+        _stable_symbols: Semantic.STABLE_SYMBOLS;
         _symbol_table: Semantic.SYMBOL_TABLE;
 
         init(
             logger: Logger,
+            stable_symbols: Semantic.STABLE_SYMBOLS,            
             symbol_table: Semantic.SYMBOL_TABLE,
             namespaces: Semantic.NAMESPACES
         )
@@ -21,6 +23,7 @@ namespace Syntax.Process is
             );
 
             _logger = logger;
+            _stable_symbols = stable_symbols;
             _symbol_table = symbol_table;
         si
 
@@ -60,6 +63,8 @@ namespace Syntax.Process is
 
             return result;
         si
+
+        is_stable(node: Trees.Node) -> bool => _stable_symbols.is_stable(node);
 
         pre(`namespace: Definitions.NAMESPACE) -> bool is
             enter_namespace(`namespace.name);

--- a/src/syntax/process/signature_help.ghul
+++ b/src/syntax/process/signature_help.ghul
@@ -20,7 +20,7 @@ namespace Syntax.Process is
             overload_resolver: Semantic.OVERLOAD_RESOLVER
         )
         is
-            super.init(logger, symbol_table, namespaces);
+            super.init(logger, null, symbol_table, namespaces);
 
             _overload_resolver = overload_resolver;
         si


### PR DESCRIPTION
Bug fixes:
- Revert stubs and stable symbols changes that caused phantom errors in VSCode (caused by #1027)