### PR TITLE
Clean-up tokenizer lookahead

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.8.3",
+      "version": "0.8.5",
       "commands": [
         "ghul-compiler"
       ]

--- a/src/compiler/compiler.ghul
+++ b/src/compiler/compiler.ghul
@@ -122,7 +122,10 @@ namespace Compiler is
                 is_internal_file
             );
 
+            let token_queue = new Lexical.TOKEN_QUEUE(512);
+
             let token_lookahead = new Lexical.TOKEN_LOOKAHEAD(
+                token_queue,
                 tokenizer
             );
 

--- a/src/lexical/token_lookahead.ghul
+++ b/src/lexical/token_lookahead.ghul
@@ -10,28 +10,30 @@ namespace Lexical is
 
     class TOKEN_LOOKAHEAD is
         _queue: TOKEN_QUEUE;
-        _mark_stack: STACK[(mark: int, prev_token: TOKEN_PAIR)];
+        _mark_stack: STACK[int];
 
         _tokenizer: TokenSource;
 
-        init(tokenizer: TokenSource) is
-            _queue = new TOKEN_QUEUE();
-            _mark_stack = new STACK[(int, TOKEN_PAIR)]();
-
+        init(
+            queue: TOKEN_QUEUE,
+            tokenizer: TokenSource
+        ) is
+            _mark_stack = new STACK[int]();
+            _queue = queue;
             _tokenizer = tokenizer;
         si
 
         // when we first start speculating, we need to tell
         // the token queue to mark the read position, because
         // we must not write past it
-        speculate(prev_token: TOKEN_PAIR) is
+        speculate() is
             if _mark_stack.count == 0 then
                 _queue.speculate_enter();
             fi
 
             // FIXME: we can get the token from the previous slot
             // in the queue
-            _mark_stack.push((_queue.mark(), prev_token));
+            _mark_stack.push(_queue.mark());
         si
 
         backtrack() -> TOKEN_PAIR is
@@ -39,17 +41,15 @@ namespace Lexical is
             // saved read position, effectively undoing the
             // speculation
 
-            let mark_prev_token = _mark_stack.pop();
+            let mark = _mark_stack.pop();
 
-            _queue.release(mark_prev_token.mark);
+            _queue.release(mark);
 
             if _mark_stack.count == 0 then
                 _queue.speculate_exit();
             fi
 
-            // FIXME: we can get the token from the previous slot
-            // in the queue
-            return mark_prev_token.prev_token;
+            return _queue.last();
         si
 
         commit() is

--- a/src/lexical/token_queue.ghul
+++ b/src/lexical/token_queue.ghul
@@ -6,13 +6,19 @@ namespace Lexical is
     class TOKEN_QUEUE is
         _buffer: LIST[TOKEN_PAIR];
         _speculate_index: int;
-        _read_index: int;
-        _write_index: int;
+        _read_index: int; // points at the last token read
+        _write_index: int; // points at the last token written
         _size: int;
 
-        count: int => (_write_index - _read_index + _size) ∩ (_size - 1);
+        count: int is
+            let result = (_write_index - _read_index + _size) ∩ (_size - 1);
 
+            return result;
+        si
+         
         avail: bool => count > 0;
+
+        is_speculating: bool => _speculate_index != -1;
 
         _peek_offset(index: int) -> int =>
             (_read_index + index) ∩ (_size - 1);
@@ -23,9 +29,15 @@ namespace Lexical is
         _prev_index(index: int) -> int =>
             (index - 1) ∩ (_size - 1);
 
-        init() is
+        init(size: int) is
+            assert size > 0 else "token queue size must be greater than 0";
+            assert (size ∩ (size - 1)) == 0 else "token queue size must be a power of 2";
+
+            _size = size;
+            _read_index = 0;
+            _write_index = 0;
             _speculate_index = -1;
-            _size = 512;
+
             _buffer = new LIST[TOKEN_PAIR](_size);
 
             // .NET can be very annoying sometimes...
@@ -36,42 +48,49 @@ namespace Lexical is
         si
 
         speculate_enter() is
+            assert _speculate_index == -1 else "already speculating";
             _speculate_index = _read_index;
         si
 
         speculate_exit() is
+            assert _speculate_index != -1 else "not speculating";
             _speculate_index = -1;
         si
 
         mark() -> int is
