### PR TITLE
Reference updated runtime library

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.6.21",
+      "version": "0.7.0",
       "commands": [
         "ghul-compiler"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "ghul.test": {
-      "version": "1.1.3",
+      "version": "1.2.0",
       "commands": [
         "ghul-test"
       ]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="ghul.targets" />
-    <PackageReference Include="ghul.pipes" />
     <PackageReference Include="ghul.runtime" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,7 @@
     <PackageVersion Include="ghul.targets" Version="1.2.4" />
 
     <!-- ghūl runtime -->
-    <PackageVersion Include="ghul.pipes" Version="1.1.3" />
-    <PackageVersion Include="ghul.runtime" Version="1.1.0" />
+    <PackageVersion Include="ghul.runtime" Version="1.2.0" />
 
     <!-- ghūl compiler dependencies -->
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />


### PR DESCRIPTION
Technical:
- Reference the updated ghūl runtime library that incorporates the ghūl port of ghul-pipes
- Remove the reference to the old C# ghul-pipes package