### PR TITLE
Add runtime library compatibility tests

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "ghul.test": {
-      "version": "1.3.0",
+      "version": "1.3.1",
       "commands": [
         "ghul-test"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.7.2",
+      "version": "0.7.3",
       "commands": [
         "ghul-compiler"
       ]

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,28 @@
-*.l linguist-language=L
-*.ghul linguist-language=Ghul
-*.jay linguist-language=Jay
-*.y linguist-language=Bison
+* text=auto eol=lf
+
+*.ghul text eol=lf
+*.ghulproj eol=lf
+*.expected eol=lf
+*.warn eol=lf
+*.error eol=lf
+*.txt text eol=lf
+*.md text eol=lf
+*.html text eol=lf
+*.css text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.xml text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.cs text eol=lf
+*.sh text eol=lf
+*.bat text eol=lf
+*.cmd text eol=lf
+*.csv text eol=lf
+*.ts text eol=lf
+*.ini text eol=lf
+*.log text eol=lf
+
+*.png binary
+*.exe binary
+*.dll binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
 
   integration_tests:
     needs: [version, bootstrap]
-    name: Run tests
+    name: Run integration tests
 
     runs-on: ubuntu-latest
     container:

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -264,6 +264,15 @@
                 "showReuseMessage": true,
                 "clear": false
             }
+        },
+        {
+            "label": "Run all project tests",
+            "type": "shell",
+            "command": "dotnet ghul-test --use-dotnet-build project-tests",
+            "group": "test",
+            "dependsOn": [
+                "Publish"
+            ]
         }
     ]
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.7.3-alpha.51</Version>
+    <Version>0.7.4-alpha.52</Version>
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <ItemGroup>
     <!-- ghūl runtime -->
-    <PackageVersion Include="ghul.runtime" Version="1.3.0" />
+    <PackageVersion Include="ghul.runtime" Version="1.3.1" />
 
     <!-- ghūl compiler dependencies -->
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />

--- a/integration-tests/execution/abstract-function-throw/.vscode/tasks.json
+++ b/integration-tests/execution/abstract-function-throw/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/anon-function-fall-through-return/.vscode/tasks.json
+++ b/integration-tests/execution/anon-function-fall-through-return/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/anon-function-in-global-function/.vscode/tasks.json
+++ b/integration-tests/execution/anon-function-in-global-function/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/anonymous-function/.vscode/tasks.json
+++ b/integration-tests/execution/anonymous-function/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/arithmetic-byte/.vscode/tasks.json
+++ b/integration-tests/execution/arithmetic-byte/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/arithmetic-int/.vscode/tasks.json
+++ b/integration-tests/execution/arithmetic-int/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/arithmetic-long/.vscode/tasks.json
+++ b/integration-tests/execution/arithmetic-long/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/arithmetic-short/.vscode/tasks.json
+++ b/integration-tests/execution/arithmetic-short/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/arithmetic-ubyte/.vscode/tasks.json
+++ b/integration-tests/execution/arithmetic-ubyte/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/arithmetic-uint/.vscode/tasks.json
+++ b/integration-tests/execution/arithmetic-uint/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/arithmetic-ulong/.vscode/tasks.json
+++ b/integration-tests/execution/arithmetic-ulong/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/arithmetic-ushort/.vscode/tasks.json
+++ b/integration-tests/execution/arithmetic-ushort/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/arithmetic-uword/.vscode/tasks.json
+++ b/integration-tests/execution/arithmetic-uword/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/arithmetic-word/.vscode/tasks.json
+++ b/integration-tests/execution/arithmetic-word/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/array-argument/.vscode/tasks.json
+++ b/integration-tests/execution/array-argument/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/array-count/.vscode/tasks.json
+++ b/integration-tests/execution/array-count/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/assembly-import/.vscode/tasks.json
+++ b/integration-tests/execution/assembly-import/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/assert/.vscode/tasks.json
+++ b/integration-tests/execution/assert/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/base-class-static-method/.vscode/tasks.json
+++ b/integration-tests/execution/base-class-static-method/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/binary-operator-instance-method/.vscode/tasks.json
+++ b/integration-tests/execution/binary-operator-instance-method/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/boolean-short-circuit/.vscode/tasks.json
+++ b/integration-tests/execution/boolean-short-circuit/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/box-object-assign/.vscode/tasks.json
+++ b/integration-tests/execution/box-object-assign/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/box-object-return-value/.vscode/tasks.json
+++ b/integration-tests/execution/box-object-return-value/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/boxing-method-arguments/.vscode/tasks.json
+++ b/integration-tests/execution/boxing-method-arguments/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/built-in-types-type-argument-variance/.vscode/tasks.json
+++ b/integration-tests/execution/built-in-types-type-argument-variance/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/call-reference-parameters/.vscode/tasks.json
+++ b/integration-tests/execution/call-reference-parameters/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/call-struct-method-for-effect-1/.vscode/tasks.json
+++ b/integration-tests/execution/call-struct-method-for-effect-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/call-struct-method-for-effect-2/.vscode/tasks.json
+++ b/integration-tests/execution/call-struct-method-for-effect-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/case-in-loop/.vscode/tasks.json
+++ b/integration-tests/execution/case-in-loop/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/case-statement/.vscode/tasks.json
+++ b/integration-tests/execution/case-statement/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/class-generic-traits/.vscode/tasks.json
+++ b/integration-tests/execution/class-generic-traits/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/class-multiple-traits/.vscode/tasks.json
+++ b/integration-tests/execution/class-multiple-traits/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/closure-capture-local-variables/.vscode/tasks.json
+++ b/integration-tests/execution/closure-capture-local-variables/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/closure-fold-to-delegate-1/.vscode/tasks.json
+++ b/integration-tests/execution/closure-fold-to-delegate-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/closure-nested-capture-2/.vscode/tasks.json
+++ b/integration-tests/execution/closure-nested-capture-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/closure-nested-capture-3/.vscode/tasks.json
+++ b/integration-tests/execution/closure-nested-capture-3/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/closure-nested-capture-4/.vscode/tasks.json
+++ b/integration-tests/execution/closure-nested-capture-4/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/closure-nested-capture-5/.vscode/tasks.json
+++ b/integration-tests/execution/closure-nested-capture-5/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/closure-nested-capture-6/.vscode/tasks.json
+++ b/integration-tests/execution/closure-nested-capture-6/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/closure-nested-capture/.vscode/tasks.json
+++ b/integration-tests/execution/closure-nested-capture/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/collection-interop/.vscode/tasks.json
+++ b/integration-tests/execution/collection-interop/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/conditional-compilation-command-line/.vscode/tasks.json
+++ b/integration-tests/execution/conditional-compilation-command-line/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/conditional-compilation/.vscode/tasks.json
+++ b/integration-tests/execution/conditional-compilation/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/constrained-generic-type-call-1/.vscode/tasks.json
+++ b/integration-tests/execution/constrained-generic-type-call-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/constrained-generic-type-call-2/.vscode/tasks.json
+++ b/integration-tests/execution/constrained-generic-type-call-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/consume-iterator-traits/.vscode/tasks.json
+++ b/integration-tests/execution/consume-iterator-traits/.vscode/tasks.json
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/control-characters/.vscode/tasks.json
+++ b/integration-tests/execution/control-characters/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/control-flow/.vscode/tasks.json
+++ b/integration-tests/execution/control-flow/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/covariant-return-type/.vscode/tasks.json
+++ b/integration-tests/execution/covariant-return-type/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/do-loop/.vscode/tasks.json
+++ b/integration-tests/execution/do-loop/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/entry-point-command-line-arg-global-function/.vscode/tasks.json
+++ b/integration-tests/execution/entry-point-command-line-arg-global-function/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/enum/.vscode/tasks.json
+++ b/integration-tests/execution/enum/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/expression-bodied-functions/.vscode/tasks.json
+++ b/integration-tests/execution/expression-bodied-functions/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/expression-function-with-explicit-type-arguments-1/.vscode/tasks.json
+++ b/integration-tests/execution/expression-function-with-explicit-type-arguments-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/expression-function-with-explicit-type-arguments-2/.vscode/tasks.json
+++ b/integration-tests/execution/expression-function-with-explicit-type-arguments-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/expression-type-with-explicit-type-arguments-1/.vscode/tasks.json
+++ b/integration-tests/execution/expression-type-with-explicit-type-arguments-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/float-literals/.vscode/tasks.json
+++ b/integration-tests/execution/float-literals/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/floats/.vscode/tasks.json
+++ b/integration-tests/execution/floats/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/for-loop/.vscode/tasks.json
+++ b/integration-tests/execution/for-loop/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/generic-class-call-method/.vscode/tasks.json
+++ b/integration-tests/execution/generic-class-call-method/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/generic-instance-fields/.vscode/tasks.json
+++ b/integration-tests/execution/generic-instance-fields/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/generic-instance-properties/.vscode/tasks.json
+++ b/integration-tests/execution/generic-instance-properties/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/generic-type-argument-object-behaviour/.vscode/tasks.json
+++ b/integration-tests/execution/generic-type-argument-object-behaviour/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/global-functions-2/.vscode/tasks.json
+++ b/integration-tests/execution/global-functions-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/global-functions-3/.vscode/tasks.json
+++ b/integration-tests/execution/global-functions-3/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/global-functions-4/.vscode/tasks.json
+++ b/integration-tests/execution/global-functions-4/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/global-functions/.vscode/tasks.json
+++ b/integration-tests/execution/global-functions/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/hello-world/.vscode/tasks.json
+++ b/integration-tests/execution/hello-world/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/ienumerable-boilerplate/.vscode/tasks.json
+++ b/integration-tests/execution/ienumerable-boilerplate/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/ienumerator-boilerplate/.vscode/tasks.json
+++ b/integration-tests/execution/ienumerator-boilerplate/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/ilasm-failure/.vscode/tasks.json
+++ b/integration-tests/execution/ilasm-failure/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/implement-closed-iterable-trait/.vscode/tasks.json
+++ b/integration-tests/execution/implement-closed-iterable-trait/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/implement-generic-trait-with-actual-types/.vscode/tasks.json
+++ b/integration-tests/execution/implement-generic-trait-with-actual-types/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/implement-iterator-non-generic/.vscode/tasks.json
+++ b/integration-tests/execution/implement-iterator-non-generic/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/implement-iterator/.vscode/tasks.json
+++ b/integration-tests/execution/implement-iterator/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/implied-anonymous-function-argument-types-2/.vscode/tasks.json
+++ b/integration-tests/execution/implied-anonymous-function-argument-types-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/implied-anonymous-function-argument-types/.vscode/tasks.json
+++ b/integration-tests/execution/implied-anonymous-function-argument-types/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/innate-compare-order/.vscode/tasks.json
+++ b/integration-tests/execution/innate-compare-order/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/int-range-operators/.vscode/tasks.json
+++ b/integration-tests/execution/int-range-operators/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/int-range-traits/.vscode/tasks.json
+++ b/integration-tests/execution/int-range-traits/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/integer-literals/.vscode/tasks.json
+++ b/integration-tests/execution/integer-literals/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/isa/.vscode/tasks.json
+++ b/integration-tests/execution/isa/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/loop-try-catch-break-continue-2/.vscode/tasks.json
+++ b/integration-tests/execution/loop-try-catch-break-continue-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/loop-try-catch-break-continue/.vscode/tasks.json
+++ b/integration-tests/execution/loop-try-catch-break-continue/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/method-overload/.vscode/tasks.json
+++ b/integration-tests/execution/method-overload/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/method-override/.vscode/tasks.json
+++ b/integration-tests/execution/method-override/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/minimal/.vscode/tasks.json
+++ b/integration-tests/execution/minimal/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/named-tuple-elements/.vscode/tasks.json
+++ b/integration-tests/execution/named-tuple-elements/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/nested-do-loops/.vscode/tasks.json
+++ b/integration-tests/execution/nested-do-loops/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/nested-short-circuit-bool-operators/.vscode/tasks.json
+++ b/integration-tests/execution/nested-short-circuit-bool-operators/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/new-minimal/.vscode/tasks.json
+++ b/integration-tests/execution/new-minimal/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/overload-resolution-2/.vscode/tasks.json
+++ b/integration-tests/execution/overload-resolution-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/overload-resolution-3/.vscode/tasks.json
+++ b/integration-tests/execution/overload-resolution-3/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/overload-resolution/.vscode/tasks.json
+++ b/integration-tests/execution/overload-resolution/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/override-same-return-type/.vscode/tasks.json
+++ b/integration-tests/execution/override-same-return-type/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/property-auto-body/.vscode/tasks.json
+++ b/integration-tests/execution/property-auto-body/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/property-inheritance/.vscode/tasks.json
+++ b/integration-tests/execution/property-inheritance/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/property-super-accessor-call/.vscode/tasks.json
+++ b/integration-tests/execution/property-super-accessor-call/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/reference-equality/.vscode/tasks.json
+++ b/integration-tests/execution/reference-equality/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/reflected-enum-equals/.vscode/tasks.json
+++ b/integration-tests/execution/reflected-enum-equals/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/sequence-indexer/.vscode/tasks.json
+++ b/integration-tests/execution/sequence-indexer/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/sequence-iterator/.vscode/tasks.json
+++ b/integration-tests/execution/sequence-iterator/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/sequence-literal/.vscode/tasks.json
+++ b/integration-tests/execution/sequence-literal/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/sequence-mixed-types/.vscode/tasks.json
+++ b/integration-tests/execution/sequence-mixed-types/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/static-anon-functions/.vscode/tasks.json
+++ b/integration-tests/execution/static-anon-functions/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/string-add/.vscode/tasks.json
+++ b/integration-tests/execution/string-add/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/string-equals/.vscode/tasks.json
+++ b/integration-tests/execution/string-equals/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/string-reference-equality/.vscode/tasks.json
+++ b/integration-tests/execution/string-reference-equality/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/struct-generic-traits/.vscode/tasks.json
+++ b/integration-tests/execution/struct-generic-traits/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/struct-get-type/.vscode/tasks.json
+++ b/integration-tests/execution/struct-get-type/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/struct-methods/.vscode/tasks.json
+++ b/integration-tests/execution/struct-methods/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/struct-multiple-traits/.vscode/tasks.json
+++ b/integration-tests/execution/struct-multiple-traits/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/struct-return-self-as-trait/.vscode/tasks.json
+++ b/integration-tests/execution/struct-return-self-as-trait/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/struct-static-members/.vscode/tasks.json
+++ b/integration-tests/execution/struct-static-members/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/super-method-call/.vscode/tasks.json
+++ b/integration-tests/execution/super-method-call/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/thread/.vscode/tasks.json
+++ b/integration-tests/execution/thread/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/throw-object/.vscode/tasks.json
+++ b/integration-tests/execution/throw-object/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/to-string/.vscode/tasks.json
+++ b/integration-tests/execution/to-string/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/trait-derived-from-trait/.vscode/tasks.json
+++ b/integration-tests/execution/trait-derived-from-trait/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/trait-isa/.vscode/tasks.json
+++ b/integration-tests/execution/trait-isa/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/trait-method-call/.vscode/tasks.json
+++ b/integration-tests/execution/trait-method-call/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/try-catch-finally/.vscode/tasks.json
+++ b/integration-tests/execution/try-catch-finally/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/try-catch/.vscode/tasks.json
+++ b/integration-tests/execution/try-catch/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/try-return/.vscode/tasks.json
+++ b/integration-tests/execution/try-return/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/tuple-explicit-element-type-assignment-compatible/.vscode/tasks.json
+++ b/integration-tests/execution/tuple-explicit-element-type-assignment-compatible/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/tuples/.vscode/tasks.json
+++ b/integration-tests/execution/tuples/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/typeof/.vscode/tasks.json
+++ b/integration-tests/execution/typeof/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/use-symbols/.vscode/tasks.json
+++ b/integration-tests/execution/use-symbols/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/void-anon-functions/.vscode/tasks.json
+++ b/integration-tests/execution/void-anon-functions/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/while-anon-function-condition-1/.vscode/tasks.json
+++ b/integration-tests/execution/while-anon-function-condition-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution/while-anon-function-condition-2/.vscode/tasks.json
+++ b/integration-tests/execution/while-anon-function-condition-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/boolean-literals/.vscode/tasks.json
+++ b/integration-tests/il/boolean-literals/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/cast-numeric-types/.vscode/tasks.json
+++ b/integration-tests/il/cast-numeric-types/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/control-flow-break-continue/.vscode/tasks.json
+++ b/integration-tests/il/control-flow-break-continue/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/control-flow-if/.vscode/tasks.json
+++ b/integration-tests/il/control-flow-if/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/control-flow-while/.vscode/tasks.json
+++ b/integration-tests/il/control-flow-while/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/def-class-implement-trait/.vscode/tasks.json
+++ b/integration-tests/il/def-class-implement-trait/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/def-class-implement-traits/.vscode/tasks.json
+++ b/integration-tests/il/def-class-implement-traits/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/def-class-minimal/.vscode/tasks.json
+++ b/integration-tests/il/def-class-minimal/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/def-class-superclass-and-traits/.vscode/tasks.json
+++ b/integration-tests/il/def-class-superclass-and-traits/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/def-class-superclass/.vscode/tasks.json
+++ b/integration-tests/il/def-class-superclass/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/def-field-instance/.vscode/tasks.json
+++ b/integration-tests/il/def-field-instance/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/def-function-fall-through-returns/.vscode/tasks.json
+++ b/integration-tests/il/def-function-fall-through-returns/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/def-function-instance-args-innate-types/.vscode/tasks.json
+++ b/integration-tests/il/def-function-instance-args-innate-types/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/def-function-instance-il-name-override/.vscode/tasks.json
+++ b/integration-tests/il/def-function-instance-il-name-override/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/def-function-instance-minimal/.vscode/tasks.json
+++ b/integration-tests/il/def-function-instance-minimal/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/def-function-static/.vscode/tasks.json
+++ b/integration-tests/il/def-function-static/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/def-generic-class/.vscode/tasks.json
+++ b/integration-tests/il/def-generic-class/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/def-namespace-class-method/.vscode/tasks.json
+++ b/integration-tests/il/def-namespace-class-method/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/def-namespace-minimal/.vscode/tasks.json
+++ b/integration-tests/il/def-namespace-minimal/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/def-namespace-nested/.vscode/tasks.json
+++ b/integration-tests/il/def-namespace-nested/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/def-namespace-qualified-name/.vscode/tasks.json
+++ b/integration-tests/il/def-namespace-qualified-name/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/def-override-should-inherit-il-name/.vscode/tasks.json
+++ b/integration-tests/il/def-override-should-inherit-il-name/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/def-trait-method/.vscode/tasks.json
+++ b/integration-tests/il/def-trait-method/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/def-variable-initializer/.vscode/tasks.json
+++ b/integration-tests/il/def-variable-initializer/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/def-variable-instance/.vscode/tasks.json
+++ b/integration-tests/il/def-variable-instance/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/def-variable-static/.vscode/tasks.json
+++ b/integration-tests/il/def-variable-static/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/empty-try-finally/.vscode/tasks.json
+++ b/integration-tests/il/empty-try-finally/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/entry-point-command-line-arg-class-static/.vscode/tasks.json
+++ b/integration-tests/il/entry-point-command-line-arg-class-static/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/entry-point-command-line-arg-global-function/.vscode/tasks.json
+++ b/integration-tests/il/entry-point-command-line-arg-global-function/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/entry-point-default-class-static-method/.vscode/tasks.json
+++ b/integration-tests/il/entry-point-default-class-static-method/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/entry-point-default-global-function/.vscode/tasks.json
+++ b/integration-tests/il/entry-point-default-global-function/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/entry-point-named-class-static-method/.vscode/tasks.json
+++ b/integration-tests/il/entry-point-named-class-static-method/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/entry-point-named-global-function/.vscode/tasks.json
+++ b/integration-tests/il/entry-point-named-global-function/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/enum/.vscode/tasks.json
+++ b/integration-tests/il/enum/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/field-load-store/.vscode/tasks.json
+++ b/integration-tests/il/field-load-store/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/float-literals/.vscode/tasks.json
+++ b/integration-tests/il/float-literals/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/generic-function-definition/.vscode/tasks.json
+++ b/integration-tests/il/generic-function-definition/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/generic-instance-fields/.vscode/tasks.json
+++ b/integration-tests/il/generic-instance-fields/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/generic-instance-properties/.vscode/tasks.json
+++ b/integration-tests/il/generic-instance-properties/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/innate-bool-short-circuit/.vscode/tasks.json
+++ b/integration-tests/il/innate-bool-short-circuit/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/innate-compare-order/.vscode/tasks.json
+++ b/integration-tests/il/innate-compare-order/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/operations-arithmetic-byte/.vscode/tasks.json
+++ b/integration-tests/il/operations-arithmetic-byte/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/operations-arithmetic-int/.vscode/tasks.json
+++ b/integration-tests/il/operations-arithmetic-int/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/operations-arithmetic-integer/.vscode/tasks.json
+++ b/integration-tests/il/operations-arithmetic-integer/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/operations-arithmetic-long/.vscode/tasks.json
+++ b/integration-tests/il/operations-arithmetic-long/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/operations-arithmetic-short/.vscode/tasks.json
+++ b/integration-tests/il/operations-arithmetic-short/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/operations-arithmetic-ubyte/.vscode/tasks.json
+++ b/integration-tests/il/operations-arithmetic-ubyte/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/operations-arithmetic-uint/.vscode/tasks.json
+++ b/integration-tests/il/operations-arithmetic-uint/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/operations-arithmetic-ulong/.vscode/tasks.json
+++ b/integration-tests/il/operations-arithmetic-ulong/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/operations-arithmetic-ushort/.vscode/tasks.json
+++ b/integration-tests/il/operations-arithmetic-ushort/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/operations-arithmetic-uword/.vscode/tasks.json
+++ b/integration-tests/il/operations-arithmetic-uword/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/operations-arithmetic-word/.vscode/tasks.json
+++ b/integration-tests/il/operations-arithmetic-word/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/output-pragma/.vscode/tasks.json
+++ b/integration-tests/il/output-pragma/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/property-definition/.vscode/tasks.json
+++ b/integration-tests/il/property-definition/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/property-il-names/.vscode/tasks.json
+++ b/integration-tests/il/property-il-names/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/ref-operator/.vscode/tasks.json
+++ b/integration-tests/il/ref-operator/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/struct-get-type/.vscode/tasks.json
+++ b/integration-tests/il/struct-get-type/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/throw-box-value/.vscode/tasks.json
+++ b/integration-tests/il/throw-box-value/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/throw-exception/.vscode/tasks.json
+++ b/integration-tests/il/throw-exception/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/try-break-continue/.vscode/tasks.json
+++ b/integration-tests/il/try-break-continue/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/try-catch-exception/.vscode/tasks.json
+++ b/integration-tests/il/try-catch-exception/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/try-catch-exceptions-finally/.vscode/tasks.json
+++ b/integration-tests/il/try-catch-exceptions-finally/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/try-catch-exceptions/.vscode/tasks.json
+++ b/integration-tests/il/try-catch-exceptions/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/try-finally/.vscode/tasks.json
+++ b/integration-tests/il/try-finally/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/typeof/.vscode/tasks.json
+++ b/integration-tests/il/typeof/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/il/variable-base-class/.vscode/tasks.json
+++ b/integration-tests/il/variable-base-class/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/additional-input-at-end-of-file/.vscode/tasks.json
+++ b/integration-tests/parse/additional-input-at-end-of-file/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/assert/.vscode/tasks.json
+++ b/integration-tests/parse/assert/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/carriage-returns/.vscode/tasks.json
+++ b/integration-tests/parse/carriage-returns/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/definition-pragma-1/.vscode/tasks.json
+++ b/integration-tests/parse/definition-pragma-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/expression-function-with-explicit-type-arguments-1/.vscode/tasks.json
+++ b/integration-tests/parse/expression-function-with-explicit-type-arguments-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/expression-function-with-explicit-type-arguments-2/.vscode/tasks.json
+++ b/integration-tests/parse/expression-function-with-explicit-type-arguments-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/expression-function-with-explicit-type-arguments-3/.vscode/tasks.json
+++ b/integration-tests/parse/expression-function-with-explicit-type-arguments-3/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/expression-function-with-explicit-type-arguments-3/err.expected
+++ b/integration-tests/parse/expression-function-with-explicit-type-arguments-3/err.expected
@@ -1,2 +1,2 @@
-test.ghul: 11,37..11,39: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, none, null, self, string literal, super, true or typeof but found []
+test.ghul: 11,37..11,39: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, null, self, string literal, super, true or typeof but found []
 test.ghul: 11,37..11,39: error: syntax error: expected ; but found []