+            assert _speculate_index != -1 else "not speculating";
+
             return _read_index;
         si
 
         release(index: int) is
+            assert _speculate_index != -1 else "not speculating";
             _read_index = index;
         si
 
-        peek() -> TOKEN_PAIR is
-            assert _read_index != _write_index else "token queue underflow";
+        last() -> TOKEN_PAIR is
+            let result = _buffer[_read_index];
 
-            return _buffer[_read_index];
+            return result;
         si
 
         enqueue(token: TOKEN_PAIR) is
+            let new_write_index = _next_index(_write_index); 
+
+            assert new_write_index != _read_index /\ new_write_index != _speculate_index else "token queue overflow";
+
+            _write_index = new_write_index;
+
             _buffer[_write_index] = token;
-
-            _write_index = _next_index(_write_index);
-
-            assert _write_index != _read_index /\ _write_index != _speculate_index else "token queue overflow";
         si
 
         dequeue() -> TOKEN_PAIR is
             assert _read_index != _write_index else "token queue underflow";
 
+            _read_index = _next_index(_read_index); 
+
             let result = _buffer[_read_index];
 
-            _read_index = _next_index(_read_index);
-            
             return result;
         si
     si

--- a/src/syntax/parsers/context.ghul
+++ b/src/syntax/parsers/context.ghul
@@ -71,7 +71,7 @@ namespace Syntax.Parsers is
         si
 
         speculate() is
-            tokenizer.speculate(current);
+            tokenizer.speculate();
         si
 
         commit() is

--- a/unit-tests/src/lexical/token_lookahead_tests.ghul
+++ b/unit-tests/src/lexical/token_lookahead_tests.ghul
@@ -1,0 +1,114 @@
+namespace Lexical.UnitTests is
+    use Collections;
+
+    use Logging;
+
+    class FAKE_TOKEN_SOURCE: Lexical.TokenSource is
+        _token_iterator: Iterator[Lexical.TOKEN_PAIR];
+
+        init(tokens: Iterable[Lexical.TOKEN_PAIR]) is
+            _token_iterator = tokens.iterator;
+        si
+
+        read_token() -> Lexical.TOKEN_PAIR is
+            if _token_iterator.move_next() then
+                return _token_iterator.current;
+            else
+                return new Lexical.TOKEN_PAIR(Lexical.TOKEN.END_OF_INPUT, new Source.LOCATION("test.ghul", 0, 0), "");
+            fi
+        si
+
+        expect_format_specifier() is
+        si
+    si
+
+    class TOKEN_LOOKAHEAD_TESTS is
+        @test()
+
+        init() is si
+
+        get_dummy_identifier(n: int) -> Lexical.TOKEN_PAIR =>
+            new Lexical.TOKEN_PAIR(Lexical.TOKEN.IDENTIFIER, new Source.LOCATION("test.ghul", 0, 0), "dummy_{n}");
+
+        given_an_empty_queue__speculate__should_enter_speculation_mode() is
+            @test()
+
+            let queue = new Lexical.TOKEN_QUEUE(8);
+            let source = new FAKE_TOKEN_SOURCE([get_dummy_identifier(1), get_dummy_identifier(2)]);
+            let lookahead = new Lexical.TOKEN_LOOKAHEAD(queue, source);
+
+            queue.speculate_enter();
+
+            assert queue.is_speculating;
+        si
+
+        given_a_stream_of_tokens__speculate_read_two_tokens_back_track_and_read_two_tokens__should_return_the_same_two_tokens_again() is
+            @test()
+
+            let expected_tokens = (0..8) | .map(i => get_dummy_identifier(i)) .collect();
+
+            let queue = new Lexical.TOKEN_QUEUE(8);
+            let source = new FAKE_TOKEN_SOURCE(expected_tokens);
+            let lookahead = new Lexical.TOKEN_LOOKAHEAD(queue, source);
+
+            lookahead.speculate();
+            let token1 = lookahead.read_token();
+            let token2 = lookahead.read_token();
+            lookahead.backtrack();
+            let token3 = lookahead.read_token();
+            let token4 = lookahead.read_token();
+
+            assert token1 == expected_tokens[0];
+            assert token2 == expected_tokens[1];
+            assert token3 == expected_tokens[0];
+            assert token4 == expected_tokens[1];
+        si
+
+        given_a_stream_of_tokens__nested_speculate_backtrack_and_read__should_return_the_same_tokens() is
+            @test()
+
+            let expected_tokens = (0..8) | .map(i => get_dummy_identifier(i)) .collect();
+
+            let queue = new Lexical.TOKEN_QUEUE(8);
+            let source = new FAKE_TOKEN_SOURCE(expected_tokens);
+            let lookahead = new Lexical.TOKEN_LOOKAHEAD(queue, source);
+
+            lookahead.speculate();
+            let token1 = lookahead.read_token();
+            let token2 = lookahead.read_token();
+            lookahead.speculate();
+            let token3 = lookahead.read_token();
+            let token4 = lookahead.read_token();
+            lookahead.backtrack();
+            let token5 = lookahead.read_token();
+            let token6 = lookahead.read_token();
+
+            assert token1 == expected_tokens[0];
+            assert token2 == expected_tokens[1];
+            assert token3 == expected_tokens[2];
+            assert token4 == expected_tokens[3];
+            assert token5 == expected_tokens[2];
+            assert token6 == expected_tokens[3];
+        si
+
+        given_a_stream_of_tokens__after_speculate_backtrack__should_return_token_before_speculate() is
+            @test()
+
+            let expected_tokens = (0..8) | .map(i => get_dummy_identifier(i)) .collect();
+
+            let queue = new Lexical.TOKEN_QUEUE(8);
+            let source = new FAKE_TOKEN_SOURCE(expected_tokens);
+            let lookahead = new Lexical.TOKEN_LOOKAHEAD(queue, source);
+
+            let token1 = lookahead.read_token();
+            let token2 = lookahead.read_token();
+            lookahead.speculate();
+
+            let token3 = lookahead.read_token();
+            let token4 = lookahead.read_token();
+            let actual = lookahead.backtrack();
+
+            assert actual == expected_tokens[1];
+        si
+    si
+si

