### PR TITLE
Don't hide the dispose method in the Iterator[T] trait

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.6.15",
+      "version": "0.6.20",
       "commands": [
         "ghul-compiler"
       ]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.6.15-alpha.1</Version>
+    <Version>0.6.21-alpha.1</Version>
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
 

--- a/integration-tests/execution/ienumerator-boilerplate/test.ghul
+++ b/integration-tests/execution/ienumerator-boilerplate/test.ghul
@@ -76,6 +76,9 @@ namespace Test is
         si
         
         reset();
+
+        dispose() is            
+        si
     si
 
     struct GENERIC_STRUCT[T]: Iterator[T] is
@@ -96,6 +99,9 @@ namespace Test is
         si
         
         reset();
+
+        dispose() is
+        si
     si
 
     class INT_CLASS: Iterator[int] is
@@ -116,6 +122,9 @@ namespace Test is
         si
         
         reset();
+
+        dispose() is
+        si
     si
 
     class STRING_CLASS: Iterator[string] is
@@ -136,6 +145,9 @@ namespace Test is
         si
         
         reset();
+
+        dispose() is
+        si
     si
 
     struct INT_STRUCT: Iterator[int] is
@@ -156,6 +168,9 @@ namespace Test is
         si
         
         reset();
+
+        dispose() is
+        si
     si
 
     struct STRING_STRUCT: Iterator[string] is
@@ -176,5 +191,8 @@ namespace Test is
         si
 
         reset();
+
+        dispose() is
+        si
     si
 si

--- a/integration-tests/execution/implement-iterator/test.ghul
+++ b/integration-tests/execution/implement-iterator/test.ghul
@@ -1,20 +1,9 @@
 namespace Test is
-
-
-
-
-
-
-
-
-    use Std = IO.Std;
-
+    use IO.Std;
     use Collections;
     
     class Main is
         entry() static is
-            
-
             let things = new Things(20);
 
             for thing in things do
@@ -42,5 +31,7 @@ namespace Test is
         si
         
         reset();
+
+        dispose() is si
     si
 si

--- a/lib/dotnet/il/ienumerator-boilerplate.il
+++ b/lib/dotnet/il/ienumerator-boilerplate.il
@@ -7,10 +7,4 @@
 	    ldnull 
 	    ret 
     }
-
-    .method public final virtual hidebysig newslot instance default void Dispose ()  cil managed 
-    {
-	    .maxstack 8
-	    ret 
-    }
     // end IEnumerator boilerplate

--- a/src/semantic/dotnet/symbol_factory.ghul
+++ b/src/semantic/dotnet/symbol_factory.ghul
@@ -165,22 +165,8 @@ namespace Semantic.DotNet is
             elif type.is_interface then
                 result.add_ancestor(_type_mapper.get_type(_type_source.get_type("System.Object")));
             fi
-
-            let exclude_disposable = false;
-
-            if 
-                type.is_interface /\ 
-                type.is_generic_type /\ 
-                type.get_generic_type_definition() == _type_source.get_type("System.Collections.Generic.IEnumerator`1")
-            then
-                exclude_disposable = true;
-            fi
             
             for i in type.get_interfaces() do
-                if exclude_disposable /\ i == _type_source.get_type("System.IDisposable") then
-                    continue;
-                fi
-
                 result.add_ancestor(_type_mapper.get_type(i));
             od
 


### PR DESCRIPTION
Technical:
- Don't hide the `dispose()` method on `Collections.Iterator[T]`
- Don't emit an empty `dispose()` method for classes implementing `Iterator[T]`

Notes:
`Iterator[T]` is mapped from `System.Collections.Generic.IEnumerator<T>`, which inherits from `System.IDisposable`. For historic reasons the compiler was hiding the dispose method from `IDisposable` and was automatically giving classes that implemented `Iterator[T]` an empty implementation. This behavior is no longer needed, and is causing problems porting the ghūl pipes implementation from C# to ghūl.