### PR TITLE
Remove transitive .NET 6 runtime dependency

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.6.12",
+      "version": "0.6.13",
       "commands": [
         "ghul-compiler"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "ghul.test": {
-      "version": "1.1.0",
+      "version": "1.1.2",
       "commands": [
         "ghul-test"
       ]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
 
   <ItemGroup>
     <PackageReference Include="ghul.targets" Version="1.2.1" />
-    <PackageReference Include="ghul.pipes" Version="1.0.0" />
-    <PackageReference Include="ghul.runtime" Version="1.0.0" />
+    <PackageReference Include="ghul.pipes" Version="1.1.0" />
+    <PackageReference Include="ghul.runtime" Version="1.1.0" />
   </ItemGroup>
 </Project>

--- a/src/driver/main.ghul
+++ b/src/driver/main.ghul
@@ -147,10 +147,6 @@ namespace Driver is
                 Std.error.write_line("!!! failed !!!");
             fi
             
-            // FIXME: the runtime should be doing this - wrapping the L stderr + stdout IO.Writers should not prevent them getting flushed:
-            Std.error.flush();
-            Std.out.flush();
-
             System.Environment.exit(result);
         si
 
@@ -373,8 +369,6 @@ namespace Driver is
             
             @IF.not.release()
             container.timers.start("il-asm");
-
-            Std.error.write_line("running ilasm: " + ilasm_path + " " + ilasm_args);
 
             let ilasm = System.Diagnostics.Process.start(ilasm_path, ilasm_args);
 

--- a/src/ioc/container.ghul
+++ b/src/ioc/container.ghul
@@ -403,6 +403,8 @@ namespace IoC is
                     value_boxer, 
                     innate_symbol_lookup);
 
+            function_caller.loader = symbol_loader;
+
             overload_resolver = new Semantic.OVERLOAD_RESOLVER(logger);
 
             symbol_use_locations = new Semantic.SYMBOL_USE_LOCATIONS();

--- a/src/logging/diagnostics_store.ghul
+++ b/src/logging/diagnostics_store.ghul
@@ -357,7 +357,7 @@ namespace Logging is
             od
         si
 
-        set_state(state: DIAGNOSTICS_STATE) is
+        merge(state: DIAGNOSTICS_STATE) is
             top.merge(state);
         si
 

--- a/src/logging/logger.ghul
+++ b/src/logging/logger.ghul
@@ -27,14 +27,7 @@ namespace Logging is
         mark() -> int;
         release(mark: int);
 
-        // FIXME: probably should be called 'merge()'
-        set_state(state: DIAGNOSTICS_STATE);
-
-        /*
-        set_state(writer: TextWriter, error_count: int, is_poisoned: bool);
-        write(text: string); 
-        write(text: string, error_count: int, is_poisoned: bool);
-        */
+        merge(state: DIAGNOSTICS_STATE);
 
         exception(location: LOCATION, exception: Exception, message: string);
         fatal(location: LOCATION, message: string);

--- a/src/semantic/dotnet/symbol_store.ghul
+++ b/src/semantic/dotnet/symbol_store.ghul
@@ -5,8 +5,6 @@ namespace Semantic.DotNet is
 
     use Collections.MAP;
 
-    // FIXME: rename this - it's not a cache - it's essential that symbols are interned for
-    // correct functioning of the type system:
     class SYMBOL_STORE is
         _symbols_by_dotnet_type: MAP[TYPE,Symbols.Scoped];
         _symbols_by_ghul_name: MAP[string,Symbols.Scoped];

--- a/src/semantic/dotnet/tuple_type_wrappers.ghul
+++ b/src/semantic/dotnet/tuple_type_wrappers.ghul
@@ -18,7 +18,7 @@ namespace Semantic.DotNet is
             self.names = names;
         si
 
-        // FIXME: requires type conversions in generated IL:
+        // FIXME: requires type conversions in generated IL (see #776):
         // get_argument_type_variance(index: int) -> Types.TYPE_VARIANCE => Types.TYPE_VARIANCE.COVARIANT;
 
         create(
@@ -43,7 +43,7 @@ namespace Semantic.DotNet is
             self.names = names; 
         si
 
-        // FIXME: requires type conversions in generated IL:
+        // FIXME: requires type conversions in generated IL (see #776):
         // get_argument_type_variance(index: int) -> Types.TYPE_VARIANCE => Types.TYPE_VARIANCE.COVARIANT;
 
         create(

--- a/src/semantic/dotnet/type_name_map.ghul
+++ b/src/semantic/dotnet/type_name_map.ghul
@@ -270,55 +270,5 @@ namespace Semantic.DotNet is
 
             return result;
         si
-
-        get_type_name(
-            name_map: MutableMap[string,string],
-            namespace_name_map: Map[string,string], 
-            qualified_name: string
-        ) -> string
-        is
-            let result: string;
-            
-            // First look for an exact mapping for the qualified name
-            if name_map.try_get_value(qualified_name, result ref) then
-                Std.error.write_line("MAP: manually mapped: " + qualified_name + " -> " + result);
-                return result;
-            fi
-
-            let type_name = new TYPE_NAME(qualified_name);
-
-            // Get the namespace name from the qualified name:
-            let namespace_name = type_name.namespace_name;
-
-            // Is the name qualified with a namespace?
-            if !namespace_name? then
-                Std.error.write_line("MAP: not qualified: " + qualified_name + " -> " + qualified_name);
-                return qualified_name;
-            fi
-
-            // Is the namespace name mapped to something else?
-            if namespace_name_map.try_get_value(namespace_name, result ref) then
-                Std.error.write_line("MAP: namespace mapped: " + qualified_name + " -> " + result + "." + type_name.name);
-                return result + "." + type_name.name;
-            fi
-
-            // no mapping:
-            Std.error.write_line("MAP: no mapping: " + qualified_name + " -> " + qualified_name);
-            return qualified_name;            
-        si
-
-        /*
-        get_ghul_type_name(type: TYPE) -> string =>
-            get_ghul_type_name(type.full_name);
-        
-        get_dotnet_type_name(qualified_name: string) -> string =>
-
-
-            get_type_name(ghul_to_dotnet_type_name_map, qualified_name);
-
-        get_ghul_type_name(qualified_name: string) -> string is
-            
-        si
-        */
     si
 si

--- a/src/semantic/function_caller.ghul
+++ b/src/semantic/function_caller.ghul
@@ -11,6 +11,10 @@ namespace Semantic is
         _symbol_table: SYMBOL_TABLE;
         _value_boxer: IR.VALUE_BOXER;
 
+        // public so container can initialize it to break a
+        // circular dependency:
+        loader: SYMBOL_LOADER public;
+
         init(
             symbol_table: SYMBOL_TABLE,
             value_boxer: IR.VALUE_BOXER
@@ -70,9 +74,6 @@ namespace Semantic is
             type: Type
         ) -> Value is
             if from == null then
-                // FIXME: IoC
-                let loader = IoC.CONTAINER.instance.symbol_loader;
-
                 from = loader.load_self(location);
             fi
 
@@ -98,9 +99,6 @@ namespace Semantic is
             type: Type
         ) -> Value is
             if from == null then
-                // FIXME: IoC
-                let loader = IoC.CONTAINER.instance.symbol_loader;
-
                 from = loader.load_self(location);
             else
                 from = new ADDRESS(from);
@@ -124,9 +122,6 @@ namespace Semantic is
             type: Type
         ) -> Value is
             if from == null then
-                // FIXME: IoC
-                let loader = IoC.CONTAINER.instance.symbol_loader;
-
                 from = loader.load_self(location);
             elif from.is_value_type then
                 from = new ADDRESS(from);

--- a/src/semantic/scope/block_scope.ghul
+++ b/src/semantic/scope/block_scope.ghul
@@ -117,7 +117,6 @@ namespace Semantic is
 
         declare_variable(location: LOCATION, name: string, is_static: bool, symbol_definition_listener: SymbolDefinitionListener) -> Symbol is
             // FIXME: IoC
-
             let owner = IoC.CONTAINER.instance.symbol_table.current_capture_context;
 
             let variable = new Symbols.LOCAL_VARIABLE(location, owner, name);

--- a/src/semantic/symbols/classy.ghul
+++ b/src/semantic/symbols/classy.ghul
@@ -319,11 +319,6 @@ namespace Semantic.Symbols is
         si
 
         gen_extends(buffer: StringBuilder) is
-            // FIXME: OOP?
-            if is_trait then
-                return;
-            fi            
-
             for ancestor in ancestors do
                 assert isa Types.NAMED(ancestor);
 
@@ -588,6 +583,10 @@ namespace Semantic.Symbols is
 
         gen_type_prefix(buffer: StringBuilder) is
             buffer.append("class ");
+        si
+
+        gen_extends(buffer: StringBuilder) is
+            // do nothing
         si
     si
 

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -1188,11 +1188,11 @@ namespace Syntax.Process is
                 binary.value = value;
             else
                 if binary_errors? /\ binary_errors.count > 0 then
-                    _logger.set_state(binary_errors);
+                    _logger.merge(binary_errors);
                 fi
 
                 if member_errors? /\ member_errors.count > 0 then
-                    _logger.set_state(member_errors);
+                    _logger.merge(member_errors);
                 fi
 
                 if (!binary_errors? \/ binary_errors.count == 0) /\ (!member_errors? \/ member_errors.count == 0) then


### PR DESCRIPTION
Bugs fixed:
- Update runtime and pipes dependencies to latest versions, removing a possible transitive dependency on .NET 6 (closes #1037)

Technical:
- Some minor code clean-ups