### PR TITLE
Point Dependabot directly at its config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@
 version: 2
 updates:
   - package-ecosystem: "nuget"
-    directory: "/"
+    directory: ".dependabot/"
     schedule:
       interval: "daily"
     allow:


### PR DESCRIPTION
- Update Dependabot directory to point directly at .dependabot/ as it otherwise can't find its dummy .csproj file