### PR TITLE
Fix issue with global definition outside any namespace on Windows

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.6.8",
+      "version": "0.6.9",
       "commands": [
         "ghul-compiler"
       ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -251,7 +251,7 @@
             }
         },
         {
-            "label": "Run all unit tests",
+            "label": "Run unit tests",
             "type": "shell",
             "command": "dotnet test unit-tests",
             "group": "test",

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.6.9-alpha.33</Version>
+    <Version>0.6.10-alpha.9</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ghul.ghulproj
+++ b/ghul.ghulproj
@@ -48,6 +48,7 @@
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />
     <PackageReference Include="runtime.linux-x64.Microsoft.NETCore.ILAsm" Version="8.0.0" />
     <PackageReference Include="runtime.win-x64.Microsoft.NETCore.ILAsm" Version="8.0.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="20.0.15" />
 
     <!-- Build outputs -->
     <None Include="nuget-readme/README.md" Pack="true" PackagePath="\" />

--- a/src/ioc/container.ghul
+++ b/src/ioc/container.ghul
@@ -411,7 +411,7 @@ namespace IoC is
 
             conditional_compilation = new Syntax.Process.CONDITIONAL_COMPILATION();
 
-            expand_namespaces = new Syntax.Process.EXPAND_NAMESPACES();
+            expand_namespaces = new Syntax.Process.EXPAND_NAMESPACES(new System.IO.Abstractions.FileSystem());
 
             add_accessors_for_properties = new Syntax.Process.ADD_ACCESSORS_FOR_PROPERTIES();
 

--- a/src/syntax/process/expand_namespaces.ghul
+++ b/src/syntax/process/expand_namespaces.ghul
@@ -1,12 +1,19 @@
 namespace Syntax.Process is
+    use System.Uri;
+    use System.UriKind;
+
+    use System.IO.Abstractions;
     use Source;
     use Trees;
 
     class EXPAND_NAMESPACES: Visitor is
+        _file_system: IFileSystem;
         _depth: int;
 
-        init() is
+        init(file_system: IFileSystem) is
             super.init();
+
+            _file_system = file_system;
         si
 
         apply(node: Node) is
@@ -61,7 +68,17 @@ namespace Syntax.Process is
             node.walk(self);
         si
 
+        is_root_directory(info: IDirectoryInfo) -> bool is
+            let root_path = _file_system.path.get_path_root(info.full_name);
+
+            return root_path =~ info.full_name;
+        si
+
         convert_file_name_to_identifier(name: string) -> string is
+            if name.length == 0 then
+                return name;
+            fi
+
             name = 
                 name
                     .replace('-', '_')
@@ -75,41 +92,59 @@ namespace Syntax.Process is
 
             return name;
         si
-        
+
         get_namespace_name(path: string) -> string is
-            if path.starts_with("file://") then
-                path = path.substring(7);
+            let local_path: string;
+            let uri: Uri;
+
+            if Uri.is_well_formed_uri_string(path, UriKind.ABSOLUTE) then
+                uri = new Uri(path);
             fi
 
-            let result = 
+            if uri? /\ uri.is_file then
+                local_path = uri.local_path;
+            else
+                local_path = path;
+            fi
+
+            let result =             
                 convert_file_name_to_identifier(
-                    IO.Path.get_file_name_without_extension(path)
+                    _file_system.path.get_file_name_without_extension(local_path)
                 );
 
-            let folder = IO.Path.get_directory_name(path);
+            let folder = _file_system.path.get_directory_name(local_path);
 
-            return get_namespace_name_for_folder(folder) + result;
+            result = get_namespace_name_for_folder(folder) + result;
+
+            return result;
         si
-
+        
         get_namespace_name_for_folder(path: string) -> string is
+            let original_path = path;
+
             if !path? \/ path =~ "" then
-                path = IO.Directory.get_current_directory();
+                path = _file_system.directory.get_current_directory();
             fi
 
-            let info = new IO.DirectoryInfo(path);
+            let info = _file_system.directory_info.from_directory_name(path);
 
-            return get_namespace_name_for_folder(info);            
+            let result = get_namespace_name_for_folder(info);
+
+            return result;            
         si        
 
-        get_namespace_name_for_folder(info: IO.DirectoryInfo) -> string is
+        get_namespace_name_for_folder(info: IDirectoryInfo) -> string is
             let result = convert_file_name_to_identifier(info.name) + "__";
 
-            if IO.File.exists(info.to_string() + "/ghul.json") \/ IO.Directory.get_files(info.to_string(), "*.ghulproj").count > 0 then
-                return result;                
+            if 
+                _file_system.file.exists(_file_system.path.combine(info.full_name, "ghul.json")) \/
+                _file_system.directory.get_files(info.full_name, "*.ghulproj").count > 0
+            then
+                return result;
             fi
 
-            if info.parent? then
-                result = get_namespace_name_for_folder(info.parent) + result;                
+            if info.parent? /\ !is_root_directory(info) then
+                result = get_namespace_name_for_folder(info.parent) + result;
             fi
 
             return result;

--- a/unit-tests/src/syntax/process/expand_namespaces.ghul
+++ b/unit-tests/src/syntax/process/expand_namespaces.ghul
@@ -1,0 +1,445 @@
+namespace Semantic.DotNet.UnitTests is
+    use Collections;
+    use System.IO.Abstractions;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+    use NSubstitute;
+    use NSubstitute.SubstituteExtensions.returns;
+
+    use Logging;
+    use Syntax.Process;
+
+    class EXPAND_NAMESPACES_TESTS is
+        @test()
+
+        init() is si
+
+        get_mock_filesystem() -> IFileSystem is
+            let arguments = System.Array.empty`[object]();
+
+            return NSubstitute.Substitute.`for`[IFileSystem](arguments);
+        si
+
+        Calling__convert_file_name_to_identifier__with_name_containing_dashes__should_convert_dashes_to_underscores() is
+            @test()
+
+            let name = "some-file-name";
+
+            let object_under_test = new EXPAND_NAMESPACES(get_mock_filesystem());
+
+            let result = object_under_test.convert_file_name_to_identifier(name);
+
+            Assert.are_equal("some_file_name", result);
+        si
+
+        Calling__convert_file_name_to_identifier__with_name_containing_periods__should_convert_periods_to_underscores() is
+            @test()
+
+            let name = "some.file.name";
+
+            let object_under_test = new EXPAND_NAMESPACES(get_mock_filesystem());
+
+            let result = object_under_test.convert_file_name_to_identifier(name);
+
+            Assert.are_equal("some_file_name", result);
+        si
+        
+        Calling__convert_file_name_to_identifier__with_name_containing_special_chars__should_omit_them() is
+            @test()
+
+            let name = "some-file-name!@#$%^&*()+{}|:\"<>?[];',/`~";
+
+            let object_under_test = new EXPAND_NAMESPACES(get_mock_filesystem());
+
+            let result = object_under_test.convert_file_name_to_identifier(name);
+
+            Assert.are_equal("some_file_name", result);
+        si
+
+        Calling__convert_file_name_to_identifier__with_name_containing_underscores__should_pass_them_through() is
+            @test()
+
+            let name = "some_file_name";
+
+            let object_under_test = new EXPAND_NAMESPACES(get_mock_filesystem());
+
+            let result = object_under_test.convert_file_name_to_identifier(name);
+
+            Assert.are_equal("some_file_name", result);
+        si
+
+        Calling__convert_file_name_to_identifier__with_empty_name__should_return_empty_name() is
+            @test()
+
+            let name = "";
+
+            let object_under_test = new EXPAND_NAMESPACES(get_mock_filesystem());
+
+            let result = object_under_test.convert_file_name_to_identifier(name);
+
+            Assert.are_equal("", result);
+        si
+
+        Calling__convert_file_name_to_identifier__with_name_containing_digits__should_pass_them_through() is
+            @test()
+
+            let name = "some_file_name_123";
+
+            let object_under_test = new EXPAND_NAMESPACES(get_mock_filesystem());
+
+            let result = object_under_test.convert_file_name_to_identifier(name);
+
+            Assert.are_equal("some_file_name_123", result);
+        si
+
+        Calling__convert_file_name_to_identifier__with_name_starting_with_digit__should_prefix_with_backtick() is
+            @test()
+
+            let name = "123_some_file_name";
+
+            let object_under_test = new EXPAND_NAMESPACES(get_mock_filesystem());
+
+            let result = object_under_test.convert_file_name_to_identifier(name);
+
+            Assert.are_equal("`123_some_file_name", result);
+        si
+
+        Calling_get_namespace_name__with_absolute_uri_and_no_config__should_return_expected_namespace_name() is
+            @test()
+
+            let path = "/some/path/to/some-file-name.ghul";
+            let uri = "file://" + path;
+
+            let arguments = System.Array.empty`[object]();
+
+            let mock_file_system = NSubstitute.Substitute.`for`[IFileSystem](arguments);
+            let mock_path = NSubstitute.Substitute.`for`[IPath](arguments);
+            let mock_directory = NSubstitute.Substitute.`for`[IDirectory](arguments);
+            let mock_directory_info_factory = NSubstitute.Substitute.`for`[IDirectoryInfoFactory](arguments);
+
+            let mock_directory_info__some_path_to = NSubstitute.Substitute.`for`[IDirectoryInfo](arguments);
+            let mock_directory_info__some_path = NSubstitute.Substitute.`for`[IDirectoryInfo](arguments);
+            let mock_directory_info__some = NSubstitute.Substitute.`for`[IDirectoryInfo](arguments);
+            let mock_directory_info__root = NSubstitute.Substitute.`for`[IDirectoryInfo](arguments);
+
+            returns(mock_directory_info_factory.from_directory_name("/some/path/to"), mock_directory_info__some_path_to, null);
+            returns(mock_directory_info_factory.from_directory_name("/some/path"), mock_directory_info__some_path, null);
+            returns(mock_directory_info_factory.from_directory_name("/some"), mock_directory_info__some, null);
+            returns(mock_directory_info_factory.from_directory_name("/"), mock_directory_info__root, null);
+
+            returns(mock_directory_info__some_path_to.full_name, "/some/path/to", null);
+            returns(mock_directory_info__some_path_to.name, "to", null);
+            returns(mock_directory_info__some_path_to.parent, mock_directory_info__some_path, null);
+
+            returns(mock_directory_info__some_path.full_name, "/some/path", null);
+            returns(mock_directory_info__some_path.name, "path", null);
+            returns(mock_directory_info__some_path.parent, mock_directory_info__some, null);
+
+            returns(mock_directory_info__some.full_name, "/some", null);
+            returns(mock_directory_info__some.name, "some", null);
+            returns(mock_directory_info__some.parent, mock_directory_info__root, null);
+
+            returns(mock_directory_info__root.full_name, "/", null);
+            returns(mock_directory_info__root.name, "", null);
+            returns(mock_directory_info__root.parent, cast IDirectoryInfo(null), null);
+
+            returns(mock_file_system.path, mock_path, null);
+            returns(mock_file_system.directory, mock_directory, null);
+            returns(mock_file_system.directory_info, mock_directory_info_factory, null);
+
+            returns(mock_path.get_file_name_without_extension(path), "some-file-name", null);
+            returns(mock_path.get_directory_name(path), "/some/path/to", null);
+
+            returns(mock_path.combine("/some/path/to", "ghul.json"), "/some/path/to/ghul.json", null);
+            returns(mock_path.combine("/some/path", "ghul.json"), "/some/path/ghul.json", null);
+            returns(mock_path.combine("/some", "ghul.json"), "/some/ghul.json", null);
+            returns(mock_path.combine("/", "ghul.json"), "/ghul.json", null);
+            returns(mock_path.combine("", "ghul.json"), "ghul.json", null); // why is this being called?
+
+            returns(mock_path.get_path_root("/some/path/to"), "/", null);
+            returns(mock_path.get_path_root("/some/path"), "/", null);
+            returns(mock_path.get_path_root("/some"), "/", null);
+            returns(mock_path.get_path_root("/"), "/", null);
+            
+            returns(mock_directory.get_current_directory(), "/some/path/to", null);
+
+            let object_under_test = new EXPAND_NAMESPACES(mock_file_system);
+
+            let result = object_under_test.get_namespace_name(uri);
+
+            Assert.are_equal("__some__path__to__some_file_name", result);
+        si
+
+        Calling_get_namespace_name__with_windows_uri_and_no_config__should_return_expected_namespace_name() is
+            @test()
+
+            let path = "C:\\some\\path\\to\\some-file-name.ghul";
+            let uri = new System.Uri(path).absolute_uri;
+
+            let arguments = System.Array.empty`[object]();
+
+            let mock_file_system = NSubstitute.Substitute.`for`[IFileSystem](arguments);
+            let mock_path = NSubstitute.Substitute.`for`[IPath](arguments);
+            let mock_directory = NSubstitute.Substitute.`for`[IDirectory](arguments);
+            let mock_directory_info_factory = NSubstitute.Substitute.`for`[IDirectoryInfoFactory](arguments);
+
+            let mock_directory_info__some_path_to = NSubstitute.Substitute.`for`[IDirectoryInfo](arguments);
+            let mock_directory_info__some_path = NSubstitute.Substitute.`for`[IDirectoryInfo](arguments);
+            let mock_directory_info__some = NSubstitute.Substitute.`for`[IDirectoryInfo](arguments);
+            let mock_directory_info__root = NSubstitute.Substitute.`for`[IDirectoryInfo](arguments);
+
+            returns(mock_directory_info_factory.from_directory_name("c:\\some\\path\\to"), mock_directory_info__some_path_to, null);
+            returns(mock_directory_info_factory.from_directory_name("c:\\some\\path"), mock_directory_info__some_path, null);
+            returns(mock_directory_info_factory.from_directory_name("c:\\some"), mock_directory_info__some, null);
+            returns(mock_directory_info_factory.from_directory_name("c:\\"), mock_directory_info__root, null);
+
+            returns(mock_directory_info__some_path_to.full_name, "c:\\some\\path\\to", null);
+            returns(mock_directory_info__some_path_to.name, "to", null);
+            returns(mock_directory_info__some_path_to.parent, mock_directory_info__some_path, null);
+
+            returns(mock_directory_info__some_path.full_name, "c:\\some\\path", null);
+            returns(mock_directory_info__some_path.name, "path", null);
+            returns(mock_directory_info__some_path.parent, mock_directory_info__some, null);
+
+            returns(mock_directory_info__some.full_name, "c:\\some", null);
+            returns(mock_directory_info__some.name, "some", null);
+            returns(mock_directory_info__some.parent, mock_directory_info__root, null);
+
+            returns(mock_directory_info__root.full_name, "c:\\", null);
+            returns(mock_directory_info__root.name, "", null);
+            returns(mock_directory_info__root.parent, cast IDirectoryInfo(null), null);
+
+            returns(mock_file_system.path, mock_path, null);
+            returns(mock_file_system.directory, mock_directory, null);
+            returns(mock_file_system.directory_info, mock_directory_info_factory, null);
+
+            returns(mock_path.get_file_name_without_extension(path), "some-file-name", null);
+            returns(mock_path.get_directory_name(path), "c:\\some\\path\\to", null);
+
+            returns(mock_path.combine("c:\\some\\path\\to", "ghul.json"), "c:\\some\\path\\to\\ghul.json", null);
+            returns(mock_path.combine("c:\\some\\path", "ghul.json"), "c:\\some\\path\\ghul.json", null);
+            returns(mock_path.combine("c:\\some", "ghul.json"), "c:\\some\\ghul.json", null);
+            returns(mock_path.combine("c:\\", "ghul.json"), "c:\\ghul.json", null);
+            returns(mock_path.combine("", "ghul.json"), "ghul.json", null); // why is this being called?
+
+            returns(mock_path.get_path_root("c:\\some\\path\\to"), "c:\\", null);
+            returns(mock_path.get_path_root("c:\\some\\path"), "c:\\", null);
+            returns(mock_path.get_path_root("c:\\some"), "c:\\", null);
+            returns(mock_path.get_path_root("c:\\"), "c:\\", null);
+            
+            returns(mock_directory.get_current_directory(), "/some/path/to", null);
+
+            let object_under_test = new EXPAND_NAMESPACES(mock_file_system);
+
+            let result = object_under_test.get_namespace_name(uri);
+
+            Assert.are_equal("__some__path__to__some_file_name", result);
+        si
+
+
+        Calling_get_namespace_name__with_absolute_path_and_no_config__should_return_expected_namespace_name() is
+            @test()
+
+            let path = "/some/path/to/some-file-name.ghul";
+
+            let arguments = System.Array.empty`[object]();
+
+            let mock_file_system = NSubstitute.Substitute.`for`[IFileSystem](arguments);
+            let mock_path = NSubstitute.Substitute.`for`[IPath](arguments);
+            let mock_directory = NSubstitute.Substitute.`for`[IDirectory](arguments);
+            let mock_directory_info_factory = NSubstitute.Substitute.`for`[IDirectoryInfoFactory](arguments);
+
+            let mock_directory_info__some_path_to = NSubstitute.Substitute.`for`[IDirectoryInfo](arguments);
+            let mock_directory_info__some_path = NSubstitute.Substitute.`for`[IDirectoryInfo](arguments);
+            let mock_directory_info__some = NSubstitute.Substitute.`for`[IDirectoryInfo](arguments);
+            let mock_directory_info__root = NSubstitute.Substitute.`for`[IDirectoryInfo](arguments);
+
+            returns(mock_directory_info_factory.from_directory_name("/some/path/to"), mock_directory_info__some_path_to, null);
+            returns(mock_directory_info_factory.from_directory_name("/some/path"), mock_directory_info__some_path, null);
+            returns(mock_directory_info_factory.from_directory_name("/some"), mock_directory_info__some, null);
+            returns(mock_directory_info_factory.from_directory_name("/"), mock_directory_info__root, null);
+
+            returns(mock_directory_info__some_path_to.full_name, "/some/path/to", null);
+            returns(mock_directory_info__some_path_to.name, "to", null);
+            returns(mock_directory_info__some_path_to.parent, mock_directory_info__some_path, null);
+
+            returns(mock_directory_info__some_path.full_name, "/some/path", null);
+            returns(mock_directory_info__some_path.name, "path", null);
+            returns(mock_directory_info__some_path.parent, mock_directory_info__some, null);
+
+            returns(mock_directory_info__some.full_name, "/some", null);
+            returns(mock_directory_info__some.name, "some", null);
+            returns(mock_directory_info__some.parent, mock_directory_info__root, null);
+
+            returns(mock_directory_info__root.full_name, "/", null);
+            returns(mock_directory_info__root.name, "", null);
+            returns(mock_directory_info__root.parent, cast IDirectoryInfo(null), null);
+
+            returns(mock_file_system.path, mock_path, null);
+            returns(mock_file_system.directory, mock_directory, null);
+            returns(mock_file_system.directory_info, mock_directory_info_factory, null);
+
+            returns(mock_path.get_file_name_without_extension(path), "some-file-name", null);
+            returns(mock_path.get_directory_name(path), "/some/path/to", null);
+
+            returns(mock_path.combine("/some/path/to", "ghul.json"), "/some/path/to/ghul.json", null);
+            returns(mock_path.combine("/some/path", "ghul.json"), "/some/path/ghul.json", null);
+            returns(mock_path.combine("/some", "ghul.json"), "/some/ghul.json", null);
+            returns(mock_path.combine("/", "ghul.json"), "/ghul.json", null);
+            returns(mock_path.combine("", "ghul.json"), "ghul.json", null); // why is this being called?
+
+            returns(mock_path.get_path_root("/some/path/to"), "/", null);
+            returns(mock_path.get_path_root("/some/path"), "/", null);
+            returns(mock_path.get_path_root("/some"), "/", null);
+            returns(mock_path.get_path_root("/"), "/", null);
+
+            returns(mock_directory.get_current_directory(), "/some/path/to", null);
+
+            let object_under_test = new EXPAND_NAMESPACES(mock_file_system);
+
+            let result = object_under_test.get_namespace_name(path);
+
+            Assert.are_equal("__some__path__to__some_file_name", result);
+        si
+
+        Calling_get_namespace_name__with_ghul_json_below_root__should_return_expected_namespace_name() is
+            @test()
+
+            let path = "/some/path/to/some-file-name.ghul";
+
+            let arguments = System.Array.empty`[object]();
+
+            let mock_file_system = NSubstitute.Substitute.`for`[IFileSystem](arguments);
+            let mock_file = NSubstitute.Substitute.`for`[IFile](arguments);
+            let mock_path = NSubstitute.Substitute.`for`[IPath](arguments);
+            let mock_directory = NSubstitute.Substitute.`for`[IDirectory](arguments);
+            let mock_directory_info_factory = NSubstitute.Substitute.`for`[IDirectoryInfoFactory](arguments);
+
+            let mock_directory_info__some_path_to = NSubstitute.Substitute.`for`[IDirectoryInfo](arguments);
+            let mock_directory_info__some_path = NSubstitute.Substitute.`for`[IDirectoryInfo](arguments);
+            let mock_directory_info__some = NSubstitute.Substitute.`for`[IDirectoryInfo](arguments);
+            let mock_directory_info__root = NSubstitute.Substitute.`for`[IDirectoryInfo](arguments);
+
+            returns(mock_directory_info_factory.from_directory_name("/some/path/to"), mock_directory_info__some_path_to, null);
+            returns(mock_directory_info_factory.from_directory_name("/some/path"), mock_directory_info__some_path, null);
+            returns(mock_directory_info_factory.from_directory_name("/some"), mock_directory_info__some, null);
+            returns(mock_directory_info_factory.from_directory_name("/"), mock_directory_info__root, null);
+
+            returns(mock_directory_info__some_path_to.full_name, "/some/path/to", null);
+            returns(mock_directory_info__some_path_to.name, "to", null);
+            returns(mock_directory_info__some_path_to.parent, mock_directory_info__some_path, null);
+
+            returns(mock_directory_info__some_path.full_name, "/some/path", null);
+            returns(mock_directory_info__some_path.name, "path", null);
+            returns(mock_directory_info__some_path.parent, mock_directory_info__some, null);
+
+            returns(mock_directory_info__some.full_name, "/some", null);
+            returns(mock_directory_info__some.name, "some", null);
+            returns(mock_directory_info__some.parent, mock_directory_info__root, null);
+
+            returns(mock_directory_info__root.full_name, "/", null);
+            returns(mock_directory_info__root.name, "", null);
+            returns(mock_directory_info__root.parent, cast IDirectoryInfo(null), null);
+
+            returns(mock_file_system.path, mock_path, null);
+            returns(mock_file_system.file, mock_file, null);
+            returns(mock_file_system.directory, mock_directory, null);
+            returns(mock_file_system.directory_info, mock_directory_info_factory, null);
+
+            returns(mock_path.get_file_name_without_extension(path), "some-file-name", null);
+            returns(mock_path.get_directory_name(path), "/some/path/to", null);
+
+            returns(mock_path.combine("/some/path/to", "ghul.json"), "/some/path/to/ghul.json", null);
+            returns(mock_path.combine("/some/path", "ghul.json"), "/some/path/ghul.json", null);
+            returns(mock_path.combine("/some", "ghul.json"), "/some/ghul.json", null);
+            returns(mock_path.combine("/", "ghul.json"), "/ghul.json", null);
+            returns(mock_path.combine("", "ghul.json"), "ghul.json", null); // why is this being called?
+
+            returns(mock_path.get_path_root("/some/path/to"), "/", null);
+            returns(mock_path.get_path_root("/some/path"), "/", null);
+            returns(mock_path.get_path_root("/some"), "/", null);
+            returns(mock_path.get_path_root("/"), "/", null);
+
+            returns(mock_directory.get_current_directory(), "/some/path/to", null);
+
+            returns(mock_file.exists("/some/path/ghul.json"), true, null);
+
+            let object_under_test = new EXPAND_NAMESPACES(mock_file_system);
+
+            let result = object_under_test.get_namespace_name(path);
+
+            Assert.are_equal("path__to__some_file_name", result);
+        si
+
+        Calling_get_namespace_name__with_ghulproj_below_root__should_return_expected_namespace_name() is
+            @test()
+
+            let path = "/some/path/to/some-file-name.ghul";
+
+            let arguments = System.Array.empty`[object]();
+
+            let mock_file_system = NSubstitute.Substitute.`for`[IFileSystem](arguments);
+            let mock_file = NSubstitute.Substitute.`for`[IFile](arguments);
+            let mock_path = NSubstitute.Substitute.`for`[IPath](arguments);
+            let mock_directory = NSubstitute.Substitute.`for`[IDirectory](arguments);
+            let mock_directory_info_factory = NSubstitute.Substitute.`for`[IDirectoryInfoFactory](arguments);
+
+            let mock_directory_info__some_path_to = NSubstitute.Substitute.`for`[IDirectoryInfo](arguments);
+            let mock_directory_info__some_path = NSubstitute.Substitute.`for`[IDirectoryInfo](arguments);
+            let mock_directory_info__some = NSubstitute.Substitute.`for`[IDirectoryInfo](arguments);
+            let mock_directory_info__root = NSubstitute.Substitute.`for`[IDirectoryInfo](arguments);
+
+            returns(mock_directory_info_factory.from_directory_name("/some/path/to"), mock_directory_info__some_path_to, null);
+            returns(mock_directory_info_factory.from_directory_name("/some/path"), mock_directory_info__some_path, null);
+            returns(mock_directory_info_factory.from_directory_name("/some"), mock_directory_info__some, null);
+            returns(mock_directory_info_factory.from_directory_name("/"), mock_directory_info__root, null);
+
+            returns(mock_directory_info__some_path_to.full_name, "/some/path/to", null);
+            returns(mock_directory_info__some_path_to.name, "to", null);
+            returns(mock_directory_info__some_path_to.parent, mock_directory_info__some_path, null);
+
+            returns(mock_directory_info__some_path.full_name, "/some/path", null);
+            returns(mock_directory_info__some_path.name, "path", null);
+            returns(mock_directory_info__some_path.parent, mock_directory_info__some, null);
+
+            returns(mock_directory_info__some.full_name, "/some", null);
+            returns(mock_directory_info__some.name, "some", null);
+            returns(mock_directory_info__some.parent, mock_directory_info__root, null);
+
+            returns(mock_directory_info__root.full_name, "/", null);
+            returns(mock_directory_info__root.name, "", null);
+            returns(mock_directory_info__root.parent, cast IDirectoryInfo(null), null);
+
+            returns(mock_file_system.path, mock_path, null);
+            returns(mock_file_system.file, mock_file, null);
+            returns(mock_file_system.directory, mock_directory, null);
+            returns(mock_file_system.directory_info, mock_directory_info_factory, null);
+
+            returns(mock_path.get_file_name_without_extension(path), "some-file-name", null);
+            returns(mock_path.get_directory_name(path), "/some/path/to", null);
+
+            returns(mock_directory.get_current_directory(), "/some/path/to", null);
+
+            returns(mock_directory.get_files("/some/path", "*.ghulproj"), ["test.ghulproj"], null);
+
+            returns(mock_path.combine("/some/path/to", "ghul.json"), "/some/path/to/ghul.json", null);
+            returns(mock_path.combine("/some/path", "ghul.json"), "/some/path/ghul.json", null);
+            returns(mock_path.combine("/some", "ghul.json"), "/some/ghul.json", null);
+            returns(mock_path.combine("/", "ghul.json"), "/ghul.json", null);
+            returns(mock_path.combine("", "ghul.json"), "ghul.json", null); // why is this being called?
+
+            returns(mock_path.get_path_root("/some/path/to"), "/", null);
+            returns(mock_path.get_path_root("/some/path"), "/", null);
+            returns(mock_path.get_path_root("/some"), "/", null);
+            returns(mock_path.get_path_root("/"), "/", null);
+
+            returns(mock_file.exists("/some/path/ghul.json"), true, null);
+
+            let object_under_test = new EXPAND_NAMESPACES(mock_file_system);
+
+            let result = object_under_test.get_namespace_name(path);
+
+            Assert.are_equal("path__to__some_file_name", result);
+        si
+    si
+si

--- a/unit-tests/unit-tests.ghulproj
+++ b/unit-tests/unit-tests.ghulproj
@@ -11,6 +11,8 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="20.0.15" />
 
     <ProjectReference Include="../ghul.ghulproj" />
 


### PR DESCRIPTION
- Fix issue where defining global symbols outside of namespaces on Windows caused spurious errors