### PR TITLE
Add ghūl icon to README

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.6.14",
+      "version": "0.6.15",
       "commands": [
         "ghul-compiler"
       ]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 This is the compiler for the [ghūl programming language](https://ghul.dev). It is a [self-hosting compiler](https://en.wikipedia.org/wiki/Self-hosting_(compilers)): the compiler itself is written entirely in ghūl.
 
+![ghūl logo icon small](https://raw.githubusercontent.com/degory/ghul-dev/035cc6d3997514d03cbbd7b15133c37bf2a79f4e/src/.vuepress/public/ghul-logo-icon-128.png)
+
 ## Prerequisites
 
 The compiler requires the [.NET 8.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)

--- a/nuget-readme/README.md
+++ b/nuget-readme/README.md
@@ -10,6 +10,8 @@
 
 This package contains the [ghūl programming language](https://ghul.dev) [compiler](https://github.com/degory/ghul) packaged as a [.NET tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools)
 
+![ghūl logo icon small](https://raw.githubusercontent.com/degory/ghul-dev/035cc6d3997514d03cbbd7b15133c37bf2a79f4e/src/.vuepress/public/ghul-logo-icon-128.png)
+
 ## Prerequisites
 
 The compiler requires the [.NET 8.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)


### PR DESCRIPTION
Documentation:
- Add ghūl logo main README.md
- Add ghūl logo NuGet README.md

Both logo links point to the logo via a raw.githubusercontent.com link to a specific commit SHA, which should be both permanent and also trusted by NuGet.org for loading images from