--- a/integration-tests/parse/expression-function-with-explicit-type-arguments-3/test.ghul
+++ b/integration-tests/parse/expression-function-with-explicit-type-arguments-3/test.ghul
@@ -16,12 +16,15 @@ namespace Test is
         // and so we're attempting to call an indexer with the type 'int' as the paramter        
         let b: int = Main.function` [int]();
 
+        // FIXME: this is syntactically valid, but results in parse errors
+        // when placed here after the previous let statement
+        // let c: (int, int) = Main.function` [(int, int)]((1, 2));
+
         let d: string = "hello";
     si
     
     other() static is
-        // FIXME: this is syntactically valid, but results in parse errors placed
-        // after let b in previous function: 
+        // syntactically valid, but semantically invalid: 
         let c: (int, int) = Main.function` [(int, int)]((1, 2));
 
         return;

--- a/integration-tests/parse/expression-function-with-explicit-type-arguments-4/.vscode/tasks.json
+++ b/integration-tests/parse/expression-function-with-explicit-type-arguments-4/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/expression-function-with-explicit-type-arguments-5/.vscode/tasks.json
+++ b/integration-tests/parse/expression-function-with-explicit-type-arguments-5/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/expression-function-with-explicit-type-arguments-6/.vscode/tasks.json
+++ b/integration-tests/parse/expression-function-with-explicit-type-arguments-6/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/expression-function-with-explicit-type-arguments-6/err.expected
+++ b/integration-tests/parse/expression-function-with-explicit-type-arguments-6/err.expected
@@ -1,2 +1,2 @@
-test.ghul: 15,37..15,39: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, none, null, self, string literal, super, true or typeof but found []
+test.ghul: 15,37..15,39: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, null, self, string literal, super, true or typeof but found []
 test.ghul: 15,37..15,39: error: syntax error: expected ; but found []

--- a/integration-tests/parse/expression-type-with-explicit-type-arguments-1/.vscode/tasks.json
+++ b/integration-tests/parse/expression-type-with-explicit-type-arguments-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/expression-type-with-explicit-type-arguments-2/.vscode/tasks.json
+++ b/integration-tests/parse/expression-type-with-explicit-type-arguments-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/expression-type-with-explicit-type-arguments-3/.vscode/tasks.json
+++ b/integration-tests/parse/expression-type-with-explicit-type-arguments-3/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/expression-type-with-explicit-type-arguments-4/.vscode/tasks.json
+++ b/integration-tests/parse/expression-type-with-explicit-type-arguments-4/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/expression-type-with-explicit-type-arguments-5/.vscode/tasks.json
+++ b/integration-tests/parse/expression-type-with-explicit-type-arguments-5/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/expression-type-with-explicit-type-arguments-6/.vscode/tasks.json
+++ b/integration-tests/parse/expression-type-with-explicit-type-arguments-6/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/generic-function-1/.vscode/tasks.json
+++ b/integration-tests/parse/generic-function-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-call-1/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-call-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-call-1/err.expected
+++ b/integration-tests/parse/incomplete-call-1/err.expected
@@ -1,4 +1,4 @@
 test.ghul: 7,13..7,17: error: symbol not found: blah
-test.ghul: 8,9..8,11: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, none, null, self, string literal, super, true or typeof but found si
+test.ghul: 8,9..8,11: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, null, self, string literal, super, true or typeof but found si
 test.ghul: 8,9..8,11: error: in secondary expression: expected ) but found si
 test.ghul: 8,9..8,11: error: syntax error: expected ; but found si

--- a/integration-tests/parse/incomplete-class-1/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-class-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-class-10/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-class-10/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-class-11/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-class-11/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-class-12/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-class-12/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-class-13/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-class-13/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-class-14/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-class-14/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-class-2/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-class-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-class-3/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-class-3/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-class-4/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-class-4/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-class-5/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-class-5/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-class-6/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-class-6/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-class-7/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-class-7/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-class-8/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-class-8/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-class-9/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-class-9/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-enum-1/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-enum-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-enum-10/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-enum-10/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-enum-2/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-enum-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-enum-3/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-enum-3/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-enum-4/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-enum-4/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-enum-5/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-enum-5/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-enum-6/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-enum-6/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-enum-6/err.expected
+++ b/integration-tests/parse/incomplete-enum-6/err.expected
@@ -1,1 +1,1 @@
-test.ghul: 8,1..8,2: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, none, null, self, string literal, super, true or typeof but found si
+test.ghul: 8,1..8,2: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, null, self, string literal, super, true or typeof but found si

--- a/integration-tests/parse/incomplete-enum-7/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-enum-7/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-enum-8/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-enum-8/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-enum-9/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-enum-9/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-for-1/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-for-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-for-10/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-for-10/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-for-10/err.expected
+++ b/integration-tests/parse/incomplete-for-10/err.expected
@@ -1,1 +1,1 @@
-test.ghul: 2,14..2,16: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, none, null, self, string literal, super, true or typeof but found do
+test.ghul: 2,14..2,16: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, null, self, string literal, super, true or typeof but found do

--- a/integration-tests/parse/incomplete-for-11/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-for-11/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-for-12/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-for-12/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-for-2/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-for-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-for-3/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-for-3/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-for-3/err.expected
+++ b/integration-tests/parse/incomplete-for-3/err.expected
@@ -1,1 +1,1 @@
-test.ghul: 4,1..4,3: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, none, null, self, string literal, super, true or typeof but found si
+test.ghul: 4,1..4,3: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, null, self, string literal, super, true or typeof but found si

--- a/integration-tests/parse/incomplete-for-4/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-for-4/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-for-4/err.expected
+++ b/integration-tests/parse/incomplete-for-4/err.expected
@@ -1,2 +1,2 @@
 test.ghul: 4,1..4,3: error: in for statement: expected do but found si
-test.ghul: 4,1..4,3: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, none, null, self, string literal, super, true or typeof but found si
+test.ghul: 4,1..4,3: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, null, self, string literal, super, true or typeof but found si

--- a/integration-tests/parse/incomplete-for-5/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-for-5/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-for-6/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-for-6/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-for-7/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-for-7/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-for-8/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-for-8/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-for-9/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-for-9/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-function-1/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-function-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-function-2/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-function-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-function-3/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-function-3/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-function-4/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-function-4/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-function-5/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-function-5/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-function-6/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-function-6/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-function-7/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-function-7/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-function-8/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-function-8/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-if-1/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-if-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-if-1/err.expected
+++ b/integration-tests/parse/incomplete-if-1/err.expected
@@ -1,2 +1,2 @@
-test.ghul: 8,9..8,11: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, none, null, self, string literal, super, true or typeof but found si
+test.ghul: 8,9..8,11: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, null, self, string literal, super, true or typeof but found si
 test.ghul: 8,9..8,11: error: syntax error: expected then but found si

--- a/integration-tests/parse/incomplete-if-1/test.ghul
+++ b/integration-tests/parse/incomplete-if-1/test.ghul
@@ -1,4 +1,4 @@
-namespace Test.ParseUnary is
+namespace Test.ParseIncompleteIf is
     
     class Test is
         test() is

--- a/integration-tests/parse/incomplete-if-2/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-if-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-if-3/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-if-3/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-if-4/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-if-4/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-if-5/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-if-5/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-member-definition-1/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-member-definition-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-member-expression-1/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-member-expression-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-member-expression-2/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-member-expression-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-member-expression-3/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-member-expression-3/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-member-expression-3/incomplete-member-expression-2/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-member-expression-3/incomplete-member-expression-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-namespace-1/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-namespace-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-namespace-2/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-namespace-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-namespace-3/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-namespace-3/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-namespace-4/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-namespace-4/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-namespace-5/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-namespace-5/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-namespace-6/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-namespace-6/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-namespace-7/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-namespace-7/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-property-1/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-property-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-property-10/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-property-10/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-property-11/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-property-11/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-property-12/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-property-12/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-property-13/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-property-13/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-property-14/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-property-14/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-property-14/err.expected
+++ b/integration-tests/parse/incomplete-property-14/err.expected
@@ -1,2 +1,2 @@
-test.ghul: 5,5..5,7: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, none, null, self, string literal, super, true or typeof but found si
+test.ghul: 5,5..5,7: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, null, self, string literal, super, true or typeof but found si
 test.ghul: 5,5..5,7: error: syntax error: expected ; but found si

--- a/integration-tests/parse/incomplete-property-14/test.ghul
+++ b/integration-tests/parse/incomplete-property-14/test.ghul
@@ -1,4 +1,4 @@
-namespace Test.ParseUnary is
+namespace Test.ParseIncompleteProperty is
     
     class Test is
         property: int = value is si, =>

--- a/integration-tests/parse/incomplete-property-15/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-property-15/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-property-15/err.expected
+++ b/integration-tests/parse/incomplete-property-15/err.expected
@@ -1,2 +1,2 @@
-test.ghul: 6,5..6,7: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, none, null, self, string literal, super, true or typeof but found si
+test.ghul: 6,5..6,7: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, null, self, string literal, super, true or typeof but found si
 test.ghul: 6,5..6,7: error: syntax error: expected ; but found si

--- a/integration-tests/parse/incomplete-property-16/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-property-16/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-property-17/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-property-17/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-property-2/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-property-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-property-3/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-property-3/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-property-3/err.expected
+++ b/integration-tests/parse/incomplete-property-3/err.expected
@@ -1,2 +1,2 @@
-test.ghul: 5,5..5,7: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, none, null, self, string literal, super, true or typeof but found si
+test.ghul: 5,5..5,7: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, null, self, string literal, super, true or typeof but found si
 test.ghul: 5,5..5,7: error: syntax error: expected ; but found si

--- a/integration-tests/parse/incomplete-property-3/test.ghul
+++ b/integration-tests/parse/incomplete-property-3/test.ghul
@@ -1,4 +1,4 @@
-namespace Test.ParseUnary is
+namespace Test.ParseIncompleteProperty is
     
     class Test is
         property: int =>

--- a/integration-tests/parse/incomplete-property-4/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-property-4/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-property-4/err.expected
+++ b/integration-tests/parse/incomplete-property-4/err.expected
@@ -1,2 +1,2 @@
-test.ghul: 6,5..6,7: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, none, null, self, string literal, super, true or typeof but found si
+test.ghul: 6,5..6,7: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, null, self, string literal, super, true or typeof but found si
 test.ghul: 6,5..6,7: error: syntax error: expected ; but found si

--- a/integration-tests/parse/incomplete-property-4/test.ghul
+++ b/integration-tests/parse/incomplete-property-4/test.ghul
@@ -1,4 +1,4 @@
-namespace Test.ParseUnary is
+namespace Test.ParseIncompleteProperty is
     use Collections;
 
     class Test is

--- a/integration-tests/parse/incomplete-property-5/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-property-5/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-property-6/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-property-6/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-property-7/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-property-7/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-property-8/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-property-8/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-property-9/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-property-9/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-trait-1/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-trait-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-try-1/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-try-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-try-10/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-try-10/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-try-11/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-try-11/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-try-12/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-try-12/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-try-2/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-try-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-try-3/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-try-3/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-try-4/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-try-4/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-try-5/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-try-5/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-try-6/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-try-6/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-try-7/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-try-7/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-try-8/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-try-8/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-try-9/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-try-9/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-type-1/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-type-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-use-1/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-use-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-use-2/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-use-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-use-3/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-use-3/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-use-4/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-use-4/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-use-5/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-use-5/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-use-6/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-use-6/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-use-7/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-use-7/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-variable-1/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-variable-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-variable-10/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-variable-10/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-variable-2/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-variable-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-variable-3/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-variable-3/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-variable-4/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-variable-4/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-variable-5/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-variable-5/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-variable-5/err.expected
+++ b/integration-tests/parse/incomplete-variable-5/err.expected
@@ -1,2 +1,2 @@
-test.ghul: 7,9..7,11: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, none, null, self, string literal, super, true or typeof but found si
+test.ghul: 7,9..7,11: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, null, self, string literal, super, true or typeof but found si
 test.ghul: 7,9..7,11: error: syntax error: expected ; but found si

--- a/integration-tests/parse/incomplete-variable-5/test.ghul
+++ b/integration-tests/parse/incomplete-variable-5/test.ghul
@@ -1,4 +1,4 @@
-namespace Test.ParseUnary is
+namespace Test.ParseIncompleteVariable is
     use Collections;
 
     class Test is

--- a/integration-tests/parse/incomplete-variable-6/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-variable-6/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-variable-6/err.expected
+++ b/integration-tests/parse/incomplete-variable-6/err.expected
@@ -1,2 +1,2 @@
-test.ghul: 7,9..7,11: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, none, null, self, string literal, super, true or typeof but found si
+test.ghul: 7,9..7,11: error: in primary expression: expected (, [, cast, char literal, false, float literal, identifier, int literal, isa, new, null, self, string literal, super, true or typeof but found si
 test.ghul: 7,9..7,11: error: syntax error: expected ; but found si

--- a/integration-tests/parse/incomplete-variable-6/test.ghul
+++ b/integration-tests/parse/incomplete-variable-6/test.ghul
@@ -1,4 +1,4 @@
-namespace Test.ParseUnary is
+namespace Test.ParseIncompleteVariable is
     use Collections;
 
     class Test is

--- a/integration-tests/parse/incomplete-variable-7/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-variable-7/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-variable-8/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-variable-8/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/incomplete-variable-9/.vscode/tasks.json
+++ b/integration-tests/parse/incomplete-variable-9/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/numbers/.vscode/tasks.json
+++ b/integration-tests/parse/numbers/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/operator-precedence-pragma/.vscode/tasks.json
+++ b/integration-tests/parse/operator-precedence-pragma/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/quoted-operator-identifier/.vscode/tasks.json
+++ b/integration-tests/parse/quoted-operator-identifier/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/statement-pragma-1/.vscode/tasks.json
+++ b/integration-tests/parse/statement-pragma-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/struct-1/.vscode/tasks.json
+++ b/integration-tests/parse/struct-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/struct-2/.vscode/tasks.json
+++ b/integration-tests/parse/struct-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/try-no-catch-or-finally/.vscode/tasks.json
+++ b/integration-tests/parse/try-no-catch-or-finally/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/parse/unary/.vscode/tasks.json
+++ b/integration-tests/parse/unary/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/anon-function-property-body/.vscode/tasks.json
+++ b/integration-tests/semantic/anon-function-property-body/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/anonymous-function-argument-name-shadow-local/.vscode/tasks.json
+++ b/integration-tests/semantic/anonymous-function-argument-name-shadow-local/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/anonymous-function-argument-type-inference/.vscode/tasks.json
+++ b/integration-tests/semantic/anonymous-function-argument-type-inference/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/anonymous-function-void-inferred-return-type/.vscode/tasks.json
+++ b/integration-tests/semantic/anonymous-function-void-inferred-return-type/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/anonymous-functions-type-variance/.vscode/tasks.json
+++ b/integration-tests/semantic/anonymous-functions-type-variance/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/array-covariance/.vscode/tasks.json
+++ b/integration-tests/semantic/array-covariance/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/array-type-compatibility/.vscode/tasks.json
+++ b/integration-tests/semantic/array-type-compatibility/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/assignment-type-check/.vscode/tasks.json
+++ b/integration-tests/semantic/assignment-type-check/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/catch-exception-types/.vscode/tasks.json
+++ b/integration-tests/semantic/catch-exception-types/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/closure-local-variable-types/.vscode/tasks.json
+++ b/integration-tests/semantic/closure-local-variable-types/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/collection-iterator-type/.vscode/tasks.json
+++ b/integration-tests/semantic/collection-iterator-type/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/consume-incomplete-values/.vscode/tasks.json
+++ b/integration-tests/semantic/consume-incomplete-values/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/cross-namespace-function-group-nested-namespaces/.vscode/tasks.json
+++ b/integration-tests/semantic/cross-namespace-function-group-nested-namespaces/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/cross-namespace-function-groups-operators/.vscode/tasks.json
+++ b/integration-tests/semantic/cross-namespace-function-groups-operators/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/cross-namespace-function-groups/.vscode/tasks.json
+++ b/integration-tests/semantic/cross-namespace-function-groups/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/dotnet-type-compatibility/.vscode/tasks.json
+++ b/integration-tests/semantic/dotnet-type-compatibility/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/double-override/.vscode/tasks.json
+++ b/integration-tests/semantic/double-override/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/enum-relational-operators/.vscode/tasks.json
+++ b/integration-tests/semantic/enum-relational-operators/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/exception-catch-variable-type/.vscode/tasks.json
+++ b/integration-tests/semantic/exception-catch-variable-type/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/exception-throw-non-exception/.vscode/tasks.json
+++ b/integration-tests/semantic/exception-throw-non-exception/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/expression-function-with-explicit-type-arguments-1/.vscode/tasks.json
+++ b/integration-tests/semantic/expression-function-with-explicit-type-arguments-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/expression-function-with-explicit-type-arguments-2/.vscode/tasks.json
+++ b/integration-tests/semantic/expression-function-with-explicit-type-arguments-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/expression-function-with-explicit-type-arguments-3/.vscode/tasks.json
+++ b/integration-tests/semantic/expression-function-with-explicit-type-arguments-3/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/expression-function-with-explicit-type-arguments-4/.vscode/tasks.json
+++ b/integration-tests/semantic/expression-function-with-explicit-type-arguments-4/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/expression-function-with-explicit-type-arguments-5/.vscode/tasks.json
+++ b/integration-tests/semantic/expression-function-with-explicit-type-arguments-5/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/expression-function-with-explicit-type-arguments-6/.vscode/tasks.json
+++ b/integration-tests/semantic/expression-function-with-explicit-type-arguments-6/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/expression-type-with-explicit-type-arguments-7/.vscode/tasks.json
+++ b/integration-tests/semantic/expression-type-with-explicit-type-arguments-7/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/expression-type-with-explicit-type-arguments-8/.vscode/tasks.json
+++ b/integration-tests/semantic/expression-type-with-explicit-type-arguments-8/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/expression-type-with-explicit-type-arguments/.vscode/tasks.json
+++ b/integration-tests/semantic/expression-type-with-explicit-type-arguments/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/expression-type-with-explicit-type-arguments/expression-explicit-type-2/.vscode/tasks.json
+++ b/integration-tests/semantic/expression-type-with-explicit-type-arguments/expression-explicit-type-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/expression-type-with-explicit-type-arguments/expression-explicit-type-3/.vscode/tasks.json
+++ b/integration-tests/semantic/expression-type-with-explicit-type-arguments/expression-explicit-type-3/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/expression-type-with-explicit-type-arguments/expression-explicit-type-4/.vscode/tasks.json
+++ b/integration-tests/semantic/expression-type-with-explicit-type-arguments/expression-explicit-type-4/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/expression-type-with-explicit-type-arguments/expression-explicit-type-5/.vscode/tasks.json
+++ b/integration-tests/semantic/expression-type-with-explicit-type-arguments/expression-explicit-type-5/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/expression-type-with-explicit-type-arguments/expression-explicit-type-6/.vscode/tasks.json
+++ b/integration-tests/semantic/expression-type-with-explicit-type-arguments/expression-explicit-type-6/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/function-generic-argument-type-parameters-not-wild-1/.vscode/tasks.json
+++ b/integration-tests/semantic/function-generic-argument-type-parameters-not-wild-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/function-generic-argument-type-parameters-not-wild-2/.vscode/tasks.json
+++ b/integration-tests/semantic/function-generic-argument-type-parameters-not-wild-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/function-no-arg-type/.vscode/tasks.json
+++ b/integration-tests/semantic/function-no-arg-type/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/function-return-type-check/.vscode/tasks.json
+++ b/integration-tests/semantic/function-return-type-check/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/function-type-checks/.vscode/tasks.json
+++ b/integration-tests/semantic/function-type-checks/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/function-type/.vscode/tasks.json
+++ b/integration-tests/semantic/function-type/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/generic-arguments-error-messages/.vscode/tasks.json
+++ b/integration-tests/semantic/generic-arguments-error-messages/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/generic-arguments/.vscode/tasks.json
+++ b/integration-tests/semantic/generic-arguments/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/generic-function-argument-object-method-call/.vscode/tasks.json
+++ b/integration-tests/semantic/generic-function-argument-object-method-call/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/generic-function-definition-2/.vscode/tasks.json
+++ b/integration-tests/semantic/generic-function-definition-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/generic-function-definition-3/.vscode/tasks.json
+++ b/integration-tests/semantic/generic-function-definition-3/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/generic-function-definition-4/.vscode/tasks.json
+++ b/integration-tests/semantic/generic-function-definition-4/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/generic-function-definition/.vscode/tasks.json
+++ b/integration-tests/semantic/generic-function-definition/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/generic-function-return-type/.vscode/tasks.json
+++ b/integration-tests/semantic/generic-function-return-type/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/generic-function-type/.vscode/tasks.json
+++ b/integration-tests/semantic/generic-function-type/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/generic-inheritance-2/.vscode/tasks.json
+++ b/integration-tests/semantic/generic-inheritance-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/generic-inheritance/.vscode/tasks.json
+++ b/integration-tests/semantic/generic-inheritance/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/generic-overrides/.vscode/tasks.json
+++ b/integration-tests/semantic/generic-overrides/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/generic-self-2/.vscode/tasks.json
+++ b/integration-tests/semantic/generic-self-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/generic-self/.vscode/tasks.json
+++ b/integration-tests/semantic/generic-self/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/generic-traits/.vscode/tasks.json
+++ b/integration-tests/semantic/generic-traits/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/generic-type-compatibility-2/.vscode/tasks.json
+++ b/integration-tests/semantic/generic-type-compatibility-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/generic-type-compatibility-3/.vscode/tasks.json
+++ b/integration-tests/semantic/generic-type-compatibility-3/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/generic-type-compatibility-3/tasks.json
+++ b/integration-tests/semantic/generic-type-compatibility-3/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "CI=1 dotnet ghul-test ${workspaceFolder}",
+            "command": "CI=1 dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/generic-type-compatibility/.vscode/tasks.json
+++ b/integration-tests/semantic/generic-type-compatibility/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/generic-type-constraints/.vscode/tasks.json
+++ b/integration-tests/semantic/generic-type-constraints/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/implied-anon-function-argument-types-1/.vscode/tasks.json
+++ b/integration-tests/semantic/implied-anon-function-argument-types-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/incomplete-tuple-literals/.vscode/tasks.json
+++ b/integration-tests/semantic/incomplete-tuple-literals/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/indexer-type-checks/.vscode/tasks.json
+++ b/integration-tests/semantic/indexer-type-checks/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/indirect-overrides/.vscode/tasks.json
+++ b/integration-tests/semantic/indirect-overrides/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/inheritance-errors/.vscode/tasks.json
+++ b/integration-tests/semantic/inheritance-errors/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/inheritance-implement-covariant-return-type/.vscode/tasks.json
+++ b/integration-tests/semantic/inheritance-implement-covariant-return-type/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/inheritance-scenarios/.vscode/tasks.json
+++ b/integration-tests/semantic/inheritance-scenarios/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/instance-member-via-type-name/.vscode/tasks.json
+++ b/integration-tests/semantic/instance-member-via-type-name/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/instance-members-static-context/.vscode/tasks.json
+++ b/integration-tests/semantic/instance-members-static-context/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/list-literal-undefined-symbol/.vscode/tasks.json
+++ b/integration-tests/semantic/list-literal-undefined-symbol/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/local-use-before-definition/.vscode/tasks.json
+++ b/integration-tests/semantic/local-use-before-definition/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/named-tuple-elements-2/.vscode/tasks.json
+++ b/integration-tests/semantic/named-tuple-elements-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/named-tuple-elements/.vscode/tasks.json
+++ b/integration-tests/semantic/named-tuple-elements/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/overload-resolution/.vscode/tasks.json
+++ b/integration-tests/semantic/overload-resolution/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/property-assign-private/.vscode/tasks.json
+++ b/integration-tests/semantic/property-assign-private/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/property-assign-readonly/.vscode/tasks.json
+++ b/integration-tests/semantic/property-assign-readonly/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/property-explicitly-typed-variable/.vscode/tasks.json
+++ b/integration-tests/semantic/property-explicitly-typed-variable/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/property-inheritance/.vscode/tasks.json
+++ b/integration-tests/semantic/property-inheritance/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/property-override-not-assignable/.vscode/tasks.json
+++ b/integration-tests/semantic/property-override-not-assignable/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/property-read-private/.vscode/tasks.json
+++ b/integration-tests/semantic/property-read-private/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/pull-down-non-generic/.vscode/tasks.json
+++ b/integration-tests/semantic/pull-down-non-generic/.vscode/tasks.json
@@ -13,7 +13,7 @@
         },
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -22,7 +22,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/pull-down/.vscode/tasks.json
+++ b/integration-tests/semantic/pull-down/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/reference-equality/.vscode/tasks.json
+++ b/integration-tests/semantic/reference-equality/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/reference-type-outside-function-arguments/.vscode/tasks.json
+++ b/integration-tests/semantic/reference-type-outside-function-arguments/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/return-type-inference-1/.vscode/tasks.json
+++ b/integration-tests/semantic/return-type-inference-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/return-type-inference-2/.vscode/tasks.json
+++ b/integration-tests/semantic/return-type-inference-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/scope-namespace-qualified/.vscode/tasks.json
+++ b/integration-tests/semantic/scope-namespace-qualified/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/simple-generic/.vscode/tasks.json
+++ b/integration-tests/semantic/simple-generic/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/simple-overrides/.vscode/tasks.json
+++ b/integration-tests/semantic/simple-overrides/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/simple-type-compatibility/.vscode/tasks.json
+++ b/integration-tests/semantic/simple-type-compatibility/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/stable-symbols/.vscode/tasks.json
+++ b/integration-tests/semantic/stable-symbols/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/static-generic-members-1/.vscode/tasks.json
+++ b/integration-tests/semantic/static-generic-members-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/static-member-via-type-name/.vscode/tasks.json
+++ b/integration-tests/semantic/static-member-via-type-name/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/superclass-constructor-error/.vscode/tasks.json
+++ b/integration-tests/semantic/superclass-constructor-error/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/symbol-resolution-1/.vscode/tasks.json
+++ b/integration-tests/semantic/symbol-resolution-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/symbol-resolution-2/.vscode/tasks.json
+++ b/integration-tests/semantic/symbol-resolution-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/symbol-resolution-3/.vscode/tasks.json
+++ b/integration-tests/semantic/symbol-resolution-3/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/trait-enforce-implement-abstract-methods/.vscode/tasks.json
+++ b/integration-tests/semantic/trait-enforce-implement-abstract-methods/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/trait-enforce-implement-parents-abstract-methods-1/.vscode/tasks.json
+++ b/integration-tests/semantic/trait-enforce-implement-parents-abstract-methods-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/trait-enforce-implement-parents-abstract-methods-2/.vscode/tasks.json
+++ b/integration-tests/semantic/trait-enforce-implement-parents-abstract-methods-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/trait-enforce-implement-parents-abstract-methods-3/.vscode/tasks.json
+++ b/integration-tests/semantic/trait-enforce-implement-parents-abstract-methods-3/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/trait-inherit-property-from-trait/.vscode/tasks.json
+++ b/integration-tests/semantic/trait-inherit-property-from-trait/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/tuple-covariance/.vscode/tasks.json
+++ b/integration-tests/semantic/tuple-covariance/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/tuple-explicit-element-type-assignment-compatible/.vscode/tasks.json
+++ b/integration-tests/semantic/tuple-explicit-element-type-assignment-compatible/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/use-aliases/.vscode/tasks.json
+++ b/integration-tests/semantic/use-aliases/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/use-duplicate-symbols/.vscode/tasks.json
+++ b/integration-tests/semantic/use-duplicate-symbols/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/use-non-static-method/.vscode/tasks.json
+++ b/integration-tests/semantic/use-non-static-method/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/use-overload-function/.vscode/tasks.json
+++ b/integration-tests/semantic/use-overload-function/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/void-type-use-1/.vscode/tasks.json
+++ b/integration-tests/semantic/void-type-use-1/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "CI=1 dotnet ghul-test ${workspaceFolder}",
+            "command": "CI=1 dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/void-type-use-2/.vscode/tasks.json
+++ b/integration-tests/semantic/void-type-use-2/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/void-type-use-3/.vscode/tasks.json
+++ b/integration-tests/semantic/void-type-use-3/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/void-type-use-4/.vscode/tasks.json
+++ b/integration-tests/semantic/void-type-use-4/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/semantic/void-type-use-5/.vscode/tasks.json
+++ b/integration-tests/semantic/void-type-use-5/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
@@ -12,7 +12,7 @@
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/project-tests/runtime-pipes/.vscode/ghul.json
+++ b/project-tests/runtime-pipes/.vscode/ghul.json
@@ -1,0 +1,6 @@
+{
+    "compiler": "dotnet ../../../publish/ghul.dll",
+    "source": [
+        "."
+    ]
+}

--- a/project-tests/runtime-pipes/.vscode/tasks.json
+++ b/project-tests/runtime-pipes/.vscode/tasks.json
@@ -1,0 +1,23 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run test",
+            "command": "dotnet ghul-test --use-dotnet-build \"${workspaceFolder}\"",
+            "type": "shell",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "Capture test expectation",
+            "command": "../../tasks/capture.sh \"${workspaceFolder}\"",
+            "type": "shell",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/project-tests/runtime-pipes/adaptor-pipe-tests.ghul
+++ b/project-tests/runtime-pipes/adaptor-pipe-tests.ghul
@@ -1,0 +1,106 @@
+namespace Tests is
+    use IO.Std.write_line;
+    use Collections;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    use Ghul.Pipes;
+        
+    class ADAPTOR_PIPEShould is
+        @test()
+   
+        init() is
+        si
+
+        Pipe_FromArray_ReturnsInstanceOfADAPTOR_PIPE() is
+            @test()
+
+            let pipe = Ghul.Pipes.Pipe`[int].from([1, 2, 3, 4, 5]);
+
+            expect_equal(pipe.get_type(), typeof ADAPTOR_PIPE[int]);
+            Assert.is_instance_of_type(pipe, typeof ADAPTOR_PIPE[int]);
+        si
+
+        Count_NonEmptyArray_ReturnsElementCount() is
+            @test()
+
+            let pipe = new ADAPTOR_PIPE[int]([1, 2, 3, 4, 5]);
+
+            expect_equal(pipe.count(), 5);
+            Assert.are_equal(5, pipe.count());
+        si
+
+        Count_EmptyArray_ReturnsZero() is
+            @test()
+
+            let pipe = new ADAPTOR_PIPE[int](empty`[int]());
+
+            expect_equal(pipe.count(), 0);
+            Assert.are_equal(0, pipe.count());
+        si
+
+        // If the collection is a MutableBag (ICollection) then the count method should
+        // call the Count method of the collection, rather than iterating over
+        // the collection to count the elements.
+
+        @IF.dont()
+        Count_MutableBag_CallsMutableBagCount() is
+            @test()
+
+            let collection = Substitute.`for`[MutableBag[int]](empty`[object]());
+
+            returns(collection.iterator, [1, 2, 3, 4].iterator, null);
+            returns(collection.count, 4, null);
+
+            let pipe = new ADAPTOR_PIPE[int](collection);
+
+            let count = pipe.count();
+
+            let actual = received(collection, 1).count;
+        si
+
+        // If the collection is a MutableBag (IReadOnlyCollection) then the count
+        // method should call the Count method of the collection, rather than
+        // iterating over the collection to count the elements.
+
+        @IF.dont()
+        Count_Bag_CallsBagCount() is
+            @test()
+
+            let collection = Substitute.`for`[MutableBag[int]](empty`[object]());
+
+            returns(collection.iterator, [1, 2, 3, 4].iterator, null);
+            returns(collection.count, 4, null);
+
+            let pipe = new ADAPTOR_PIPE[int](collection);
+
+            let count = pipe.count();
+
+            let actual = received(collection, 1).count;
+        si
+
+        Iterator_ReturnsSelf() is
+            @test()
+
+            let pipe = new ADAPTOR_PIPE[string]([ "a", "b", "c" ]);
+
+            expect_equal(pipe, pipe.iterator);
+            Assert.are_same(pipe, pipe.iterator);
+        si
+        
+        Iterator_ReturnsCorrectElements() is
+            @test()
+
+            let pipe = new ADAPTOR_PIPE[string]([ "a", "b", "c" ]);
+
+            // FIXME: this shouldn't need a cast - why are array literals
+            // not reliably Iterable[T] anymore?
+            expect_equal([ "a", "b", "c" ] |, pipe);
+ 
+            assert_are_equal(
+                [ "a", "b", "c" ],
+                pipe
+            );
+        si
+    si
+si

--- a/project-tests/runtime-pipes/cat-pipe-tests.ghul
+++ b/project-tests/runtime-pipes/cat-pipe-tests.ghul
@@ -1,0 +1,98 @@
+namespace Tests is
+    use IO.Std.write_line;
+
+    use Collections;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    use Ghul.Pipes;
+
+
+    class CatPipeShould is
+        @test()
+
+        init() is
+        si
+
+        Cat_EmptySequences_ReturnsEmptySequence() is
+            @test()
+
+            let pipe = 
+                Ghul.Pipes.Pipe`[int]
+                    .from(empty`[int]())
+                    .cat(empty`[int]());
+
+            expect_equal(empty`[int]() |, pipe);
+
+            Assert.are_equal(0, pipe.count());
+        si
+
+        Cat_EmptyPlusNonEmpty_ReturnsSecondSequence() is
+            @test()
+
+            let pipe = 
+                Ghul.Pipes.Pipe`[int]
+                    .from(empty`[int]())
+                    .cat([1, 2, 3, 4, 5]);
+
+            expect_equal([1, 2, 3, 4, 5] |, pipe);
+            assert_are_equal([1, 2, 3, 4, 5], pipe);
+        si
+
+        Cat_NonEmptyPlusEmpty_ReturnsFirstSequence() is
+            @test()
+
+            let pipe = 
+                Ghul.Pipes.Pipe`[int]
+                    .from([1, 2, 3, 4, 5])
+                    .cat(empty`[int]());
+
+            expect_equal([1, 2, 3, 4, 5] |, pipe);
+            assert_are_equal([1, 2, 3, 4, 5], pipe);
+        si
+
+        Cat_NonEmptyPlusNonEmpty_ReturnsBothSequencesInOrder() is
+            @test()
+
+            let pipe = 
+                Ghul.Pipes.Pipe`[int]
+                    .from([1, 2, 3, 4, 5])
+                    .cat([6, 7, 8, 9, 10]);
+
+            expect_equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 10] |, pipe);
+            assert_are_equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], pipe);
+        si
+
+        Cat_ChainedCalls_ReturnsConcatenationOfAllInputs() is
+            @test()
+
+            let pipe = 
+                Ghul.Pipes.Pipe`[int]
+                    .from([3, 4, 5])
+                    .cat([1, 2, 1])
+                    .cat(empty`[int]())
+                    .cat([2, 3, 4])
+                    .cat([5]);
+
+            write_line(pipe);
+
+            expect_equal([3, 4, 5, 1, 2, 1, 2, 3, 4, 5] |, pipe);
+            assert_are_equal([3, 4, 5, 1, 2, 1, 2, 3, 4, 5], pipe);
+        si
+
+        Cat_ChainedCalls_CountReturnsSumOfAllCounts() is
+            @test()
+
+            let pipe = 
+                Ghul.Pipes.Pipe`[int]
+                    .from([3, 4, 5])
+                    .cat([1, 2, 1])
+                    .cat(empty`[int]())
+                    .cat([2, 3, 4])
+                    .cat([5]);
+
+            expect_equal(10, pipe.count());
+            Assert.are_equal(10, pipe.count());
+        si
+    si
+si

