### PR TITLE
Drop reference to targets package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
         required: true
 
   pull_request:
+
   push:
     branches: [main]
 
@@ -22,7 +23,7 @@ env:
 jobs:
   version:
     name: Create a version number
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 1
     outputs:
       tag: ${{ steps.create_version.outputs.tag }}
@@ -47,7 +48,7 @@ jobs:
   unit_tests:
     name: Run unit tests
     needs: [version]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     container:
       image: mcr.microsoft.com/dotnet/sdk:8.0-jammy
@@ -73,7 +74,7 @@ jobs:
   bootstrap:
     name: Bootstrap compiler
     needs: [version]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     container:
       image: mcr.microsoft.com/dotnet/sdk:8.0-jammy
@@ -95,7 +96,7 @@ jobs:
         TAG_VERSION: ${{ needs.version.outputs.tag }}
         PACKAGE_VERSION: ${{ needs.version.outputs.package }}
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: ghul-compiler-package
         path: ./nupkg/ghul.compiler.${{ needs.version.outputs.package }}.nupkg
@@ -104,7 +105,7 @@ jobs:
     needs: [version, bootstrap]
     name: Run tests
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/dotnet/sdk:8.0-jammy
 
@@ -116,7 +117,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Download ghul.compiler package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: ghul-compiler-package
         path: nupkg
@@ -137,8 +138,7 @@ jobs:
     - name: Run integration tests
       run: bash -c "set -o pipefail ; dotnet ghul-test integration-tests | tee test-results.txt"
 
-    - uses: actions/upload-artifact@v2
-      if: ${{ always() }}
+    - uses: actions/upload-artifact@v4
       with:
         name: test-results
         path: test-results.txt
@@ -149,14 +149,14 @@ jobs:
 
     timeout-minutes: 5
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
     steps:
     - uses: actions/checkout@v3
 
     - name: Download ghul compiler tool package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: ghul-compiler-package
         path: nupkg
@@ -172,7 +172,7 @@ jobs:
     outputs:
       status: ${{ job.status }}
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     if: ${{ github.event_name != 'pull_request' }}
@@ -181,7 +181,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Download ghul.compiler package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: ghul-compiler-package
         path: nupkg
@@ -202,7 +202,7 @@ jobs:
   container_tests:
     needs: [version, build_container]
     name: Run tests in development container
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 6
 
     container:
@@ -233,7 +233,7 @@ jobs:
     - name: Run integration tests
       run: bash -c "set -o pipefail ; ghul-test integration-tests | tee test-results.txt"
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       if: ${{ always() }}
       with:
         name: container-test-results
@@ -242,7 +242,7 @@ jobs:
   tag_containers:
     needs: [version, container_tests]
     name: Tag containers
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     timeout-minutes: 5
 
@@ -291,7 +291,7 @@ jobs:
 
     timeout-minutes: 5
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: ${{ github.event_name != 'pull_request' }}
 
@@ -299,7 +299,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Download ghul compiler tool package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: ghul-compiler-package
         path: nupkg
@@ -317,7 +317,7 @@ jobs:
   create_release:
     needs: [version, container_tests, publish_release_package]
     name: Create release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     timeout-minutes: 5
     if: ${{ github.event_name != 'pull_request' || github.repository != 'degory/ghul' }}
@@ -326,7 +326,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Download ghul compiler tool package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: ghul-compiler-package
         path: nupkg

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,7 +17,7 @@ jobs:
       # will not occur.
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1.1.1
+        uses: dependabot/fetch-metadata@v1.6.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       # Here the PR gets approved.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ghul.targets" />
     <PackageReference Include="ghul.runtime" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,5 @@
 <Project>
   <ItemGroup>
-    <!-- ghūl MSBuild targets -->
-    <PackageVersion Include="ghul.targets" Version="1.2.4" />
-
     <!-- ghūl runtime -->
     <PackageVersion Include="ghul.runtime" Version="1.3.0" />
 


### PR DESCRIPTION
Technical:
- Drop the reference to the old separate ghūl MSBuild targets package, which is not needed now that the targets are included in the runtime library package
- Bump artifacts actions to latest in CI workflow
- Use ubuntu-latest instead of ubuntu-20.04 in CI workflow
- Bump Dependabot/fetch-metadata action to latest in Dependabot auto-merge workflow