### PR TITLE
Fix can't return string interpolation

### DIFF
--- a/integration-tests/parse/string-interpolation-4/test.ghul
+++ b/integration-tests/parse/string-interpolation-4/test.ghul
@@ -12,3 +12,12 @@ entry() is
     "{x / 3}{x * y}";
 si
 
+test(x: int, y: int) -> string is
+    return "interpolate {x+y} and {x/y} together";
+
+    return "{x*y} at the beginning and {x-y} in the middle";
+
+    return "now {x+(y/x)} in the middle and end with {x + x + y}";
+
+    return "{x / 3}{x * y}";
+si

--- a/src/syntax/parsers/statements/node.ghul
+++ b/src/syntax/parsers/statements/node.ghul
@@ -54,6 +54,7 @@ namespace Syntax.Parsers.Statements is
                 Lexical.TOKEN.INT_LITERAL,
                 Lexical.TOKEN.FLOAT_LITERAL,
                 Lexical.TOKEN.STRING_LITERAL,
+                Lexical.TOKEN.ENTER_STRING,
                 Lexical.TOKEN.CHAR_LITERAL,
                 Lexical.TOKEN.TRUE,
                 Lexical.TOKEN.FALSE,


### PR DESCRIPTION
Bugs fixed:
- Attempting to return a string with interpolations using a return statement results in a syntax error