--- a/project-tests/runtime-pipes/common.ghul
+++ b/project-tests/runtime-pipes/common.ghul
@@ -1,0 +1,26 @@
+namespace Tests is
+    use IO.Std.write_line;
+    use Collections;
+    
+    use Microsoft.VisualStudio.TestTools.UnitTesting;
+    
+    use Ghul.Pipes;
+    
+    empty[T]() -> T[] => System.Array.empty`[T]();
+    
+    iv[T](index: int, value: T) -> INDEXED_VALUE[T] => new INDEXED_VALUE[T](index, value);
+    
+    expect_equal[T](a: T, b: T) is
+        write_line("expect_equal: {0} == {1}", a, b);
+    si
+    
+    assert_are_equal[T](expected: Iterable[T], actual: Pipe[T]) is
+        let expected_elements = new LIST[T]();
+        let actual_elements = new LIST[T]();
+    
+        expected_elements.add_range(expected);
+        actual_elements.add_range(actual);
+    
+        CollectionAssert.are_equal(expected_elements, actual_elements);
+    si
+si

--- a/project-tests/runtime-pipes/filter-pipe-tests.ghul
+++ b/project-tests/runtime-pipes/filter-pipe-tests.ghul
@@ -1,0 +1,135 @@
+namespace Tests is
+
+    use Collections;
+    use Pipes;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting;
+
+
+    class FilterPipeShould is
+        @test()
+
+        init() is
+        si
+
+        Filter_ConsecutiveNonMatchingValues_AreRemoved() is
+            @test()
+
+            let pipe = 
+                Ghul.Pipes.Pipe`[int]
+                    .from([3, 4, 5, 1, 2, 1, 2, 3, 4, 5]);
+
+
+            let result = 
+                pipe
+                    .filter(i => i > 2);
+
+            expect_equal([3, 4, 5, 3, 4, 5] |, result);
+            assert_are_equal([3, 4, 5, 3, 4, 5], result);
+        si
+        
+        Filter_NonConsecutiveNonMatchingValues_AreRemoved() is
+            @test()
+
+            let pipe = 
+                Ghul.Pipes.Pipe`[int]
+                    .from([3, 4, 1, 5, 2, 3, 1, 4, 5]);
+
+            let result =
+                pipe
+                    .filter(i => i > 2);
+
+            expect_equal([3, 4, 5, 3, 4, 5] |, result);
+            assert_are_equal([3, 4, 5, 3, 4, 5], result);
+        si
+
+        Filter_LeadingNonMatchingValues_AreRemoved() is
+            @test()
+
+            let pipe = 
+                Ghul.Pipes.Pipe`[int]
+                    .from([1, 2, 1, 3, 4, 5, 6, 7]);
+
+            let result =
+                pipe
+                    .filter(i => i > 2);
+
+            expect_equal([3, 4, 5, 6, 7] |, result);
+            assert_are_equal([3, 4, 5, 6, 7], result);
+        si
+
+        Filter_TrailingNonMatchingValues_AreRemoved() is
+            @test()
+
+            let pipe = 
+                Ghul.Pipes.Pipe`[int]
+                    .from([7, 6, 5, 4, 3, 2, 1]);
+
+            let result =
+                pipe
+                    .filter(i => i > 2);
+
+            expect_equal([7, 6, 5, 4, 3] |, result);
+            assert_are_equal([7, 6, 5, 4, 3], result);
+        si
+
+        Filter_CalledTwice_ReturnsOnlyElementsThatMatchBothPredicates() is
+            @test()
+
+            let pipe = 
+                Ghul.Pipes.Pipe`[int]
+                    .from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            let result =
+                pipe
+                    .filter(i => i > 3 /\ i < 9)
+                    .filter(i => (i ∩ 1) == 0);
+
+            expect_equal([4, 6, 8] |, result);
+            assert_are_equal([4, 6, 8], result);
+        si
+
+        Count_AlwaysTruePredicate_ReturnsElementCount() is
+            @test()
+
+            let input = ["a", "b", "c", "d"];
+
+            let pipe = new FilterPipe[string](input.iterator, (e: string) => true);
+
+            expect_equal(4, pipe.count());
+            Assert.are_equal(4, pipe.count());
+        si
+
+        Count_EmptyList_ReturnsZero() is
+            @test()
+
+            let input = empty`[int]();
+
+            let pipe = new FilterPipe[int](input.iterator, (e: int) => true);
+
+            expect_equal(0, pipe.count());
+            Assert.are_equal(0, pipe.count());
+        si
+
+        Iterator_ReturnsSelf() is
+            @test()
+
+            let input = ["a", "b", "c"];
+
+            let pipe = new FilterPipe[string](input.iterator, (e: string) => true);
+
+            expect_equal(pipe, pipe.iterator);
+            Assert.are_same(pipe, pipe.iterator);
+        si
+
+        Iterator_AlwaysTruePredicate_ResultEqualsInput() is
+            @test()
+
+            let input = ["a", "b", "c"];
+
+            let pipe = new FilterPipe[string](input.iterator, (e: string) => true);
+
+            assert_are_equal(["a", "b", "c"] |, pipe);
+        si
+    si
+si

--- a/project-tests/runtime-pipes/index-pipe-tests.ghul
+++ b/project-tests/runtime-pipes/index-pipe-tests.ghul
@@ -1,0 +1,87 @@
+namespace Tests is
+
+    use Collections;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    use Ghul.Pipes;
+
+    class IndexPipeShould is
+        @test()
+
+        init() is
+        si
+
+        Index_EmptyArray_ReturnsEmptySequence() is
+            @test()
+
+            let pipe = 
+                Ghul.Pipes.Pipe`[int]
+                    .from(empty`[int]());
+
+            let result = 
+                pipe
+                    .index();
+
+            expect_equal(empty`[INDEXED_VALUE[int]]() |, result);
+            assert_are_equal(empty`[INDEXED_VALUE[int]](), result);
+        si
+
+        Index_MultipleElements_ReturnsExpectedSequence() is
+            @test()
+
+            let pipe = 
+                Ghul.Pipes.Pipe`[string]
+                    .from(["3", "4", "1", "5", "2", "3", "1", "4", "5"]);
+
+            let result = 
+                pipe
+                    .index();
+
+            expect_equal([iv(0, "3"), iv(1, "4"), iv(2, "1"), iv(3, "5"), iv(4, "2"), iv(5, "3"), iv(6, "1"), iv(7, "4"), iv(8, "5")] |, result);
+            assert_are_equal([iv(0, "3"), iv(1, "4"), iv(2, "1"), iv(3, "5"), iv(4, "2"), iv(5, "3"), iv(6, "1"), iv(7, "4"), iv(8, "5")], result);
+        si
+
+        Index_MultipleElementsPositiveInitialIndex_ReturnsExpectedSequence() is
+            @test()
+
+            let pipe = 
+                Ghul.Pipes.Pipe`[string]
+                    .from(["3", "4", "1", "5", "2", "3", "1", "4", "5"]);
+
+            let result = 
+                pipe
+                    .index(3);
+
+            expect_equal([iv(3, "3"), iv(4, "4"), iv(5, "1"), iv(6, "5"), iv(7, "2"), iv(8, "3"), iv(9, "1"), iv(10, "4"), iv(11, "5")] |, result);
+            assert_are_equal([iv(3, "3"), iv(4, "4"), iv(5, "1"), iv(6, "5"), iv(7, "2"), iv(8, "3"), iv(9, "1"), iv(10, "4"), iv(11, "5")], result);
+        si
+
+        Index_MultipleElementsNegativeInitialIndex_ReturnsExpectedSequence() is
+            @test()
+
+            let pipe = 
+                Ghul.Pipes.Pipe`[string]
+                    .from(["3", "4", "1", "5", "2", "3", "1", "4", "5"]);
+
+            let result = 
+                pipe
+                    .index(-3);
+
+            expect_equal([iv(-3, "3"), iv(-2, "4"), iv(-1, "1"), iv(0, "5"), iv(1, "2"), iv(2, "3"), iv(3, "1"), iv(4, "4"), iv(5, "5")] |, result);
+            assert_are_equal([iv(-3, "3"), iv(-2, "4"), iv(-1, "1"), iv(0, "5"), iv(1, "2"), iv(2, "3"), iv(3, "1"), iv(4, "4"), iv(5, "5")], result);
+        si
+
+        IndexedValue_ToString_ReturnsIndexAndValueInParentheses() is
+            @test()
+
+            let indexedValue = iv(1234, "ABCD");
+
+            expect_equal("(1234,ABCD)", indexedValue.to_string());
+            Assert.are_equal("(1234,ABCD)", indexedValue.to_string());
+        si        
+    si
+si
+
+
+

--- a/project-tests/runtime-pipes/map-pipe-tests.ghul
+++ b/project-tests/runtime-pipes/map-pipe-tests.ghul
@@ -1,0 +1,61 @@
+namespace Tests is
+
+    use Collections;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    use Ghul.Pipes;
+
+    class MapPipeShould is
+        @test()
+
+        init() is
+        si
+
+        Map_EmptyArray_ReturnsEmptySequence() is
+            @test()
+
+            let pipe = 
+                Ghul.Pipes.Pipe`[int]
+                    .from(empty`[int]());
+
+            let result = 
+                pipe
+                    .map(i => i.to_string());
+
+            expect_equal(empty`[string]() |, result);
+            assert_are_equal(empty`[string](), result);
+        si
+
+        Map_IntsToStrings_ReturnsExpectedSequence() is
+            @test()
+
+            let pipe = 
+                Ghul.Pipes.Pipe`[int]
+                    .from([3, 4, 1, 5, 2, 3, 1, 4, 5]);
+
+            let result = 
+                pipe
+                    .map(i => i.to_string());
+
+            expect_equal(["3", "4", "1", "5", "2", "3", "1", "4", "5"] |, result);
+            assert_are_equal(["3", "4", "1", "5", "2", "3", "1", "4", "5"], result);
+        si
+
+        Map_CalledTwice_AppliesBothFunctionsToEveryElementInCorrectOrder() is
+            @test()
+
+            let pipe = 
+                Ghul.Pipes.Pipe`[int]
+                    .from([1, 2, 3, 4, 5, 6]);
+
+            let result = 
+                pipe
+                    .map(i => "" + i + "-first")
+                    .map(i => i + "-second");
+
+            expect_equal(["1-first-second", "2-first-second", "3-first-second", "4-first-second", "5-first-second", "6-first-second"] |, result);
+            assert_are_equal(["1-first-second", "2-first-second", "3-first-second", "4-first-second", "5-first-second", "6-first-second"], result);
+        si
+    si
+si

