### PR TITLE
Point Dependabot at repo root

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,6 @@
 version: 2
 updates:
   - package-ecosystem: "nuget"
-    directory: ".dependabot/"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "nuget"
-    directory: "unit-tests/.dependabot/"
+    directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
- Previously Dependabot was enabled for only the .dependabot and unit-tests/.dependabot directories, which meant it wasn't picking up the .NET local tools config.