### PR TITLE
Add a workflow to manually trigger Dependabot

### DIFF
--- a/.github/workflows/dependabot-manual-trigger.yml
+++ b/.github/workflows/dependabot-manual-trigger.yml
@@ -1,0 +1,17 @@
+name: Trigger Dependabot
+
+on:
+  workflow_dispatch:
+
+jobs:
+  trigger-dependabot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Dependabot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -X POST -H "Authorization: token $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/${{ github.repository }}/dispatches \
+          -d '{"event_type": "trigger-dependabot"}'


### PR DESCRIPTION
- Add a new GitHub Actions workflow that manually triggers Dependabot via the GitHub API