--- a/project-tests/runtime-pipes/pipe-operator-tests.ghul
+++ b/project-tests/runtime-pipes/pipe-operator-tests.ghul
@@ -1,0 +1,450 @@
+namespace Tests is
+
+    use Collections;
+
+    use System.Text.StringBuilder;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    use Ghul.Pipes;
+
+    class PipeOperatorShould is
+        @test()
+
+        init() is
+        si
+
+        // same as all the other pipe tests (see PipeShould), but using the pipe operator
+
+        Pipe_SkipThenFirst_ReturnsCorrectElement() is
+            @test()
+
+            let result = 
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] | 
+                    .skip(5)
+                    .first();
+
+            expect_equal(new MAYBE[int](6), result);
+            Assert.are_equal(new MAYBE[int](6), result);
+        si
+
+        Pipe_TakeThenFirst_ReturnsFirstElement() is
+            @test()
+
+            let result = 
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] | 
+                    .take(5)
+                    .first();
+
+            Assert.are_equal(new MAYBE[int](1), result);
+        si
+
+        Pipe_FirstEmptySequence_ReturnsMaybeNot() is
+            @test()
+
+            let result = 
+                empty`[int]() |
+                    .first();
+
+            Assert.are_equal(new MAYBE[int](), result);
+        si
+
+        Pipe_FindEmptySequence_ReturnsMaybeNot() is
+            @test()
+
+            let result = 
+                empty`[int]() | 
+                    .find(i => i > 10);
+
+            Assert.are_equal(new MAYBE[int](), result);
+        si
+
+        Pipe_FindNonEmptySequenceButNoMatch_ReturnsMaybeNot() is
+            @test()
+
+            let result = 
+                [1, 2, 3, 4, 5, 6, 7, 8, 9] | 
+                    .find(i => i == 10);
+
+            Assert.are_equal(new MAYBE[int](), result);
+        si
+
+        Pipe_FindSingleMatchingElement_ReturnsThatElement() is
+            @test()
+
+            let result = 
+                [1, 2, 3, 4, 5, 6, 7, 8, 9] | 
+                    .find(i => i == 4);
+
+            Assert.are_equal(new MAYBE[int](4), result);
+        si
+
+        Pipe_FindMultipleMatchingElement_ReturnsFirstMatchingElement() is
+            @test()
+
+            let array = [new THING(1), new THING(2), new THING(3), new THING(4), new THING(3), new THING(2), new THING(3), new THING(8), new THING(9)];
+
+            let result = 
+                array |
+                    .find(t => t.key == 3);
+
+            Assert.are_equal(new MAYBE[THING](array[2]), result);
+        si
+
+        Pipe_HasNoElements_ReturnsFalse() is
+            @test()
+
+            let result = 
+                empty`[int]() | 
+                    .has(i => i == 4);
+
+            Assert.is_false(result);
+        si
+
+        Pipe_HasSomeElementsButNoneMatch_ReturnsFalse() is
+            @test()
+
+            let result = 
+                [1, 2, 3, 4, 5, 6, 7, 8, 9] | 
+                    .has(i => i == 99);
+
+            Assert.is_false(result);
+        si
+
+        Pipe_HasSomeElementsOneMatches_ReturnsTrue() is
+            @test()
+
+            let result = 
+                [1, 2, 3, 4, 5, 6, 7, 8, 9] | 
+                    .has(i => i == 4);
+
+            Assert.is_true(result);
+        si
+
+        Pipe_HasSomeElementsMultipleMatches_ReturnsTrue() is
+            @test()
+
+            let result = 
+                [1, 2, 3, 4, 5, 6, 7, 8, 9] | 
+                    .has(i => i > 4);
+
+            Assert.is_true(result);
+        si
+
+        Pipe_SkipThenFilter_ReturnsFilteredTailSequence() is
+            @test()
+
+            let result = 
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] | 
+                    .skip(5)
+                    .filter(i => (i ∩ 1) == 0);
+
+            assert_are_equal([6, 8, 10], result);
+        si
+
+        Pipe_FilterThenSkip_ReturnsFilteredTailSequence() is
+            @test()
+
+            let result = 
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] | 
+                    .filter(i => (i ∩ 1) == 0)
+                    .skip(1);
+
+            assert_are_equal([4, 6, 8, 10], result);
+        si
+
+        Pipe_SkipThenIndex_StartsIndexingFromZero() is
+            @test()
+
+            let result = 
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] | 
+                    .skip(4)
+                    .index();
+
+            assert_are_equal([iv(0, 5), iv(1, 6), iv(2, 7), iv(3, 8), iv(4, 9), iv(5, 10)], result);
+        si
+
+        Pipe_IndexThenSkip_StartsIndexingFromCorrectOffset() is
+            @test()
+
+            let result = 
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] | 
+                    .index()
+                    .skip(6);
+
+            assert_are_equal([iv(6, 7), iv(7, 8), iv(8, 9), iv(9, 10)], result);
+        si
+
+        Pipe_TakeThenFilter_ReturnsFilteredHeadSequence() is
+            @test()
+
+            let result =
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] |
+                    .take(5)
+                    .filter(i => (i ∩ 1) == 0);
+
+            assert_are_equal([2, 4], result);
+        si
+
+        Pipe_FilterThenTake_ReturnsFilteredHeadSequence() is
+            @test()
+
+            let result = 
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] |
+                    .filter(i => (i ∩ 1) == 0)
+                    .take(3);
+
+            assert_are_equal([2, 4, 6], result);
+        si
+
+        Pipe_IndexThenFilter_RetainsOriginalIndexes() is
+            @test()
+
+            let result = 
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] | 
+                    .index()
+                    .filter(i => (i.value ∩ 1) == 1);
+
+            assert_are_equal([iv(0,1), iv(2,3), iv(4,5), iv(6,7), iv(8,9)], result);
+        si
+
+        Pipe_FilterThenIndex_AppliesNewIndexes() is
+            @test()
+
+            let result = 
+                [3, 4, 1, 5, 2, 3, 1, 4, 5] | 
+                    .filter(i => i > 2)
+                    .index();
+
+            assert_are_equal([iv(0,3), iv(1,4), iv(2,5), iv(3,3), iv(4,4), iv(5,5)], result);
+        si
+
+        Pipe_SkipThenMap_ReturnsMappedTailSequence() is
+            @test()
+
+            let result = 
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] | 
+                    .skip(5)
+                    .map(i => "X" + i);
+
+            assert_are_equal(["X6", "X7", "X8", "X9", "X10"], result);
+        si
+
+        Pipe_MapThenSkip_ReturnsMappedTailSequence() is
+            @test()
+
+            let result = 
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] |
+                    .map(i => "X" + i)
+                    .skip(5);
+
+            assert_are_equal(["X6", "X7", "X8", "X9", "X10"], result);
+        si
+
+        Pipe_TakeThenMap_ReturnsMappedHeadSequence() is
+            @test()
+
+            let result = 
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] | 
+                    .take(4)
+                    .map(i => "X" + i);
+
+            assert_are_equal(["X1", "X2", "X3", "X4"], result);
+        si
+
+        Pipe_MapThenTake_ReturnsMappedHeadSequence() is
+            @test()
+
+            let result = 
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] | 
+                    .map(i => "X" + i)
+                    .take(6);
+
+            assert_are_equal(["X1", "X2", "X3", "X4", "X5", "X6"], result);
+        si
+
+        Pipe_TakeThenIndex_StartsIndexingFromZero() is
+            @test()
+
+            let result = 
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] | 
+                    .take(4)
+                    .index();
+
+            assert_are_equal([iv(0, 1), iv(1, 2), iv(2, 3), iv(3, 4)], result);
+        si
+
+        Pipe_IndexThenTake_StartsIndexingFromZero() is
+            @test()
+
+            let result =
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] | 
+                    .index()
+                    .take(6);
+
+            assert_are_equal([iv(0, 1), iv(1, 2), iv(2, 3), iv(3, 4), iv(4, 5), iv(5, 6)], result);
+        si
+
+        Pipe_FilterThenFilter_ReturnsOnlyElementsThatMatchBothPredicates() is
+            @test()
+
+            let result = 
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] | 
+                    .filter(i => i > 3 /\ i < 9)
+                    .filter(i => (i ∩ 1) == 0);
+
+            assert_are_equal([4, 6, 8], result);
+        si
+
+        Pipe_MapThenMap_AppliesBothFunctionsToEveryElementInCorrectOrder() is
+            @test()
+
+            let result = 
+                [1, 2, 3, 4, 5, 6] | 
+                    .map(i => "" + i + "-first")
+                    .map(i => i + "-second");
+
+            assert_are_equal(["1-first-second", "2-first-second", "3-first-second", "4-first-second", "5-first-second", "6-first-second"], result);
+        si
+
+        Pipe_Running() is
+            @test()
+
+            let result = 
+                [1, 2, 3, 4, 5, 6] | 
+                    .reduce(0, (running, element) => running + element);
+
+            Assert.are_equal(1 + 2 + 3 + 4 + 5 + 6, result);
+        si
+
+        Pipe_Mapped_Running() is
+            @test()
+
+            let result = 
+                [1, 2, 3, 4, 5, 6] | 
+                    .reduce(0, (running, element) => running + element, total => "total: " + total);
+
+            Assert.are_equal("total: " + (1 + 2 + 3 + 4 + 5 + 6), result);
+        si
+
+        Sort_NoComparer_SortsInDefaultOrder() is
+            @test()
+
+            let result = 
+                [2, 1, 4, 3, 6, 5] | .sort();
+
+            assert_are_equal([1, 2, 3, 4, 5, 6], result);
+        si
+
+        Sort_GivenComparer_SortsInComparerOrder() is
+            @test()
+
+            let result = 
+                [2, 1, 4, 3, 6, 5] | 
+                    .sort(new ReverseIntComparer());
+
+            assert_are_equal([6, 5, 4, 3, 2, 1], result);
+        si
+
+        Sort_GivenCompareFunction_SortsInCompareFunctionOrder() is
+            @test()
+
+            let result = 
+                [2, 1, 4, 3, 6, 5] |
+                    .sort((x, y) => y - x);
+
+            assert_are_equal([6, 5, 4, 3, 2, 1], result);
+        si
+
+        Sort_CalledTwice_SortsInLastComparerOrder() is
+            @test()
+
+            let result = 
+                [2, 1, 4, 3, 6, 5] | 
+                    .sort()
+                    .sort(new ReverseIntComparer());
+
+            assert_are_equal([6, 5, 4, 3, 2, 1], result);
+        si
+
+        Sort_EnumeratedTwice_ReturnsSameResultBothTimes() is
+            @test()
+
+            let result = 
+                [2, 1, 4, 3, 6, 5] | 
+                    .sort(new ReverseIntComparer());
+
+            result.collect();
+
+            assert_are_equal([6, 5, 4, 3, 2, 1], result);
+        si
+
+        ToString_WithNoSeparatorArgument_ReturnsStringRepresentationOfAllElementsSeparatedWithACommaAndSpace() is
+            @test()
+
+            let result = 
+                [2, 1, 4, 3, 6, 5] | 
+                    .to_string();
+
+            Assert.are_equal("2, 1, 4, 3, 6, 5", result);
+        si
+
+        ToString_WithSeparatorArgument_ReturnsStringRepresentationOfAllElementsSeparatedWithThatSeparator() is
+            @test()
+
+            let result = 
+                [2, 1, 4, 3, 6, 5] | 
+                    .to_string("///");
+
+            Assert.are_equal("2///1///4///3///6///5", result);
+        si
+
+        ToString_CalledTwice_ReturnsStringRepresentationOfAllElements() is
+            @test()
+
+            let pipe = [2, 1, 4, 3, 6, 5] |;
+
+            pipe.to_string();
+
+            let result = pipe.to_string("\t");
+
+            Assert.are_equal("2\t1\t4\t3\t6\t5", result);
+        si
+
+        AppendTo_WithNoSeparatorArgument_AppendsStringRepresentationOfAllElementsSeparatedWithACommaAndSpace() is
+            @test()
+
+            let result = new StringBuilder("XX");
+
+            [2, 1, 4, 3, 6, 5] | .append_to(result);
+
+            Assert.are_equal("XX2, 1, 4, 3, 6, 5", result.to_string());
+        si
+
+        AppendTo_WithSeparatorArgument_AppendsStringRepresentationOfAllElementsSeparatedWithThatSeparator() is
+            @test()
+
+            let result = new StringBuilder("XX");
+
+            let pipe = [2, 1, 4, 3, 6, 5] | .append_to(result, "///");
+
+            Assert.are_equal("XX2///1///4///3///6///5", result.to_string());
+        si
+
+        AppendTo_CalledTwice_AppendsStringRepresentationOfAllElementsTwice() is
+            @test()
+
+            let result = new StringBuilder("XX");
+
+            let pipe = [2, 1, 4, 3, 6, 5] |;
+            
+            pipe.append_to(result, "-");
+
+            result.append("YY");
+
+            pipe.append_to(result, "_");
+
+            Assert.are_equal("XX2-1-4-3-6-5YY2_1_4_3_6_5", result.to_string());
+        si
+    si    
+si

--- a/project-tests/runtime-pipes/pipe-tests.ghul
+++ b/project-tests/runtime-pipes/pipe-tests.ghul
@@ -1,0 +1,490 @@
+namespace Tests is
+
+    use Collections;
+
+    use System.Text.StringBuilder;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    use Ghul.Pipes;
+
+    class PipeShould is
+        @test()
+
+        init() is
+        si
+
+        Pipe_SkipThenFirst_ReturnsCorrectElement() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            Assert.are_equal(new MAYBE[int](6), pipe.skip(5).first());
+        si
+
+        Pipe_TakeThenFirst_ReturnsFirstElement() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            Assert.are_equal(new MAYBE[int](1), pipe.take(5).first());
+        si
+
+        Pipe_FirstEmptySequence_ReturnsMaybeNot() is
+            @test()
+
+            let pipe = Pipe`[int].from(empty`[int]());
+
+            let first = pipe.first();
+            let expected = new MAYBE[int]();
+
+            Assert.are_equal(expected, first);
+        si
+
+        Pipe_FindEmptySequence_ReturnsMaybeNot() is
+            @test()
+
+            let pipe = Pipe`[int].from(empty`[int]());
+
+            let found = pipe.find(i => i > 10);
+            let expected = new MAYBE[int]();
+
+            Assert.are_equal(expected, found);
+        si
+
+        Pipe_FindNonEmptySequenceButNoMatch_ReturnsMaybeNot() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+            let found = pipe.find(i => i == 10);
+            let expected = new MAYBE[int]();
+
+            Assert.are_equal(expected, found);
+        si
+
+        Pipe_FindSingleMatchingElement_ReturnsThatElement() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+            let found = pipe.find(i => i == 4);
+            let expected = new MAYBE[int](4);
+
+            Assert.are_equal(expected, found);
+        si
+
+        Pipe_FindMultipleMatchingElement_ReturnsFirstMatchingElement() is
+            @test()
+
+            let array = [new THING(1), new THING(2), new THING(3), new THING(4), new THING(3), new THING(2), new THING(3), new THING(8), new THING(9)];
+
+            let pipe = Pipe`[THING].from(array);
+
+            let found = pipe.find(t => t.key == 3);
+            let expected = new MAYBE[THING](array[2]);
+
+            Assert.are_equal(expected, found);
+        si
+
+        Pipe_HasNoElements_ReturnsFalse() is
+            @test()
+
+            let pipe = Pipe`[int].from(empty`[int]());
+
+            Assert.is_false(pipe.has(i => i == 4));
+        si
+
+        Pipe_HasSomeElementsButNoneMatch_ReturnsFalse() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+            Assert.is_false(pipe.has(i => i == 99));
+        si
+
+        Pipe_HasSomeElementsOneMatches_ReturnsTrue() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+            Assert.is_true(pipe.has(i => i == 4));
+        si
+
+        Pipe_HasSomeElementsMultipleMatches_ReturnsTrue() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+            Assert.is_true(pipe.has(i => i > 4));
+        si
+
+        Pipe_SkipThenFilter_ReturnsFilteredTailSequence() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            let result = pipe.skip(5).filter(i => (i ∩ 1) == 0);
+
+            assert_are_equal([6, 8, 10], result);
+        si
+
+        Pipe_FilterThenSkip_ReturnsFilteredTailSequence() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            let result = pipe.filter(i => (i ∩ 1) == 0).skip(1);
+
+            assert_are_equal([4, 6, 8, 10], result);
+        si
+
+        Pipe_SkipThenIndex_StartsIndexingFromZero() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            let result = pipe.skip(4).index();
+
+            assert_are_equal([iv(0, 5), iv(1, 6), iv(2, 7), iv(3, 8), iv(4, 9), iv(5, 10)], result);
+        si
+
+        Pipe_IndexThenSkip_StartsIndexingFromCorrectOffset() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            let result = pipe.index().skip(6);
+
+            assert_are_equal([iv(6, 7), iv(7, 8), iv(8, 9), iv(9, 10)], result);
+        si
+
+        Pipe_TakeThenFilter_ReturnsFilteredHeadSequence() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            let result = pipe.take(5).filter(i => (i ∩ 1) == 0);
+
+            assert_are_equal([2, 4], result);
+        si
+
+        Pipe_FilterThenTake_ReturnsFilteredHeadSequence() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            let result = pipe.filter(i => (i ∩ 1) == 0).take(3);
+
+            assert_are_equal([2, 4, 6], result);
+        si
+
+        Pipe_IndexThenFilter_RetainsOriginalIndexes() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            let result = pipe.index().filter(i => (i.value ∩ 1) == 1);
+
+            assert_are_equal([iv(0,1), iv(2,3), iv(4,5), iv(6,7), iv(8,9)], result);
+        si
+
+        Pipe_FilterThenIndex_AppliesNewIndexes() is
+            @test()
+
+            let pipe = Pipe`[int].from([3, 4, 1, 5, 2, 3, 1, 4, 5]);
+
+            let result = pipe.filter(i => i > 2).index();
+
+            assert_are_equal([iv(0,3), iv(1,4), iv(2,5), iv(3,3), iv(4,4), iv(5,5)], result);
+        si
+
+        Pipe_SkipThenMap_ReturnsMappedTailSequence() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            let result = pipe.skip(5).map(i => "X" + i);
+
+            assert_are_equal(["X6", "X7", "X8", "X9", "X10"], result);
+        si
+
+        Pipe_MapThenSkip_ReturnsMappedTailSequence() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            let result = pipe.map(i => "X" + i).skip(5);
+
+            assert_are_equal(["X6", "X7", "X8", "X9", "X10"], result);
+        si
+
+        Pipe_TakeThenMap_ReturnsMappedHeadSequence() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            let result = pipe.take(4).map(i => "X" + i);
+
+            assert_are_equal(["X1", "X2", "X3", "X4"], result);
+        si
+
+        Pipe_MapThenTake_ReturnsMappedHeadSequence() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            let result = pipe.map(i => "X" + i).take(6);
+
+            assert_are_equal(["X1", "X2", "X3", "X4", "X5", "X6"], result);
+        si
+
+        Pipe_TakeThenIndex_StartsIndexingFromZero() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            let result = pipe.take(4).index();
+
+            assert_are_equal([iv(0, 1), iv(1, 2), iv(2, 3), iv(3, 4)], result);
+        si
+
+        Pipe_IndexThenTake_StartsIndexingFromZero() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            let result = pipe.index().take(6);
+
+            assert_are_equal([iv(0, 1), iv(1, 2), iv(2, 3), iv(3, 4), iv(4, 5), iv(5, 6)], result);
+        si
+
+        Pipe_FilterThenFilter_ReturnsOnlyElementsThatMatchBothPredicates() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            let result = pipe.filter(i => i > 3 /\ i < 9).filter(i => (i ∩ 1) == 0);
+
+            assert_are_equal([4, 6, 8], result);
+        si
+
+        Pipe_MapThenMap_AppliesBothFunctionsToEveryElementInCorrectOrder() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6]);
+
+            let result = pipe.map(i => "" + i + "-first").map(i => i + "-second");
+
+            assert_are_equal(["1-first-second", "2-first-second", "3-first-second", "4-first-second", "5-first-second", "6-first-second"], result);
+        si
+
+        Pipe_Running() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6]);
+
+            let result = pipe.reduce(0, (running, element) => running + element);
+
+            Assert.are_equal(1 + 2 + 3 + 4 + 5 + 6, result);
+        si
+
+        Pipe_Mapped_Running() is
+            @test()
+
+            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6]);
+
+            let result = pipe.reduce(0, (running, element) => running + element, total => "total: " + total);
+
+            Assert.are_equal("total: " + (1 + 2 + 3 + 4 + 5 + 6), result);
+        si
+
+        Sort_NoComparer_SortsInDefaultOrder() is
+            @test()
+
+            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+
+            let result = pipe.sort();
+
+            assert_are_equal([1, 2, 3, 4, 5, 6], result);
+        si
+
+        Sort_GivenComparer_SortsInComparerOrder() is
+            @test()
+
+            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+
+            let result = pipe.sort(new ReverseIntComparer());
+
+            assert_are_equal([6, 5, 4, 3, 2, 1], result);
+        si
+
+        Sort_GivenCompareFunction_SortsInCompareFunctionOrder() is
+            @test()
+
+            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+
+            let result = pipe.sort((x, y) => y - x);
+
+            assert_are_equal([6, 5, 4, 3, 2, 1], result);
+        si
+
+        Sort_CalledTwice_SortsInLastComparerOrder() is
+            @test()
+
+            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+
+            let result = pipe.sort().sort(new ReverseIntComparer());
+
+            assert_are_equal([6, 5, 4, 3, 2, 1], result);
+        si
+
+        Sort_EnumeratedTwice_ReturnsSameResultBothTimes() is
+            @test()
+
+            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+
+            let sorted = pipe.sort(new ReverseIntComparer());
+
+            sorted.collect();
+
+            assert_are_equal([6, 5, 4, 3, 2, 1], sorted);
+        si
+
+        ToString_WithNoSeparatorArgument_ReturnsStringRepresentationOfAllElementsSeparatedWithACommaAndSpace() is
+            @test()
+
+            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+
+            let result = pipe.to_string();
+
+            Assert.are_equal("2, 1, 4, 3, 6, 5", result);
+        si
+
+        ToString_WithSeparatorArgument_ReturnsStringRepresentationOfAllElementsSeparatedWithThatSeparator() is
+            @test()
+
+            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+
+            let result = pipe.to_string("///");
+
+            Assert.are_equal("2///1///4///3///6///5", result);
+        si
+
+        ToString_CalledTwice_ReturnsStringRepresentationOfAllElements() is
+            @test()
+
+            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+
+            pipe.to_string();
+
+            let result = pipe.to_string("\t");
+
+            Assert.are_equal("2\t1\t4\t3\t6\t5", result);
+        si
+
+        AppendTo_WithNoSeparatorArgument_AppendsStringRepresentationOfAllElementsSeparatedWithACommaAndSpace() is
+            @test()
+
+            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+
+            let result = new StringBuilder("XX");
+
+            pipe.append_to(result);
+
+            Assert.are_equal("XX2, 1, 4, 3, 6, 5", result.to_string());
+        si
+
+        AppendTo_WithSeparatorArgument_AppendsStringRepresentationOfAllElementsSeparatedWithThatSeparator() is
+            @test()
+
+            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+
+            let result = new StringBuilder("XX");
+
+            pipe.append_to(result, "///");
+
+            Assert.are_equal("XX2///1///4///3///6///5", result.to_string());
+        si
+
+        AppendTo_CalledTwice_AppendsStringRepresentationOfAllElementsTwice() is
+            @test()
+
+            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+
+            let result = new StringBuilder("XX");
+
+            pipe.append_to(result, "-");
+
+            result.append("YY");
+
+            pipe.append_to(result, "_");
+
+            Assert.are_equal("XX2-1-4-3-6-5YY2_1_4_3_6_5", result.to_string());
+        si
+    si
+
+    class THING is
+        key: int;
+
+        init(key: int) is
+            self.key = key;
+        si
+    si
+
+    class ReverseIntComparer: IComparer`1[int] is
+        init() is si
+        compare(x: int, y: int) -> int => y - x;
+    si
+si
+
+
+/*
+
+These C# tests need to be translated into ghul
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using FluentAssertions;
+
+using Pipes;
+
+namespace Tests
+{
+    [TestClass]
+    public class PipeShould
+    {
+    
+        [TestMethod]
+        public void AppendTo_CalledTwice_AppendsStringRepresentationOfAllElementsTwice()
+        {
+            var pipe = Pipe.From(new [] {2, 1, 4, 3, 6, 5});
+
+            var result = new System.Text.StringBuilder("XX");
+
+            pipe
+                .AppendTo(result, "-");
+
+            result.Append("YY");
+
+            pipe
+                .AppendTo(result, "_");
+
+            result
+                .ToString()
+                .Should()
+                .Be("XX2-1-4-3-6-5YY2_1_4_3_6_5");
+        }
+
+
+        class ReverseIntComparer: System.Collections.Generic.IComparer<int>
+        {
+            public int Compare(int x, int y)
+            {
+                return y - x;
+            }
+        }
+    }
+}
+
+
+*/

--- a/project-tests/runtime-pipes/run.expected
+++ b/project-tests/runtime-pipes/run.expected
@@ -1,0 +1,379 @@
+run test: ADAPTOR_PIPEShould.Count_EmptyArray_ReturnsZero
+expect_equal: 0 == 0
+finished: ADAPTOR_PIPEShould.Count_EmptyArray_ReturnsZero
+
+run test: ADAPTOR_PIPEShould.Count_NonEmptyArray_ReturnsElementCount
+expect_equal: 5 == 5
+finished: ADAPTOR_PIPEShould.Count_NonEmptyArray_ReturnsElementCount
+
+run test: ADAPTOR_PIPEShould.Iterator_ReturnsCorrectElements
+expect_equal: a, b, c == a, b, c
+finished: ADAPTOR_PIPEShould.Iterator_ReturnsCorrectElements
+
+run test: ADAPTOR_PIPEShould.Iterator_ReturnsSelf
+expect_equal: a, b, c == a, b, c
+finished: ADAPTOR_PIPEShould.Iterator_ReturnsSelf
+
+run test: ADAPTOR_PIPEShould.Pipe_FromArray_ReturnsInstanceOfADAPTOR_PIPE
+expect_equal: Ghul.Pipes.ADAPTOR_PIPE[System.Int32] == Ghul.Pipes.ADAPTOR_PIPE[System.Int32]
+finished: ADAPTOR_PIPEShould.Pipe_FromArray_ReturnsInstanceOfADAPTOR_PIPE
+
+run test: CatPipeShould.Cat_ChainedCalls_CountReturnsSumOfAllCounts
+expect_equal: 10 == 10
+finished: CatPipeShould.Cat_ChainedCalls_CountReturnsSumOfAllCounts
+
+run test: CatPipeShould.Cat_ChainedCalls_ReturnsConcatenationOfAllInputs
+3, 4, 5, 1, 2, 1, 2, 3, 4, 5
+expect_equal: 3, 4, 5, 1, 2, 1, 2, 3, 4, 5 == 3, 4, 5, 1, 2, 1, 2, 3, 4, 5
+finished: CatPipeShould.Cat_ChainedCalls_ReturnsConcatenationOfAllInputs
+
+run test: CatPipeShould.Cat_EmptyPlusNonEmpty_ReturnsSecondSequence
+expect_equal: 1, 2, 3, 4, 5 == 1, 2, 3, 4, 5
+finished: CatPipeShould.Cat_EmptyPlusNonEmpty_ReturnsSecondSequence
+
+run test: CatPipeShould.Cat_EmptySequences_ReturnsEmptySequence
+expect_equal:  == 
+finished: CatPipeShould.Cat_EmptySequences_ReturnsEmptySequence
+
+run test: CatPipeShould.Cat_NonEmptyPlusEmpty_ReturnsFirstSequence
+expect_equal: 1, 2, 3, 4, 5 == 1, 2, 3, 4, 5
+finished: CatPipeShould.Cat_NonEmptyPlusEmpty_ReturnsFirstSequence
+
+run test: CatPipeShould.Cat_NonEmptyPlusNonEmpty_ReturnsBothSequencesInOrder
+expect_equal: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 == 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+finished: CatPipeShould.Cat_NonEmptyPlusNonEmpty_ReturnsBothSequencesInOrder
+
+run test: FilterPipeShould.Count_AlwaysTruePredicate_ReturnsElementCount
+expect_equal: 4 == 4
+finished: FilterPipeShould.Count_AlwaysTruePredicate_ReturnsElementCount
+
+run test: FilterPipeShould.Count_EmptyList_ReturnsZero
+expect_equal: 0 == 0
+finished: FilterPipeShould.Count_EmptyList_ReturnsZero
+
+run test: FilterPipeShould.Filter_CalledTwice_ReturnsOnlyElementsThatMatchBothPredicates
+expect_equal: 4, 6, 8 == 4, 6, 8
+finished: FilterPipeShould.Filter_CalledTwice_ReturnsOnlyElementsThatMatchBothPredicates
+
+run test: FilterPipeShould.Filter_ConsecutiveNonMatchingValues_AreRemoved
+expect_equal: 3, 4, 5, 3, 4, 5 == 3, 4, 5, 3, 4, 5
+finished: FilterPipeShould.Filter_ConsecutiveNonMatchingValues_AreRemoved
+
+run test: FilterPipeShould.Filter_LeadingNonMatchingValues_AreRemoved
+expect_equal: 3, 4, 5, 6, 7 == 3, 4, 5, 6, 7
+finished: FilterPipeShould.Filter_LeadingNonMatchingValues_AreRemoved
+
+run test: FilterPipeShould.Filter_NonConsecutiveNonMatchingValues_AreRemoved
+expect_equal: 3, 4, 5, 3, 4, 5 == 3, 4, 5, 3, 4, 5
+finished: FilterPipeShould.Filter_NonConsecutiveNonMatchingValues_AreRemoved
+
+run test: FilterPipeShould.Filter_TrailingNonMatchingValues_AreRemoved
+expect_equal: 7, 6, 5, 4, 3 == 7, 6, 5, 4, 3
+finished: FilterPipeShould.Filter_TrailingNonMatchingValues_AreRemoved
+
+run test: FilterPipeShould.Iterator_AlwaysTruePredicate_ResultEqualsInput
+finished: FilterPipeShould.Iterator_AlwaysTruePredicate_ResultEqualsInput
+
+run test: FilterPipeShould.Iterator_ReturnsSelf
+expect_equal: a, b, c == a, b, c
+finished: FilterPipeShould.Iterator_ReturnsSelf
+
+run test: IndexPipeShould.Index_EmptyArray_ReturnsEmptySequence
+expect_equal:  == 
+finished: IndexPipeShould.Index_EmptyArray_ReturnsEmptySequence
+
+run test: IndexPipeShould.Index_MultipleElements_ReturnsExpectedSequence
+expect_equal: (0,3), (1,4), (2,1), (3,5), (4,2), (5,3), (6,1), (7,4), (8,5) == (0,3), (1,4), (2,1), (3,5), (4,2), (5,3), (6,1), (7,4), (8,5)
+finished: IndexPipeShould.Index_MultipleElements_ReturnsExpectedSequence
+
+run test: IndexPipeShould.Index_MultipleElementsNegativeInitialIndex_ReturnsExpectedSequence
+expect_equal: (-3,3), (-2,4), (-1,1), (0,5), (1,2), (2,3), (3,1), (4,4), (5,5) == (-3,3), (-2,4), (-1,1), (0,5), (1,2), (2,3), (3,1), (4,4), (5,5)
+threw: IndexPipeShould.Index_MultipleElementsNegativeInitialIndex_ReturnsExpectedSequence
+error: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException: CollectionAssert.AreEqual failed. (Element at index 0 do not match.)
+   at Microsoft.VisualStudio.TestTools.UnitTesting.Assert.ThrowAssertFailed(String assertionName, String message) in /_/src/TestFramework/TestFramework/Assertions/Assert.cs:line 60
+   at Microsoft.VisualStudio.TestTools.UnitTesting.CollectionAssert.AreEqual(ICollection expected, ICollection actual, String message, Object[] parameters) in /_/src/TestFramework/TestFramework/Assertions/CollectionAssert.cs:line 956
+   at Microsoft.VisualStudio.TestTools.UnitTesting.CollectionAssert.AreEqual(ICollection expected, ICollection actual) in /_/src/TestFramework/TestFramework/Assertions/CollectionAssert.cs:line 894
+   at Tests.assert_are_equal[T](IEnumerable`1 expected, Pipe actual)
+   at Tests.IndexPipeShould.Index_MultipleElementsNegativeInitialIndex_ReturnsExpectedSequence()
+   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
+   at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
+   at Test.entry()
+
+run test: IndexPipeShould.Index_MultipleElementsPositiveInitialIndex_ReturnsExpectedSequence
+expect_equal: (3,3), (4,4), (5,1), (6,5), (7,2), (8,3), (9,1), (10,4), (11,5) == (3,3), (4,4), (5,1), (6,5), (7,2), (8,3), (9,1), (10,4), (11,5)
+threw: IndexPipeShould.Index_MultipleElementsPositiveInitialIndex_ReturnsExpectedSequence
+error: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException: CollectionAssert.AreEqual failed. (Element at index 0 do not match.)
+   at Microsoft.VisualStudio.TestTools.UnitTesting.Assert.ThrowAssertFailed(String assertionName, String message) in /_/src/TestFramework/TestFramework/Assertions/Assert.cs:line 60
+   at Microsoft.VisualStudio.TestTools.UnitTesting.CollectionAssert.AreEqual(ICollection expected, ICollection actual, String message, Object[] parameters) in /_/src/TestFramework/TestFramework/Assertions/CollectionAssert.cs:line 956
+   at Microsoft.VisualStudio.TestTools.UnitTesting.CollectionAssert.AreEqual(ICollection expected, ICollection actual) in /_/src/TestFramework/TestFramework/Assertions/CollectionAssert.cs:line 894
+   at Tests.assert_are_equal[T](IEnumerable`1 expected, Pipe actual)
+   at Tests.IndexPipeShould.Index_MultipleElementsPositiveInitialIndex_ReturnsExpectedSequence()
+   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
+   at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
+   at Test.entry()
+
+run test: IndexPipeShould.IndexedValue_ToString_ReturnsIndexAndValueInParentheses
+expect_equal: (1234,ABCD) == (1234,ABCD)
+finished: IndexPipeShould.IndexedValue_ToString_ReturnsIndexAndValueInParentheses
+
+run test: MapPipeShould.Map_CalledTwice_AppliesBothFunctionsToEveryElementInCorrectOrder
+expect_equal: 1-first-second, 2-first-second, 3-first-second, 4-first-second, 5-first-second, 6-first-second == 1-first-second, 2-first-second, 3-first-second, 4-first-second, 5-first-second, 6-first-second
+finished: MapPipeShould.Map_CalledTwice_AppliesBothFunctionsToEveryElementInCorrectOrder
+
+run test: MapPipeShould.Map_EmptyArray_ReturnsEmptySequence
+expect_equal:  == 
+finished: MapPipeShould.Map_EmptyArray_ReturnsEmptySequence
+
+run test: MapPipeShould.Map_IntsToStrings_ReturnsExpectedSequence
+expect_equal: 3, 4, 1, 5, 2, 3, 1, 4, 5 == 3, 4, 1, 5, 2, 3, 1, 4, 5
+finished: MapPipeShould.Map_IntsToStrings_ReturnsExpectedSequence
+
+run test: PipeOperatorShould.AppendTo_CalledTwice_AppendsStringRepresentationOfAllElementsTwice
+finished: PipeOperatorShould.AppendTo_CalledTwice_AppendsStringRepresentationOfAllElementsTwice
+
+run test: PipeOperatorShould.AppendTo_WithNoSeparatorArgument_AppendsStringRepresentationOfAllElementsSeparatedWithACommaAndSpace
+finished: PipeOperatorShould.AppendTo_WithNoSeparatorArgument_AppendsStringRepresentationOfAllElementsSeparatedWithACommaAndSpace
+
+run test: PipeOperatorShould.AppendTo_WithSeparatorArgument_AppendsStringRepresentationOfAllElementsSeparatedWithThatSeparator
+finished: PipeOperatorShould.AppendTo_WithSeparatorArgument_AppendsStringRepresentationOfAllElementsSeparatedWithThatSeparator
+
+run test: PipeOperatorShould.Pipe_FilterThenFilter_ReturnsOnlyElementsThatMatchBothPredicates
+finished: PipeOperatorShould.Pipe_FilterThenFilter_ReturnsOnlyElementsThatMatchBothPredicates
+
+run test: PipeOperatorShould.Pipe_FilterThenIndex_AppliesNewIndexes
+finished: PipeOperatorShould.Pipe_FilterThenIndex_AppliesNewIndexes
+
+run test: PipeOperatorShould.Pipe_FilterThenSkip_ReturnsFilteredTailSequence
+finished: PipeOperatorShould.Pipe_FilterThenSkip_ReturnsFilteredTailSequence
+
+run test: PipeOperatorShould.Pipe_FilterThenTake_ReturnsFilteredHeadSequence
+finished: PipeOperatorShould.Pipe_FilterThenTake_ReturnsFilteredHeadSequence
+
+run test: PipeOperatorShould.Pipe_FindEmptySequence_ReturnsMaybeNot
+finished: PipeOperatorShould.Pipe_FindEmptySequence_ReturnsMaybeNot
+
+run test: PipeOperatorShould.Pipe_FindMultipleMatchingElement_ReturnsFirstMatchingElement
+finished: PipeOperatorShould.Pipe_FindMultipleMatchingElement_ReturnsFirstMatchingElement
+
+run test: PipeOperatorShould.Pipe_FindNonEmptySequenceButNoMatch_ReturnsMaybeNot
+finished: PipeOperatorShould.Pipe_FindNonEmptySequenceButNoMatch_ReturnsMaybeNot
+
+run test: PipeOperatorShould.Pipe_FindSingleMatchingElement_ReturnsThatElement
+finished: PipeOperatorShould.Pipe_FindSingleMatchingElement_ReturnsThatElement
+
+run test: PipeOperatorShould.Pipe_FirstEmptySequence_ReturnsMaybeNot
+finished: PipeOperatorShould.Pipe_FirstEmptySequence_ReturnsMaybeNot
+
+run test: PipeOperatorShould.Pipe_HasNoElements_ReturnsFalse
+finished: PipeOperatorShould.Pipe_HasNoElements_ReturnsFalse
+
+run test: PipeOperatorShould.Pipe_HasSomeElementsButNoneMatch_ReturnsFalse
+finished: PipeOperatorShould.Pipe_HasSomeElementsButNoneMatch_ReturnsFalse
+
+run test: PipeOperatorShould.Pipe_HasSomeElementsMultipleMatches_ReturnsTrue
+finished: PipeOperatorShould.Pipe_HasSomeElementsMultipleMatches_ReturnsTrue
+
+run test: PipeOperatorShould.Pipe_HasSomeElementsOneMatches_ReturnsTrue
+finished: PipeOperatorShould.Pipe_HasSomeElementsOneMatches_ReturnsTrue
+
+run test: PipeOperatorShould.Pipe_IndexThenFilter_RetainsOriginalIndexes
+finished: PipeOperatorShould.Pipe_IndexThenFilter_RetainsOriginalIndexes
+
+run test: PipeOperatorShould.Pipe_IndexThenSkip_StartsIndexingFromCorrectOffset
+finished: PipeOperatorShould.Pipe_IndexThenSkip_StartsIndexingFromCorrectOffset
+
+run test: PipeOperatorShould.Pipe_IndexThenTake_StartsIndexingFromZero
+finished: PipeOperatorShould.Pipe_IndexThenTake_StartsIndexingFromZero
+
+run test: PipeOperatorShould.Pipe_Mapped_Running
+finished: PipeOperatorShould.Pipe_Mapped_Running
+
+run test: PipeOperatorShould.Pipe_MapThenMap_AppliesBothFunctionsToEveryElementInCorrectOrder
+finished: PipeOperatorShould.Pipe_MapThenMap_AppliesBothFunctionsToEveryElementInCorrectOrder
+
+run test: PipeOperatorShould.Pipe_MapThenSkip_ReturnsMappedTailSequence
+finished: PipeOperatorShould.Pipe_MapThenSkip_ReturnsMappedTailSequence
+
+run test: PipeOperatorShould.Pipe_MapThenTake_ReturnsMappedHeadSequence
+finished: PipeOperatorShould.Pipe_MapThenTake_ReturnsMappedHeadSequence
+
+run test: PipeOperatorShould.Pipe_Running
+finished: PipeOperatorShould.Pipe_Running
+
+run test: PipeOperatorShould.Pipe_SkipThenFilter_ReturnsFilteredTailSequence
+finished: PipeOperatorShould.Pipe_SkipThenFilter_ReturnsFilteredTailSequence
+
+run test: PipeOperatorShould.Pipe_SkipThenFirst_ReturnsCorrectElement
+expect_equal: Ghul.MAYBE[System.Int32] == Ghul.MAYBE[System.Int32]
+finished: PipeOperatorShould.Pipe_SkipThenFirst_ReturnsCorrectElement
+
+run test: PipeOperatorShould.Pipe_SkipThenIndex_StartsIndexingFromZero
+finished: PipeOperatorShould.Pipe_SkipThenIndex_StartsIndexingFromZero
+
+run test: PipeOperatorShould.Pipe_SkipThenMap_ReturnsMappedTailSequence
+finished: PipeOperatorShould.Pipe_SkipThenMap_ReturnsMappedTailSequence
+
+run test: PipeOperatorShould.Pipe_TakeThenFilter_ReturnsFilteredHeadSequence
+finished: PipeOperatorShould.Pipe_TakeThenFilter_ReturnsFilteredHeadSequence
+
+run test: PipeOperatorShould.Pipe_TakeThenFirst_ReturnsFirstElement
+finished: PipeOperatorShould.Pipe_TakeThenFirst_ReturnsFirstElement
+
+run test: PipeOperatorShould.Pipe_TakeThenIndex_StartsIndexingFromZero
+finished: PipeOperatorShould.Pipe_TakeThenIndex_StartsIndexingFromZero
+
+run test: PipeOperatorShould.Pipe_TakeThenMap_ReturnsMappedHeadSequence
+finished: PipeOperatorShould.Pipe_TakeThenMap_ReturnsMappedHeadSequence
+
+run test: PipeOperatorShould.Sort_CalledTwice_SortsInLastComparerOrder
+finished: PipeOperatorShould.Sort_CalledTwice_SortsInLastComparerOrder
+
+run test: PipeOperatorShould.Sort_EnumeratedTwice_ReturnsSameResultBothTimes
+finished: PipeOperatorShould.Sort_EnumeratedTwice_ReturnsSameResultBothTimes
+
+run test: PipeOperatorShould.Sort_GivenCompareFunction_SortsInCompareFunctionOrder
+finished: PipeOperatorShould.Sort_GivenCompareFunction_SortsInCompareFunctionOrder
+
+run test: PipeOperatorShould.Sort_GivenComparer_SortsInComparerOrder
+finished: PipeOperatorShould.Sort_GivenComparer_SortsInComparerOrder
+
+run test: PipeOperatorShould.Sort_NoComparer_SortsInDefaultOrder
+finished: PipeOperatorShould.Sort_NoComparer_SortsInDefaultOrder
+
+run test: PipeOperatorShould.ToString_CalledTwice_ReturnsStringRepresentationOfAllElements
+finished: PipeOperatorShould.ToString_CalledTwice_ReturnsStringRepresentationOfAllElements
+
+run test: PipeOperatorShould.ToString_WithNoSeparatorArgument_ReturnsStringRepresentationOfAllElementsSeparatedWithACommaAndSpace
+finished: PipeOperatorShould.ToString_WithNoSeparatorArgument_ReturnsStringRepresentationOfAllElementsSeparatedWithACommaAndSpace
+
+run test: PipeOperatorShould.ToString_WithSeparatorArgument_ReturnsStringRepresentationOfAllElementsSeparatedWithThatSeparator
+finished: PipeOperatorShould.ToString_WithSeparatorArgument_ReturnsStringRepresentationOfAllElementsSeparatedWithThatSeparator
+
+run test: PipeShould.AppendTo_CalledTwice_AppendsStringRepresentationOfAllElementsTwice
+finished: PipeShould.AppendTo_CalledTwice_AppendsStringRepresentationOfAllElementsTwice
+
+run test: PipeShould.AppendTo_WithNoSeparatorArgument_AppendsStringRepresentationOfAllElementsSeparatedWithACommaAndSpace
+finished: PipeShould.AppendTo_WithNoSeparatorArgument_AppendsStringRepresentationOfAllElementsSeparatedWithACommaAndSpace
+
+run test: PipeShould.AppendTo_WithSeparatorArgument_AppendsStringRepresentationOfAllElementsSeparatedWithThatSeparator
+finished: PipeShould.AppendTo_WithSeparatorArgument_AppendsStringRepresentationOfAllElementsSeparatedWithThatSeparator
+
+run test: PipeShould.Pipe_FilterThenFilter_ReturnsOnlyElementsThatMatchBothPredicates
+finished: PipeShould.Pipe_FilterThenFilter_ReturnsOnlyElementsThatMatchBothPredicates
+
+run test: PipeShould.Pipe_FilterThenIndex_AppliesNewIndexes
+finished: PipeShould.Pipe_FilterThenIndex_AppliesNewIndexes
+
+run test: PipeShould.Pipe_FilterThenSkip_ReturnsFilteredTailSequence
+finished: PipeShould.Pipe_FilterThenSkip_ReturnsFilteredTailSequence
+
+run test: PipeShould.Pipe_FilterThenTake_ReturnsFilteredHeadSequence
+finished: PipeShould.Pipe_FilterThenTake_ReturnsFilteredHeadSequence
+
+run test: PipeShould.Pipe_FindEmptySequence_ReturnsMaybeNot
+finished: PipeShould.Pipe_FindEmptySequence_ReturnsMaybeNot
+
+run test: PipeShould.Pipe_FindMultipleMatchingElement_ReturnsFirstMatchingElement
+finished: PipeShould.Pipe_FindMultipleMatchingElement_ReturnsFirstMatchingElement
+
+run test: PipeShould.Pipe_FindNonEmptySequenceButNoMatch_ReturnsMaybeNot
+finished: PipeShould.Pipe_FindNonEmptySequenceButNoMatch_ReturnsMaybeNot
+
+run test: PipeShould.Pipe_FindSingleMatchingElement_ReturnsThatElement
+finished: PipeShould.Pipe_FindSingleMatchingElement_ReturnsThatElement
+
+run test: PipeShould.Pipe_FirstEmptySequence_ReturnsMaybeNot
+finished: PipeShould.Pipe_FirstEmptySequence_ReturnsMaybeNot
+
+run test: PipeShould.Pipe_HasNoElements_ReturnsFalse
+finished: PipeShould.Pipe_HasNoElements_ReturnsFalse
+
+run test: PipeShould.Pipe_HasSomeElementsButNoneMatch_ReturnsFalse
+finished: PipeShould.Pipe_HasSomeElementsButNoneMatch_ReturnsFalse
+
+run test: PipeShould.Pipe_HasSomeElementsMultipleMatches_ReturnsTrue
+finished: PipeShould.Pipe_HasSomeElementsMultipleMatches_ReturnsTrue
+
+run test: PipeShould.Pipe_HasSomeElementsOneMatches_ReturnsTrue
+finished: PipeShould.Pipe_HasSomeElementsOneMatches_ReturnsTrue
+
+run test: PipeShould.Pipe_IndexThenFilter_RetainsOriginalIndexes
+finished: PipeShould.Pipe_IndexThenFilter_RetainsOriginalIndexes
+
+run test: PipeShould.Pipe_IndexThenSkip_StartsIndexingFromCorrectOffset
+finished: PipeShould.Pipe_IndexThenSkip_StartsIndexingFromCorrectOffset
+
+run test: PipeShould.Pipe_IndexThenTake_StartsIndexingFromZero
+finished: PipeShould.Pipe_IndexThenTake_StartsIndexingFromZero
+
+run test: PipeShould.Pipe_Mapped_Running
+finished: PipeShould.Pipe_Mapped_Running
+
+run test: PipeShould.Pipe_MapThenMap_AppliesBothFunctionsToEveryElementInCorrectOrder
+finished: PipeShould.Pipe_MapThenMap_AppliesBothFunctionsToEveryElementInCorrectOrder
+
+run test: PipeShould.Pipe_MapThenSkip_ReturnsMappedTailSequence
+finished: PipeShould.Pipe_MapThenSkip_ReturnsMappedTailSequence
+
+run test: PipeShould.Pipe_MapThenTake_ReturnsMappedHeadSequence
+finished: PipeShould.Pipe_MapThenTake_ReturnsMappedHeadSequence
+
+run test: PipeShould.Pipe_Running
+finished: PipeShould.Pipe_Running
+
+run test: PipeShould.Pipe_SkipThenFilter_ReturnsFilteredTailSequence
+finished: PipeShould.Pipe_SkipThenFilter_ReturnsFilteredTailSequence
+
+run test: PipeShould.Pipe_SkipThenFirst_ReturnsCorrectElement
+finished: PipeShould.Pipe_SkipThenFirst_ReturnsCorrectElement
+
+run test: PipeShould.Pipe_SkipThenIndex_StartsIndexingFromZero
+finished: PipeShould.Pipe_SkipThenIndex_StartsIndexingFromZero
+
+run test: PipeShould.Pipe_SkipThenMap_ReturnsMappedTailSequence
+finished: PipeShould.Pipe_SkipThenMap_ReturnsMappedTailSequence
+
+run test: PipeShould.Pipe_TakeThenFilter_ReturnsFilteredHeadSequence
+finished: PipeShould.Pipe_TakeThenFilter_ReturnsFilteredHeadSequence
+
+run test: PipeShould.Pipe_TakeThenFirst_ReturnsFirstElement
+finished: PipeShould.Pipe_TakeThenFirst_ReturnsFirstElement
+
+run test: PipeShould.Pipe_TakeThenIndex_StartsIndexingFromZero
+finished: PipeShould.Pipe_TakeThenIndex_StartsIndexingFromZero
+
+run test: PipeShould.Pipe_TakeThenMap_ReturnsMappedHeadSequence
+finished: PipeShould.Pipe_TakeThenMap_ReturnsMappedHeadSequence
+
+run test: PipeShould.Sort_CalledTwice_SortsInLastComparerOrder
+finished: PipeShould.Sort_CalledTwice_SortsInLastComparerOrder
+
+run test: PipeShould.Sort_EnumeratedTwice_ReturnsSameResultBothTimes
+finished: PipeShould.Sort_EnumeratedTwice_ReturnsSameResultBothTimes
+
+run test: PipeShould.Sort_GivenCompareFunction_SortsInCompareFunctionOrder
+finished: PipeShould.Sort_GivenCompareFunction_SortsInCompareFunctionOrder
+
+run test: PipeShould.Sort_GivenComparer_SortsInComparerOrder
+finished: PipeShould.Sort_GivenComparer_SortsInComparerOrder
+
+run test: PipeShould.Sort_NoComparer_SortsInDefaultOrder
+finished: PipeShould.Sort_NoComparer_SortsInDefaultOrder
+
+run test: PipeShould.ToString_CalledTwice_ReturnsStringRepresentationOfAllElements
+finished: PipeShould.ToString_CalledTwice_ReturnsStringRepresentationOfAllElements
+
+run test: PipeShould.ToString_WithNoSeparatorArgument_ReturnsStringRepresentationOfAllElementsSeparatedWithACommaAndSpace
+finished: PipeShould.ToString_WithNoSeparatorArgument_ReturnsStringRepresentationOfAllElementsSeparatedWithACommaAndSpace
+
+run test: PipeShould.ToString_WithSeparatorArgument_ReturnsStringRepresentationOfAllElementsSeparatedWithThatSeparator
+finished: PipeShould.ToString_WithSeparatorArgument_ReturnsStringRepresentationOfAllElementsSeparatedWithThatSeparator
+

--- a/project-tests/runtime-pipes/run.expected
+++ b/project-tests/runtime-pipes/run.expected
@@ -88,37 +88,11 @@ finished: IndexPipeShould.Index_MultipleElements_ReturnsExpectedSequence
 
 run test: IndexPipeShould.Index_MultipleElementsNegativeInitialIndex_ReturnsExpectedSequence
 expect_equal: (-3,3), (-2,4), (-1,1), (0,5), (1,2), (2,3), (3,1), (4,4), (5,5) == (-3,3), (-2,4), (-1,1), (0,5), (1,2), (2,3), (3,1), (4,4), (5,5)
-threw: IndexPipeShould.Index_MultipleElementsNegativeInitialIndex_ReturnsExpectedSequence
-error: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
- ---> Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException: CollectionAssert.AreEqual failed. (Element at index 0 do not match.)
-   at Microsoft.VisualStudio.TestTools.UnitTesting.Assert.ThrowAssertFailed(String assertionName, String message) in /_/src/TestFramework/TestFramework/Assertions/Assert.cs:line 60
-   at Microsoft.VisualStudio.TestTools.UnitTesting.CollectionAssert.AreEqual(ICollection expected, ICollection actual, String message, Object[] parameters) in /_/src/TestFramework/TestFramework/Assertions/CollectionAssert.cs:line 956
-   at Microsoft.VisualStudio.TestTools.UnitTesting.CollectionAssert.AreEqual(ICollection expected, ICollection actual) in /_/src/TestFramework/TestFramework/Assertions/CollectionAssert.cs:line 894
-   at Tests.assert_are_equal[T](IEnumerable`1 expected, Pipe actual)
-   at Tests.IndexPipeShould.Index_MultipleElementsNegativeInitialIndex_ReturnsExpectedSequence()
-   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
-   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
-   --- End of inner exception stack trace ---
-   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
-   at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
-   at Test.entry()
+finished: IndexPipeShould.Index_MultipleElementsNegativeInitialIndex_ReturnsExpectedSequence
 
 run test: IndexPipeShould.Index_MultipleElementsPositiveInitialIndex_ReturnsExpectedSequence
 expect_equal: (3,3), (4,4), (5,1), (6,5), (7,2), (8,3), (9,1), (10,4), (11,5) == (3,3), (4,4), (5,1), (6,5), (7,2), (8,3), (9,1), (10,4), (11,5)
-threw: IndexPipeShould.Index_MultipleElementsPositiveInitialIndex_ReturnsExpectedSequence
-error: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
- ---> Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException: CollectionAssert.AreEqual failed. (Element at index 0 do not match.)
-   at Microsoft.VisualStudio.TestTools.UnitTesting.Assert.ThrowAssertFailed(String assertionName, String message) in /_/src/TestFramework/TestFramework/Assertions/Assert.cs:line 60
-   at Microsoft.VisualStudio.TestTools.UnitTesting.CollectionAssert.AreEqual(ICollection expected, ICollection actual, String message, Object[] parameters) in /_/src/TestFramework/TestFramework/Assertions/CollectionAssert.cs:line 956
-   at Microsoft.VisualStudio.TestTools.UnitTesting.CollectionAssert.AreEqual(ICollection expected, ICollection actual) in /_/src/TestFramework/TestFramework/Assertions/CollectionAssert.cs:line 894
-   at Tests.assert_are_equal[T](IEnumerable`1 expected, Pipe actual)
-   at Tests.IndexPipeShould.Index_MultipleElementsPositiveInitialIndex_ReturnsExpectedSequence()
-   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
-   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
-   --- End of inner exception stack trace ---
-   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
-   at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
-   at Test.entry()
+finished: IndexPipeShould.Index_MultipleElementsPositiveInitialIndex_ReturnsExpectedSequence
 
 run test: IndexPipeShould.IndexedValue_ToString_ReturnsIndexAndValueInParentheses
 expect_equal: (1234,ABCD) == (1234,ABCD)

--- a/project-tests/runtime-pipes/runtime.ghulproj
+++ b/project-tests/runtime-pipes/runtime.ghulproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <GhulCompiler>dotnet ghul-compiler</GhulCompiler>
+    <AssemblyName>binary</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <GhulSources Include="**/*.ghul" />
+
+    <PackageReference Include="MSTest.TestFramework" />
+  </ItemGroup>
+</Project>

--- a/project-tests/runtime-pipes/test.ghul
+++ b/project-tests/runtime-pipes/test.ghul
@@ -1,0 +1,57 @@
+namespace Test is
+    use IO.Std.write_line;
+    use System.Reflection;
+    use System.Activator;
+    use Type = System.Type2;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    entry() is
+        let type_compare = (t1: Type, t2: Type) is
+            let t1_name = t1.name;
+            return t1_name.compare_to(t2.name);
+        si;
+
+        let method_compare = (m1: MethodInfo, m2: MethodInfo) is
+            let m1_name = m1.name;
+            return m1_name.compare_to(m2.name);
+        si;
+
+        let assembly = Assembly.get_executing_assembly();
+
+        let types = assembly.get_types() | .sort(type_compare);
+
+        for type in types do
+            let is_test_class = type.get_custom_attributes(typeof TestClassAttribute, false).count > 0;
+
+            if !is_test_class then
+                continue;
+            fi
+
+            let methods = type.get_methods() | .sort(method_compare);
+
+            for method in methods do
+                let is_test_method = method.get_custom_attributes(typeof TestMethodAttribute, false).count > 0;
+
+                if !is_test_method then
+                    continue;
+                fi
+
+                try
+                    write_line("run test: " + type.name + "." + method.name);
+
+                    let instance = Activator.create_instance(type);
+    
+                    method.invoke(instance, null);
+    
+                    write_line("finished: " + type.name + "." + method.name);
+                    write_line();
+                catch e: System.Exception
+                    write_line("threw: " + type.name + "." + method.name);
+                    write_line("error: " + e);
+                    write_line();
+                yrt
+            od
+        od
+    si
+si

--- a/project-tests/runtime-pipes/tests.ghul
+++ b/project-tests/runtime-pipes/tests.ghul
@@ -1,0 +1,31 @@
+namespace Tests is
+    use IO.Std.write_line;
+
+    use Collections;
+    use Microsoft.VisualStudio.TestTools.UnitTesting;
+
+
+    assert_equal[T](a: Collections.Iterable[T], b: Collections.Iterable[T]) is
+        // FIXME: can no-longer construct LIST[T] from an Iterable[T]
+        // not sure if this is a change from .NET 6 to .NET 8 or if it's
+        // a compiler bug:
+
+        let la: Collections.LIST[T] = new Collections.LIST[T]();
+        let lb: Collections.LIST[T] = new Collections.LIST[T]();
+
+        la.add_range(a);
+        lb.add_range(b);
+
+        CollectionAssert.are_equal(la, lb);            
+    si
+
+    collect[T](iterator: LIST_REVERSE_ITERATOR[T]) -> Iterable[T] is
+        let result = new LIST[T]();
+
+        while iterator.move_next() do
+            result.add(iterator.current);
+        od
+
+        return result;
+    si
+si

--- a/project-tests/runtime-ranges/.vscode/ghul.json
+++ b/project-tests/runtime-ranges/.vscode/ghul.json
@@ -1,0 +1,6 @@
+{
+    "compiler": "dotnet ../../../publish/ghul.dll",
+    "source": [
+        "."
+    ]
+}

--- a/project-tests/runtime-ranges/.vscode/tasks.json
+++ b/project-tests/runtime-ranges/.vscode/tasks.json
@@ -1,0 +1,23 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run test",
+            "command": "dotnet ghul-test --use-dotnet-build \"${workspaceFolder}\"",
+            "type": "shell",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "Capture test expectation",
+            "command": "../../tasks/capture.sh \"${workspaceFolder}\"",
+            "type": "shell",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/project-tests/runtime-ranges/common.ghul
+++ b/project-tests/runtime-ranges/common.ghul
@@ -1,0 +1,26 @@
+namespace Tests is
+    use IO.Std.write_line;
+    use Collections;
+    
+    use Microsoft.VisualStudio.TestTools.UnitTesting;
+    
+    use Ghul.Pipes;
+    
+    empty[T]() -> T[] => System.Array.empty`[T]();
+    
+    iv[T](index: int, value: T) -> INDEXED_VALUE[T] => new INDEXED_VALUE[T](index, value);
+    
+    expect_equal[T](a: T, b: T) is
+        write_line("expect_equal: {0} == {1}", a, b);
+    si
+    
+    assert_are_equal[T](expected: Iterable[T], actual: Pipe[T]) is
+        let expected_elements = new LIST[T]();
+        let actual_elements = new LIST[T]();
+    
+        expected_elements.add_range(expected);
+        actual_elements.add_range(actual);
+    
+        CollectionAssert.are_equal(expected_elements, actual_elements);
+    si
+si

--- a/project-tests/runtime-ranges/int-range-inclusive.ghul
+++ b/project-tests/runtime-ranges/int-range-inclusive.ghul
@@ -1,0 +1,159 @@
+namespace Tests is
+    use Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    class INT_RANGE_INCLUSIVE_Should is
+        @test()
+
+        init() is si
+
+        INT_RANGE_INCLUSIVE__init__given_0_to_10__constructs_range_with_11_elements() is
+            @test()
+
+            let range = new Ghul.INT_RANGE_INCLUSIVE(0, 10);
+
+            expect_equal(range | .count(), 11);
+
+            Assert.are_equal(Pipes.Pipe`[int].from(range) .count(), 11);
+        si        
+
+        INT_RANGE_INCLUSIVE__init__given_0_to_10__constructs_range_with_11_elements_consecutive_elements_0_through_10() is
+            @test()
+
+            let range = new Ghul.INT_RANGE_INCLUSIVE(0, 10);
+
+            expect_equal(range |, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] |);
+            assert_equal(range, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        si
+
+        INT_RANGE_INCLUSIVE__init__given_10_to_0__constructs_range_with_0_elements() is
+            @test()
+
+            let range = new Ghul.INT_RANGE_INCLUSIVE(10, 0);
+
+            expect_equal(range | .count(), 0);
+            Assert.are_equal(Pipes.Pipe`[int].from(range) .count(), 0);
+        si
+
+        INT_RANGE_INCLUSIVE__init__given_50_to_50__constructs_range_with_1_elements() is
+            @test()
+
+            let range = new Ghul.INT_RANGE_INCLUSIVE(50, 50);
+
+            expect_equal(range | .count(), 1);
+            Assert.are_equal(Pipes.Pipe`[int].from(range) .count(), 1);
+        si
+
+        INT_RANGE_INCLUSIVE__colon_colon__given_0_to_10__constructs_range_with_consecutive_elements_0_through_10() is
+            @test()
+
+            let range = 0::10;
+
+            expect_equal(range |, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] |);
+            assert_equal(range, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);            
+        si
+
+        INT_RANGE_INCLUSIVE__colon_colon__minus_5_to_5__constructs_range_with_consecutive_elements_minus_5_through_5() is
+            @test()
+
+            let range = -5::5;
+
+            expect_equal(range |, [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5] |);
+            assert_equal(range, [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]);            
+        si
+
+        INT_RANGE_INCLUSIVE__reset__given_partially_enumerated_range__starts_from_beginning_again() is
+            @test()
+
+            let range = 0::10;
+            
+            Pipes.Pipe`[int].from(range) .take(5);
+
+            expect_equal(range |, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] |);
+            assert_equal(range, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        si
+
+        INT_RANGE_INCLUSIVE__from__given_0_to_10__is_0() is
+            @test()
+
+            let range = 0::10;
+
+            expect_equal(range.from, 0);
+            Assert.are_equal(range.from, 0);
+        si
+
+        INT_RANGE_INCLUSIVE__to__given_0_to_10__is_10() is
+            @test()
+
+            let range = 0::10;
+
+            expect_equal(range.to, 10);
+            Assert.are_equal(range.to, 10);
+        si
+
+        INT_RANGE_INCLUSIVE__move_next__given_0_to_10__returns_true() is
+            @test()
+
+            let range = 0::10;
+
+            let result = range.move_next();
+
+            expect_equal(result, true);
+            Assert.is_true(result);
+        si
+
+        INT_RANGE_INCLUSIVE__move_next__given_10_to_0__returns_false() is
+            @test()
+
+            let range = 10::0;
+
+            let result = range.move_next();
+
+            expect_equal(result, true);
+            Assert.is_false(result);
+        si
+
+        INT_RANGE_INCLUSIVE__to_string__given_new_0_to_10__returns_0_colon_colon_10() is
+            @test()
+
+            let range = 0::10;
+
+            expect_equal(range.to_string(), "0::10");
+            Assert.are_equal("0::10", range.to_string());
+        si
+
+        INT_RANGE_INCLUSIVE__to_string__given_reset_0_to_10__returns_0_colon_colon_10() is
+            @test()
+
+            let range = 0::10;
+
+            range.reset();
+
+            expect_equal(range.to_string(), "0::10");
+            Assert.are_equal("0::10", range.to_string());
+        si
+
+        INT_RANGE_INCLUSIVE__to_string__given_0_to_10_then_move_next_returns_0_colon_colon_10_at_0() is
+            @test()
+
+            let range = 0::10;
+
+            range.move_next();
+
+            expect_equal(range.to_string(), "0::10 @ 0");
+            Assert.are_equal("0::10 @ 0", range.to_string());
+        si
+
+        INT_RANGE_INCLUSIVE__to_string__given_0_to_10_then_3_move_next_returns_0_colon_colon_10_at_2() is
+            @test()
+
+            let range = 0::10;
+
+            range.move_next();
+            range.move_next();
+            range.move_next();
+
+            expect_equal(range.to_string(), "0::10 @ 2");
+            Assert.are_equal("0::10 @ 2", range.to_string());
+        si        
+    si
+si

--- a/project-tests/runtime-ranges/int-range.ghul
+++ b/project-tests/runtime-ranges/int-range.ghul
@@ -1,0 +1,158 @@
+namespace Tests is
+    use Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    class INT_RANGE_Should is
+        @test()
+
+        init() is si
+
+        INT_RANGE__init__given_0_to_10__constructs_range_with_10_elements() is
+            @test()
+
+            let range = new Ghul.INT_RANGE(0, 10);
+
+            expect_equal(range | .count(), 10);
+            Assert.are_equal(Pipes.Pipe`[int].from(range) .count(), 10);
+        si        
+
+        INT_RANGE__init__given_0_to_10__constructs_range_with_10_elements_consecutive_elements_0_through_9() is
+            @test()
+
+            let range = new Ghul.INT_RANGE(0, 10);
+
+            expect_equal(range |, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] |);
+            assert_equal(range, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        si
+
+        INT_RANGE__init__given_10_to_0__constructs_range_with_0_elements() is
+            @test()
+
+            let range = new Ghul.INT_RANGE(10, 0);
+
+            expect_equal(range | .count(), 0);
+            Assert.are_equal(Pipes.Pipe`[int].from(range) .count(), 0);
+        si
+
+        INT_RANGE__init__given_50_to_50__constructs_range_with_0_elements() is
+            @test()
+
+            let range = new Ghul.INT_RANGE(50, 50);
+
+            expect_equal(range | .count(), 0);
+            Assert.are_equal(Pipes.Pipe`[int].from(range) .count(), 0);
+        si
+
+        INT_RANGE__dot_dot__given_0_to_10__constructs_range_with_consecutive_elements_0_through_9() is
+            @test()
+
+            let range = 0..10;
+
+            expect_equal(range |, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] |);
+            assert_equal(range, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);            
+        si
+
+        INT_RANGE__dot_dot__minus_5_to_5__constructs_range_with_consecutive_elements_minus_5_through_4() is
+            @test()
+
+            let range = -5..5;
+
+            expect_equal(range |, [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4] |);
+            assert_equal(range, [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4]);            
+        si
+
+        INT_RANGE__reset__given_partially_enumerated_range__starts_from_beginning_again() is
+            @test()
+
+            let range = 0..10;
+            
+            Pipes.Pipe`[int].from(range) .take(5);
+
+            expect_equal(range |, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] |);
+            assert_equal(range, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        si
+
+        INT_RANGE__from__given_0_to_10__is_0() is
+            @test()
+
+            let range = 0..10;
+
+            expect_equal(range.from, 0);
+            Assert.are_equal(range.from, 0);
+        si
+
+        INT_RANGE__to__given_0_to_10__is_10() is
+            @test()
+
+            let range = 0..10;
+
+            expect_equal(range.to, 10);
+            Assert.are_equal(range.to, 10);
+        si
+
+        INT_RANGE__move_next__given_0_to_10__returns_true() is
+            @test()
+
+            let range = 0..10;
+
+            let result = range.move_next();
+
+            expect_equal(result, true);
+            Assert.is_true(result);
+        si
+
+        INT_RANGE__move_next__given_10_to_0__returns_false() is
+            @test()
+
+            let range = 10..0;
+
+            let result = range.move_next();
+
+            expect_equal(result, false);
+            Assert.is_false(result);
+        si
+
+        INT_RANGE__to_string__given_new_0_to_10__returns_0_dot_dot_10() is
+            @test()
+
+            let range = 0..10;
+
+            expect_equal(range.to_string(), "0..10");
+            Assert.are_equal("0..10", range.to_string());
+        si
+
+        INT_RANGE__to_string__given_reset_0_to_10__returns_0_dot_dot_10() is
+            @test()
+
+            let range = 0..10;
+
+            range.reset();
+
+            expect_equal(range.to_string(), "0..10");
+            Assert.are_equal("0..10", range.to_string());
+        si
+
+        INT_RANGE__to_string__given_0_to_10_then_move_next_returns_0_dot_dot_10_at_0() is
+            @test()
+
+            let range = 0..10;
+
+            range.move_next();
+
+            expect_equal(range.to_string(), "0..10 @ 0");
+            Assert.are_equal("0..10 @ 0", range.to_string());
+        si
+
+        INT_RANGE__to_string__given_0_to_10_then_3_move_next_returns_0_dot_dot_10_at_2() is
+            @test()
+
+            let range = 0..10;
+
+            range.move_next();
+            range.move_next();
+            range.move_next();
+
+            expect_equal(range.to_string(), "0..10 @ 2");
+            Assert.are_equal("0..10 @ 2", range.to_string());
+        si
+    si
+si

--- a/project-tests/runtime-ranges/list-reverse-iterator.ghul
+++ b/project-tests/runtime-ranges/list-reverse-iterator.ghul
@@ -1,0 +1,55 @@
+namespace Tests is
+    use Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    use Collections.Iterable;
+    use Collections.LIST;
+    use Collections.LIST_REVERSE_ITERATOR;
+
+    class LIST_REVERSE_ITERATOR_Should is
+        @test()
+
+        init() is si
+
+        LIST_REVERSE_ITERATOR__iterator__given_empty_list__returns_no_elements() is
+            @test()
+
+            let iterator = new LIST_REVERSE_ITERATOR[int](new Collections.LIST[int]());
+
+            expect_equal(collect(iterator) |, empty`[int]() |);
+            assert_equal(collect(iterator), empty`[int]());
+        si
+
+        LIST_REVERSE_ITERATOR__iterator__given_single_element_list__returns_that_element() is
+            @test()
+
+            let iterator = new LIST_REVERSE_ITERATOR[int](new Collections.LIST[int]([1]));
+
+            let result = collect(iterator);
+
+            expect_equal(result |, [1] |);
+            assert_equal(result, [1]);
+        si
+
+        LIST_REVERSE_ITERATOR__iterator__given_odd_length_multiple_element_list__returns_elements_in_reverse_order() is
+            @test()
+
+            let iterator = new LIST_REVERSE_ITERATOR[int](new Collections.LIST[int]([1, 2, 3, 6, 7, 8, 11]));
+
+            let result = collect(iterator);
+
+            expect_equal(result |, [11, 8, 7, 6, 3, 2, 1] |);
+            assert_equal(result, [11, 8, 7, 6, 3, 2, 1]);
+        si
+
+        LIST_REVERSE_ITERATOR__iterator__given_even_length_multiple_element_list__returns_elements_in_reverse_order() is
+            @test()
+
+            let iterator = new LIST_REVERSE_ITERATOR[int](new Collections.LIST[int]([1, 2, 3, 6, 7, 8, 11, 3, 6, 2]));
+
+            let result = collect(iterator);
+
+            expect_equal(result |, [2, 6, 3, 11, 8, 7, 6, 3, 2, 1] |);
+            assert_equal(result, [2, 6, 3, 11, 8, 7, 6, 3, 2, 1]);
+        si
+    si
+si

--- a/project-tests/runtime-ranges/run.expected
+++ b/project-tests/runtime-ranges/run.expected
@@ -1,0 +1,136 @@
+run test: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__colon_colon__given_0_to_10__constructs_range_with_consecutive_elements_0_through_10
+expect_equal: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 == 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+finished: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__colon_colon__given_0_to_10__constructs_range_with_consecutive_elements_0_through_10
+
+run test: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__colon_colon__minus_5_to_5__constructs_range_with_consecutive_elements_minus_5_through_5
+expect_equal: -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5 == -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5
+finished: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__colon_colon__minus_5_to_5__constructs_range_with_consecutive_elements_minus_5_through_5
+
+run test: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__from__given_0_to_10__is_0
+expect_equal: 0 == 0
+finished: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__from__given_0_to_10__is_0
+
+run test: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__init__given_0_to_10__constructs_range_with_11_elements
+expect_equal: 11 == 11
+finished: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__init__given_0_to_10__constructs_range_with_11_elements
+
+run test: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__init__given_0_to_10__constructs_range_with_11_elements_consecutive_elements_0_through_10
+expect_equal: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 == 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+finished: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__init__given_0_to_10__constructs_range_with_11_elements_consecutive_elements_0_through_10
+
+run test: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__init__given_10_to_0__constructs_range_with_0_elements
+expect_equal: 0 == 0
+finished: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__init__given_10_to_0__constructs_range_with_0_elements
+
+run test: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__init__given_50_to_50__constructs_range_with_1_elements
+expect_equal: 1 == 1
+finished: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__init__given_50_to_50__constructs_range_with_1_elements
+
+run test: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__move_next__given_0_to_10__returns_true
+expect_equal: True == True
+finished: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__move_next__given_0_to_10__returns_true
+
+run test: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__move_next__given_10_to_0__returns_false
+expect_equal: False == True
+finished: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__move_next__given_10_to_0__returns_false
+
+run test: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__reset__given_partially_enumerated_range__starts_from_beginning_again
+expect_equal: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 == 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+finished: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__reset__given_partially_enumerated_range__starts_from_beginning_again
+
+run test: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__to__given_0_to_10__is_10
+expect_equal: 10 == 10
+finished: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__to__given_0_to_10__is_10
+
+run test: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__to_string__given_0_to_10_then_3_move_next_returns_0_colon_colon_10_at_2
+expect_equal: 0::10 @ 2 == 0::10 @ 2
+finished: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__to_string__given_0_to_10_then_3_move_next_returns_0_colon_colon_10_at_2
+
+run test: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__to_string__given_0_to_10_then_move_next_returns_0_colon_colon_10_at_0
+expect_equal: 0::10 @ 0 == 0::10 @ 0
+finished: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__to_string__given_0_to_10_then_move_next_returns_0_colon_colon_10_at_0
+
+run test: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__to_string__given_new_0_to_10__returns_0_colon_colon_10
+expect_equal: 0::10 == 0::10
+finished: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__to_string__given_new_0_to_10__returns_0_colon_colon_10
+
+run test: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__to_string__given_reset_0_to_10__returns_0_colon_colon_10
+expect_equal: 0::10 == 0::10
+finished: INT_RANGE_INCLUSIVE_Should.INT_RANGE_INCLUSIVE__to_string__given_reset_0_to_10__returns_0_colon_colon_10
+
+run test: INT_RANGE_Should.INT_RANGE__dot_dot__given_0_to_10__constructs_range_with_consecutive_elements_0_through_9
+expect_equal: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 == 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+finished: INT_RANGE_Should.INT_RANGE__dot_dot__given_0_to_10__constructs_range_with_consecutive_elements_0_through_9
+
+run test: INT_RANGE_Should.INT_RANGE__dot_dot__minus_5_to_5__constructs_range_with_consecutive_elements_minus_5_through_4
+expect_equal: -5, -4, -3, -2, -1, 0, 1, 2, 3, 4 == -5, -4, -3, -2, -1, 0, 1, 2, 3, 4
+finished: INT_RANGE_Should.INT_RANGE__dot_dot__minus_5_to_5__constructs_range_with_consecutive_elements_minus_5_through_4
+
+run test: INT_RANGE_Should.INT_RANGE__from__given_0_to_10__is_0
+expect_equal: 0 == 0
+finished: INT_RANGE_Should.INT_RANGE__from__given_0_to_10__is_0
+
+run test: INT_RANGE_Should.INT_RANGE__init__given_0_to_10__constructs_range_with_10_elements
+expect_equal: 10 == 10
+finished: INT_RANGE_Should.INT_RANGE__init__given_0_to_10__constructs_range_with_10_elements
+
+run test: INT_RANGE_Should.INT_RANGE__init__given_0_to_10__constructs_range_with_10_elements_consecutive_elements_0_through_9
+expect_equal: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 == 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+finished: INT_RANGE_Should.INT_RANGE__init__given_0_to_10__constructs_range_with_10_elements_consecutive_elements_0_through_9
+
+run test: INT_RANGE_Should.INT_RANGE__init__given_10_to_0__constructs_range_with_0_elements
+expect_equal: 0 == 0
+finished: INT_RANGE_Should.INT_RANGE__init__given_10_to_0__constructs_range_with_0_elements
+
+run test: INT_RANGE_Should.INT_RANGE__init__given_50_to_50__constructs_range_with_0_elements
+expect_equal: 0 == 0
+finished: INT_RANGE_Should.INT_RANGE__init__given_50_to_50__constructs_range_with_0_elements
+
+run test: INT_RANGE_Should.INT_RANGE__move_next__given_0_to_10__returns_true
+expect_equal: True == True
+finished: INT_RANGE_Should.INT_RANGE__move_next__given_0_to_10__returns_true
+
+run test: INT_RANGE_Should.INT_RANGE__move_next__given_10_to_0__returns_false
+expect_equal: False == False
+finished: INT_RANGE_Should.INT_RANGE__move_next__given_10_to_0__returns_false
+
+run test: INT_RANGE_Should.INT_RANGE__reset__given_partially_enumerated_range__starts_from_beginning_again
+expect_equal: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 == 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+finished: INT_RANGE_Should.INT_RANGE__reset__given_partially_enumerated_range__starts_from_beginning_again
+
+run test: INT_RANGE_Should.INT_RANGE__to__given_0_to_10__is_10
+expect_equal: 10 == 10
+finished: INT_RANGE_Should.INT_RANGE__to__given_0_to_10__is_10
+
+run test: INT_RANGE_Should.INT_RANGE__to_string__given_0_to_10_then_3_move_next_returns_0_dot_dot_10_at_2
+expect_equal: 0..10 @ 2 == 0..10 @ 2
+finished: INT_RANGE_Should.INT_RANGE__to_string__given_0_to_10_then_3_move_next_returns_0_dot_dot_10_at_2
+
+run test: INT_RANGE_Should.INT_RANGE__to_string__given_0_to_10_then_move_next_returns_0_dot_dot_10_at_0
+expect_equal: 0..10 @ 0 == 0..10 @ 0
+finished: INT_RANGE_Should.INT_RANGE__to_string__given_0_to_10_then_move_next_returns_0_dot_dot_10_at_0
+
+run test: INT_RANGE_Should.INT_RANGE__to_string__given_new_0_to_10__returns_0_dot_dot_10
+expect_equal: 0..10 == 0..10
+finished: INT_RANGE_Should.INT_RANGE__to_string__given_new_0_to_10__returns_0_dot_dot_10
+
+run test: INT_RANGE_Should.INT_RANGE__to_string__given_reset_0_to_10__returns_0_dot_dot_10
+expect_equal: 0..10 == 0..10
+finished: INT_RANGE_Should.INT_RANGE__to_string__given_reset_0_to_10__returns_0_dot_dot_10
+
+run test: LIST_REVERSE_ITERATOR_Should.LIST_REVERSE_ITERATOR__iterator__given_empty_list__returns_no_elements
+expect_equal:  == 
+finished: LIST_REVERSE_ITERATOR_Should.LIST_REVERSE_ITERATOR__iterator__given_empty_list__returns_no_elements
+
+run test: LIST_REVERSE_ITERATOR_Should.LIST_REVERSE_ITERATOR__iterator__given_even_length_multiple_element_list__returns_elements_in_reverse_order
+expect_equal: 2, 6, 3, 11, 8, 7, 6, 3, 2, 1 == 2, 6, 3, 11, 8, 7, 6, 3, 2, 1
+finished: LIST_REVERSE_ITERATOR_Should.LIST_REVERSE_ITERATOR__iterator__given_even_length_multiple_element_list__returns_elements_in_reverse_order
+
+run test: LIST_REVERSE_ITERATOR_Should.LIST_REVERSE_ITERATOR__iterator__given_odd_length_multiple_element_list__returns_elements_in_reverse_order
+expect_equal: 11, 8, 7, 6, 3, 2, 1 == 11, 8, 7, 6, 3, 2, 1
+finished: LIST_REVERSE_ITERATOR_Should.LIST_REVERSE_ITERATOR__iterator__given_odd_length_multiple_element_list__returns_elements_in_reverse_order
+
+run test: LIST_REVERSE_ITERATOR_Should.LIST_REVERSE_ITERATOR__iterator__given_single_element_list__returns_that_element
+expect_equal: 1 == 1
+finished: LIST_REVERSE_ITERATOR_Should.LIST_REVERSE_ITERATOR__iterator__given_single_element_list__returns_that_element
+

--- a/project-tests/runtime-ranges/runtime-ranges.ghulproj
+++ b/project-tests/runtime-ranges/runtime-ranges.ghulproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <GhulCompiler>dotnet ghul-compiler</GhulCompiler>
+    <AssemblyName>binary</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <GhulSources Include="**/*.ghul" />
+
+    <PackageReference Include="MSTest.TestFramework" />
+  </ItemGroup>
+</Project>

--- a/project-tests/runtime-ranges/test.ghul
+++ b/project-tests/runtime-ranges/test.ghul
@@ -1,0 +1,57 @@
+namespace Test is
+    use IO.Std.write_line;
+    use System.Reflection;
+    use System.Activator;
+    use Type = System.Type2;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    entry() is
+        let type_compare = (t1: Type, t2: Type) is
+            let t1_name = t1.name;
+            return t1_name.compare_to(t2.name);
+        si;
+
+        let method_compare = (m1: MethodInfo, m2: MethodInfo) is
+            let m1_name = m1.name;
+            return m1_name.compare_to(m2.name);
+        si;
+
+        let assembly = Assembly.get_executing_assembly();
+
+        let types = assembly.get_types() | .sort(type_compare);
+
+        for type in types do
+            let is_test_class = type.get_custom_attributes(typeof TestClassAttribute, false).count > 0;
+
+            if !is_test_class then
+                continue;
+            fi
+
+            let methods = type.get_methods() | .sort(method_compare);
+
+            for method in methods do
+                let is_test_method = method.get_custom_attributes(typeof TestMethodAttribute, false).count > 0;
+
+                if !is_test_method then
+                    continue;
+                fi
+
+                try
+                    write_line("run test: " + type.name + "." + method.name);
+
+                    let instance = Activator.create_instance(type);
+    
+                    method.invoke(instance, null);
+    
+                    write_line("finished: " + type.name + "." + method.name);
+                    write_line();
+                catch e: System.Exception
+                    write_line("threw: " + type.name + "." + method.name);
+                    write_line("error: " + e);
+                    write_line();
+                yrt
+            od
+        od
+    si
+si

--- a/project-tests/runtime-ranges/tests.ghul
+++ b/project-tests/runtime-ranges/tests.ghul
@@ -1,0 +1,31 @@
+namespace Tests is
+    use IO.Std.write_line;
+
+    use Collections;
+    use Microsoft.VisualStudio.TestTools.UnitTesting;
+
+
+    assert_equal[T](a: Collections.Iterable[T], b: Collections.Iterable[T]) is
+        // FIXME: can no-longer construct LIST[T] from an Iterable[T]
+        // not sure if this is a change from .NET 6 to .NET 8 or if it's
+        // a compiler bug:
+
+        let la: Collections.LIST[T] = new Collections.LIST[T]();
+        let lb: Collections.LIST[T] = new Collections.LIST[T]();
+
+        la.add_range(a);
+        lb.add_range(b);
+
+        CollectionAssert.are_equal(la, lb);            
+    si
+
+    collect[T](iterator: LIST_REVERSE_ITERATOR[T]) -> Iterable[T] is
+        let result = new LIST[T]();
+
+        while iterator.move_next() do
+            result.add(iterator.current);
+        od
+
+        return result;
+    si
+si

--- a/src/driver/main.ghul
+++ b/src/driver/main.ghul
@@ -102,7 +102,7 @@ namespace Driver is
                 Std.output_encoding = new System.Text.UTF8Encoding(false);
 
                 if arguments.count == 0 then
-                    Std.out.write_line("ghūl " + compiler_version);
+                    Std.out.write("ghūl " + compiler_version + "\n");
                     Std.out.flush();
 
                     System.Environment.exit(0);
@@ -135,17 +135,20 @@ namespace Driver is
 
                 result = finish_build();
             catch e: Exception
-                Std.error.write_line(e);
+                Std.error.write(e);
+                Std.error.write("\n");
                 Std.error.flush();
 
                 result = 1;
             yrt
 
             if result == 0 then
-                Std.error.write_line("*** succeeded ***");
+                Std.error.write("*** succeeded ***");
             else
-                Std.error.write_line("!!! failed !!!");
+                Std.error.write("!!! failed !!!");
             fi
+
+            Std.error.write("\n");
             
             System.Environment.exit(result);
         si

--- a/src/lexical/token.ghul
+++ b/src/lexical/token.ghul
@@ -43,7 +43,6 @@ namespace Lexical is
         LET,
         NAMESPACE,
         NEW,
-        NONE,
         NULL,
         OD,
         OPERATOR,

--- a/src/lexical/token_names.ghul
+++ b/src/lexical/token_names.ghul
@@ -51,7 +51,6 @@ namespace Lexical is
             _names[TOKEN.LET] = "let";
             _names[TOKEN.NAMESPACE] = "namespace";
             _names[TOKEN.NEW] = "new";
-            _names[TOKEN.NONE] = "none";
             _names[TOKEN.NULL] = "null";
             _names[TOKEN.OD] = "od";
             _names[TOKEN.OPERATOR] = "operator";

--- a/src/logging/diagnostics_store.ghul
+++ b/src/logging/diagnostics_store.ghul
@@ -198,7 +198,8 @@ namespace Logging is
         write_all_diagnostics(writer: TextWriter, formatter: DiagnosticFormatter) is
             if _diagnostics.count == 0 then
                 // FIXME: we only want to do this for the LSP connection
-                writer.write_line(_path);
+                writer.write(_path);
+                writer.write("\n");
 
                 return;
             fi
@@ -207,7 +208,8 @@ namespace Logging is
                 let formatted = formatter.format(diagnostic);
 
                 if formatted? then
-                    writer.write_line(formatted);
+                    writer.write(formatted);
+                    writer.write("\n");
                 fi
             od            
         si
@@ -400,7 +402,7 @@ namespace Logging is
         write_poison_messages() is
             // FIXME
             if is_poisoned then
-                IO.Std.error.write_line("internal compiler error");
+                IO.Std.error.write("internal compiler error\n");
             fi
         si
     si

--- a/src/semantic/dotnet/ambiguous_method_checker.ghul
+++ b/src/semantic/dotnet/ambiguous_method_checker.ghul
@@ -80,14 +80,8 @@ namespace Semantic.DotNet is
                 if s.count > 1 then
                     for function in s.iterable do
                         if function.owner != owner then
-                            IO.Std.error.write_line(
-                                "ignore ambiguous method: hide function: " + function + " in " + owner + " from " + function.owner
-                            );
-
                             function.hide();
                         fi
-
-                        // _logger.error(function.location, message);
                     od
                 fi
             od

--- a/src/syntax/parsers/expressions/primary.ghul
+++ b/src/syntax/parsers/expressions/primary.ghul
@@ -224,15 +224,6 @@ namespace Syntax.Parsers.Expressions is
                 (context: CONTEXT) is
                     let location = context.location;
                     context.next_token();
-                    return new Trees.Expressions.Literals.NONE(location);
-                si,
-                Lexical.TOKEN.NONE
-            );
-
-            add_parser(
-                (context: CONTEXT) is
-                    let location = context.location;
-                    context.next_token();
                     return new Trees.Expressions.NULL(location);
                 si,
                 Lexical.TOKEN.NULL


### PR DESCRIPTION
Technical:
- Add integration tests to check compiler compatibility with the runtime library
- Remove the unused `none` keyword
- Remove debug output when hiding ambiguous methods in reflected types
- Fix broken VSCode tasks for integration tests on Windows
- Update .gitattributes to strip \r on Windows