### PR TITLE
Dependabot config changes

### DIFF
--- a/.dependabot/ghul-dependabot.csproj
+++ b/.dependabot/ghul-dependabot.csproj
@@ -1,3 +1,11 @@
+<!--
+    Ensure Dependabot is triggered for this repository as
+    it doesn't recognize .ghulproj as a valid project file
+-->
+
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../ghul.ghulproj" />
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
 </Project>

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    allow:
+      - dependency-type: "all"
+    ignore:
+      # avoid potential endless loop of updates
+      # because the compiler is a dependency of the compiler
+      - dependency-name: "ghul.compiler"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,11 +1,12 @@
 <Project>
   <PropertyGroup>
     <Version>0.6.15-alpha.1</Version>
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ghul.targets" Version="1.2.4" />
-    <PackageReference Include="ghul.pipes" Version="1.1.2" />
-    <PackageReference Include="ghul.runtime" Version="1.1.0" />
+    <PackageReference Include="ghul.targets" />
+    <PackageReference Include="ghul.pipes" />
+    <PackageReference Include="ghul.runtime" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,26 @@
+<Project>
+  <ItemGroup>
+    <!-- ghūl MSBuild targets -->
+    <PackageVersion Include="ghul.targets" Version="1.2.4" />
+
+    <!-- ghūl runtime -->
+    <PackageVersion Include="ghul.pipes" Version="1.1.2" />
+    <PackageVersion Include="ghul.runtime" Version="1.1.0" />
+
+    <!-- ghūl compiler dependencies -->
+    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />
+    <PackageVersion Include="runtime.linux-x64.Microsoft.NETCore.ILAsm" Version="8.0.0" />
+    <PackageVersion Include="runtime.win-x64.Microsoft.NETCore.ILAsm" Version="8.0.0" />
+
+    <!-- unit test dependencies -->
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageVersion Include="Moq" Version="4.20.70" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.2.0" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.2.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="NSubstitute" Version="5.1.0" />
+
+    <!-- common dependencies -->
+    <PackageVersion Include="System.IO.Abstractions" Version="20.0.15" />
+  </ItemGroup>
+</Project>

--- a/ghul.ghulproj
+++ b/ghul.ghulproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+
     <!-- Framework -->
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
@@ -48,10 +50,10 @@
     <GhulOptions Include="--define release" Condition="'$(CI)' != ''" />
 
     <!-- Package dependencies -->
-    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />
-    <PackageReference Include="runtime.linux-x64.Microsoft.NETCore.ILAsm" Version="8.0.0" />
-    <PackageReference Include="runtime.win-x64.Microsoft.NETCore.ILAsm" Version="8.0.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="20.0.15" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" />
+    <PackageReference Include="runtime.linux-x64.Microsoft.NETCore.ILAsm" />
+    <PackageReference Include="runtime.win-x64.Microsoft.NETCore.ILAsm" />
+    <PackageReference Include="System.IO.Abstractions" />
 
     <!-- Build outputs -->
     <None Include="nuget-readme/README.md" Pack="true" PackagePath="\" />

--- a/unit-tests/.dependabot/unit-tests-dependabot.csproj
+++ b/unit-tests/.dependabot/unit-tests-dependabot.csproj
@@ -1,3 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../unit-tests.ghulproj" />
-</Project>

--- a/unit-tests/unit-tests.ghulproj
+++ b/unit-tests/unit-tests.ghulproj
@@ -1,20 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <GhulCompiler>dotnet ghul-compiler</GhulCompiler>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="20.0.15" />
-
     <ProjectReference Include="../ghul.ghulproj" />
+    
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
 
     <GhulSources Include="src/**/*.ghul" />
   </ItemGroup>


### PR DESCRIPTION
- Migrate to Directory.Packages.props to get all package dependencies into a single file
- Remove the unit tests dummy Dependabot .csproj file
- Replace the root dummy Dependabot .csproj file with a minimal one that doesn't import the .ghulproj
- Enable dotnet tool dependency updates with dependency-type 'all'
- Block Dependabot from updating the compiler tool to prevent endless update loops