--- a/unit-tests/src/lexical/token_queue_tests.ghul
+++ b/unit-tests/src/lexical/token_queue_tests.ghul
@@ -1,0 +1,376 @@
+namespace Lexical.UnitTests is
+    use Collections;
+
+    use Logging;
+
+    class TOKEN_QUEUE_TESTS is
+        @test()
+
+        init() is si
+
+        split_at_white_space(source_string: string) -> Iterable[string]
+            => source_string.split([' ', '\t', '\r', '\n'], System.StringSplitOptions.REMOVE_EMPTY_ENTRIES);
+
+        get_dummy_identifier(n: int) -> Lexical.TOKEN_PAIR =>
+            new Lexical.TOKEN_PAIR(Lexical.TOKEN.IDENTIFIER, new Source.LOCATION("test.ghul", 0, 0), "dummy_{n}");
+
+        given_a_non_power_of_2_size__init__should_throw() is
+            @test()
+
+            let exception_thrown = false;
+
+            try
+                let queue = new Lexical.TOKEN_QUEUE(3);
+            catch ex: System.Exception
+                exception_thrown = true;
+            yrt
+            
+            assert exception_thrown;
+        si
+
+        given_a_new_token_queue__count__should_return_0() is
+            @test()
+
+            let queue = new Lexical.TOKEN_QUEUE(128);
+
+            assert queue.count == 0;
+        si
+
+        given_an_empty_token_queue__enqueue__should_add_a_token_to_the_queue() is
+            @test()
+
+            let queue = new Lexical.TOKEN_QUEUE(16);
+
+            queue.enqueue(get_dummy_identifier(1));
+
+            assert queue.count == 1;
+        si
+
+        given_a_queue_with_one_token__dequeue__should_return_the_token() is
+            @test()
+
+            let queue = new Lexical.TOKEN_QUEUE(16);
+
+            let expected_token = get_dummy_identifier(1);
+
+            queue.enqueue(expected_token);
+
+            let actual_token = queue.dequeue();
+
+            assert actual_token == expected_token;
+        si
+
+        given_a_queue_with_one_token__dequeue__should_decrement_count() is
+            @test()
+
+            let queue = new Lexical.TOKEN_QUEUE(16);
+
+            queue.enqueue(get_dummy_identifier(1));
+
+            queue.dequeue();
+
+            assert queue.count == 0;
+        si
+
+        given_an_empty_queue__dequeue__should_throw() is
+            @test()
+
+            let queue = new Lexical.TOKEN_QUEUE(16);
+
+            let exception_thrown = false;
+
+            try
+                queue.dequeue();
+            catch ex: System.Exception
+                exception_thrown = true;
+            yrt
+
+            assert exception_thrown;
+        si
+
+        given_a_token_dequeued__last__should_return_the_dequeued_token() is
+            @test()
+
+            let queue = new Lexical.TOKEN_QUEUE(16);
+
+            queue.enqueue(get_dummy_identifier(1));
+
+            let actual_token = queue.dequeue();
+
+            assert queue.last() == actual_token;
+        si
+        
+        given_a_nearly_full_queue__enqueue__should_not_throw() is
+            @test()
+
+            let queue = new Lexical.TOKEN_QUEUE(4);
+
+            let exception_thrown = false;
+
+            try
+                // we only expect to be able to queue size-1 tokens, as
+                // one slot is reserved for the last token read
+                queue.enqueue(get_dummy_identifier(1));
+                queue.enqueue(get_dummy_identifier(2));
+                queue.enqueue(get_dummy_identifier(3));
+            catch ex: System.Exception
+                IO.Std.error.write_line("exception caught: {ex}");
+                exception_thrown = true;
+            yrt
+
+            assert !exception_thrown;
+        si
+
+        given_a_full_queue__enqueue__should_throw() is
+            @test()
+
+            let queue = new Lexical.TOKEN_QUEUE(4);
+
+            // we only expect to be able to queue size-1 tokens, as
+            // one slot is reserved for the last token read
+
+            queue.enqueue(get_dummy_identifier(1));
+            queue.enqueue(get_dummy_identifier(2));
+            queue.enqueue(get_dummy_identifier(3));
+
+            let exception_thrown = false;
+
+            try
+                queue.enqueue(get_dummy_identifier(4));
+            catch ex: System.Exception
+                exception_thrown = true;
+            yrt
+
+            assert exception_thrown;
+        si
+
+        given_six_tokens_enqueued_four_dequeued_and_two_more_enqueued__dequeue_then_last__should_return_the_last_four_tokens() is
+            @test()
+
+            let tokens = (0..8) | .map(i => get_dummy_identifier(i)) .collect();
+
+            let queue = new Lexical.TOKEN_QUEUE(8);
+
+            // queue is empty
+
+            IO.Std.error.write_line("enqueueing 6 tokens...");
+
+            for i in 0..6 do
+                queue.enqueue(tokens[i]);
+            od
+
+            // queue has six tokens available
+
+            IO.Std.error.write_line("dequeuing 4 tokens...");
+
+            for i in 0..4 do
+                queue.dequeue();
+            od
+
+            // queue has two tokens available
+
+            IO.Std.error.write_line("enqueueing 2 tokens...");
+
+            queue.enqueue(tokens[6]);
+            queue.enqueue(tokens[7]);
+
+            // queue has four tokens available
+
+            let expected_tokens = [tokens[4], tokens[5], tokens[6], tokens[7]];
+
+            IO.Std.error.write_line("checking last 4 tokens...");
+
+            for i in 0..4 do
+                IO.Std.error.write_line("checking token {i} expect {expected_tokens[i]}...");
+
+                let dequeued = queue.dequeue();
+                let last = queue.last();
+
+                IO.Std.error.write_line("dequeued: {dequeued}, last: {last} expect: {expected_tokens[i]}");
+                IO.Std.error.write_line("dequeued == expected_tokens[{i}]: {dequeued == expected_tokens[i]}");
+                IO.Std.error.write_line("last == expected_tokens[{i}]: {last == expected_tokens[i]}");
+
+                assert dequeued == expected_tokens[i];
+                assert last == expected_tokens[i];
+            od
+
+            IO.Std.error.write_line("done");
+        si
+
+        given_not_in_speculate_mode__speculate_enter__should_enter_speculation_mode() is
+            @test()
+
+            let queue = new Lexical.TOKEN_QUEUE(8);
+
+            queue.speculate_enter();
+
+            assert queue.is_speculating;
+        si
+
+        given_in_speculate_mode__speculate_enter__should_throw() is
+            @test()
+
+            let queue = new Lexical.TOKEN_QUEUE(8);
+
+            let exception_thrown = false;
+
+            queue.speculate_enter();
+
+            try
+                queue.speculate_enter();
+            catch ex: System.Exception
+                exception_thrown = true;
+            yrt
+            
+            assert exception_thrown;
+        si
+
+        given_not_in_speculate_mode__speculate_exit__should_throw() is
+            @test()
+
+            let queue = new Lexical.TOKEN_QUEUE(8);
+
+            let exception_thrown = false;
+
+            try
+                queue.speculate_exit();
+            catch ex: System.Exception
+                exception_thrown = true;
+            yrt
+
+            assert exception_thrown;
+        si
+
+        given_in_speculate_mode__speculate_exit__should_exit_speculation_mode() is
+            @test()
+
+            let queue = new Lexical.TOKEN_QUEUE(8);
+
+            queue.speculate_enter();
+            queue.speculate_exit();
+
+            assert !queue.is_speculating;
+        si
+
+        given_six_tokens_enqueued_and_four_dequeued__mark__should_return_4() is
+            @test()
+
+            let queue = new Lexical.TOKEN_QUEUE(8);
+
+            for i in 0..6 do
+                queue.enqueue(get_dummy_identifier(i));
+            od
+
+            for i in 0..4 do
+                queue.dequeue();
+            od
+
+            queue.speculate_enter();
+
+            assert queue.mark() == 4;
+        si
+
+        given_buffer_wrapped__mark__should_return_correct_index() is
+            @test()
+
+            let queue = new Lexical.TOKEN_QUEUE(8);
+
+            for i in 0..6 do
+                queue.enqueue(get_dummy_identifier(i));
+            od
+
+            for i in 0..4 do
+                queue.dequeue();
+            od
+
+            queue.speculate_enter();
+
+            for i in 0..4 do
+                queue.enqueue(get_dummy_identifier(i + 6));
+            od
+
+            assert queue.mark() == 4;            
+        si
+
+        given_buffer_wrapped_and_speculating__enqueue__should_throw_on_overflow() is
+            @test()
+
+            let queue = new Lexical.TOKEN_QUEUE(8);
+
+            // seven slots available in the buffer
+            // initially, allowing for the last read
+            // token slot
+
+            for i in 0..6 do
+                queue.enqueue(get_dummy_identifier(i));
+            od
+
+            // we've used up 6 slots, so there should be
+            // one slot free
+
+            for i in 0..4 do
+                queue.dequeue();
+            od
+
+            // free up four slots, so there should now be
+            // five slots free
+
+            queue.speculate_enter();
+
+            // we're now speculating, so we should only be
+            // able to enqueue five more tokens before we
+            // reach the speculative mark
+
+            for i in 0..5 do
+                queue.enqueue(get_dummy_identifier(i + 6));
+            od
+
+            let exception_thrown = false;
+
+            try
+                queue.enqueue(get_dummy_identifier(10));
+            catch ex: System.Exception
+                exception_thrown = true;
+            yrt
+
+            assert exception_thrown;
+        si
+
+        given_a_speculative_mark__enqueue__should_throw_rather_than_writing_past_it() is
+            @test()
+
+            let queue = new Lexical.TOKEN_QUEUE(8);
+
+            for i in 0..4 do
+                queue.enqueue(get_dummy_identifier(i));
+            od
+
+            queue.speculate_enter();
+            queue.mark();
+
+            for i in 0..4 do
+                queue.dequeue();
+            od
+            
+            // the queue is notionally empty, but four entries are
+            // still in the speculative buffer, so we should only be
+            // able to enqueue three more tokens before we reach the
+            // speculative mark, allowing one slot for the last token
+            // read
+
+            let exception_thrown = false;
+
+            for i in 0..3 do
+                queue.enqueue(get_dummy_identifier(i + 4));
+            od
+
+            try
+                queue.enqueue(get_dummy_identifier(7));
+            catch ex: System.Exception
+                exception_thrown = true;
+            yrt
+            
+            assert exception_thrown;
+        si
+    si
+si


### PR DESCRIPTION
Technical:
- Adjust the way the token queue read + write indexes are maintained so the pre-speculate state can be restored without having to save the previous token on the speculative token queue index stack
- Add unit tests for the token queue and speculative token lookahead mechanisms.