### PR TITLE
Use scoped disposal to manage speculative parsing

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.8.5",
+      "version": "0.8.6",
       "commands": [
         "ghul-compiler"
       ]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.8.4-alpha.1</Version>
+    <Version>0.8.7-alpha.9</Version>
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
 

--- a/src/driver/main.ghul
+++ b/src/driver/main.ghul
@@ -470,16 +470,9 @@ namespace Driver is
                 return;
             fi
 
-            let reader: IO.StreamReader;
-            try
-                reader = File.open_text(path);
+            let use reader = File.open_text(path);
 
-                compiler.parse_and_queue(path, reader, flags.copy(), is_internal_file);
-            finally
-                if reader? then
-                    reader.close();
-                fi
-            yrt            
+            compiler.parse_and_queue(path, reader, flags.copy(), is_internal_file);
         si
 
         analyse() is

--- a/src/logging/diagnostics_store.ghul
+++ b/src/logging/diagnostics_store.ghul
@@ -359,6 +359,12 @@ namespace Logging is
             od
         si
 
+        speculate_then_commit() -> LOGGER_SPECULATE_THEN_COMMIT =>
+            new LOGGER_SPECULATE_THEN_COMMIT(self);
+
+        speculate_then_backtrack() -> LOGGER_SPECULATE_THEN_BACKTRACK =>
+            new LOGGER_SPECULATE_THEN_BACKTRACK(self);
+
         merge(state: DIAGNOSTICS_STATE) is
             top.merge(state);
         si

--- a/src/logging/logger.ghul
+++ b/src/logging/logger.ghul
@@ -10,10 +10,32 @@ namespace Logging is
 
     use Source;
 
+    struct DEBUG_THEN_EXIT: Disposable is
+        _initialized: bool;
+        _depth: int;
+
+        init(depth: int) is
+            _initialized = true;
+            _depth = depth;
+        si
+
+        dispose() is
+            if _initialized then
+                _debug_depth = _depth;
+            fi
+
+            _initialized = false;
+        si
+    si
+
     _debug_depth: int;
 
-    debug_enter() is
+    debug_enter() -> DEBUG_THEN_EXIT is
+        let result = new DEBUG_THEN_EXIT(_debug_depth);
+
         _debug_depth = _debug_depth + 1;
+
+        return result;
     si
 
     in_debug() -> bool is
@@ -59,7 +81,7 @@ namespace Logging is
     si
 
     debug_always(message: string) is
-        for i in 1.._debug_depth do
+        for i in 0.._debug_depth do
             IO.Std.error.write("  ");
         od
         
@@ -78,12 +100,14 @@ namespace Logging is
         speculate();
         roll_back() -> DIAGNOSTICS_STATE;
         commit();
+        mark() -> int;
+        release(mark: int);
+
+        speculate_then_commit() -> LOGGER_SPECULATE_THEN_COMMIT;
+        speculate_then_backtrack() -> LOGGER_SPECULATE_THEN_BACKTRACK;
 
         start_analysis();
         end_analysis();
-
-        mark() -> int;
-        release(mark: int);
 
         merge(state: DIAGNOSTICS_STATE);
 
@@ -100,5 +124,115 @@ namespace Logging is
         clear(path: string, analysis_only: bool);
 
         write_all_diagnostics(writer: TextWriter, formatter: DiagnosticFormatter);
+    si
+
+    struct LOGGER_SPECULATE_THEN_COMMIT: Disposable is
+        _logger: Logger;
+
+        is_speculating: bool => _logger != null;
+
+        init(logger: Logger) is
+            debug_enter();
+            debug(">> logger speculate then commit...");
+
+            _logger = logger;
+            _logger.speculate();
+        si
+
+        backtrack() -> DIAGNOSTICS_STATE is
+            debug("-- logger state: explicit backtrack");
+
+            let result = _logger.roll_back();
+            _logger = null;
+            return result;
+        si
+
+        backtrack_and_restart() -> DIAGNOSTICS_STATE is
+            debug("-- logger state: explicit backtrack and restart");
+
+            let result = _logger.roll_back();
+            _logger.speculate();
+            return result;
+        si
+
+        commit() is
+            debug("-- logger state: explicit commit");
+
+            _logger.commit();
+            _logger = null;
+        si
+
+        cancel() is
+            debug("-- logger state: explicit cancel");
+
+            _logger = null;
+        si        
+
+        dispose() is
+            if _logger != null then
+                debug("-- logger state: implicit commit");
+
+                _logger.commit();
+                _logger = null;
+            fi
+
+            debug("<< logger state exit");
+            debug_exit();
+        si
+    si
+    
+    struct LOGGER_SPECULATE_THEN_BACKTRACK: Disposable is
+        _logger: Logger;
+
+        is_speculating: bool => _logger != null;
+
+        init(logger: Logger) is
+            debug_enter();
+            debug(">> logger speculate then backtrack...");
+
+            _logger = logger;
+            _logger.speculate();
+        si
+
+        backtrack() -> DIAGNOSTICS_STATE is
+            debug("-- logger state: explicit backtrack");
+
+            let result = _logger.roll_back();
+            _logger = null;
+            return result;
+        si
+
+        backtrack_and_restart() -> DIAGNOSTICS_STATE is
+            debug("-- logger state: explicit backtrack and restart");
+
+            let result = _logger.roll_back();
+            _logger.speculate();
+            return result;
+        si
+
+        commit() is
+            debug("-- logger state: explicit commit");
+
+            _logger.commit();
+            _logger = null;
+        si
+
+        cancel() is
+            debug("-- logger state: explicit cancel");            
+
+            _logger = null;
+        si
+
+        dispose() is
+            if _logger != null then
+                debug("-- logger state: implicit backtrack");
+
+                _logger.roll_back();
+                _logger = null;
+            fi
+
+            debug("<< logger state exit");
+            debug_exit();
+        si
     si
 si

--- a/src/semantic/overload_resolver.ghul
+++ b/src/semantic/overload_resolver.ghul
@@ -55,6 +55,7 @@ namespace Semantic is
             try
                 return _resolve(location, group, arguments, want_infer, want_instance);
             catch e: Exception
+                // FIXME: this is probably lost by the subsequent release
                 _logger.exception(location, e, "exception resolving overload: {group} arguments {arguments}");
                 return null;
 
@@ -73,6 +74,7 @@ namespace Semantic is
             try
                 return _find_matches(group, arguments);
             catch e: Exception
+                // FIXME: this is probably lost by the subsequent release
                 _logger.exception(null, e, "exception resolving overload: {group} arguments {arguments}");
                 return null;
 

--- a/src/syntax/parsers/context.ghul
+++ b/src/syntax/parsers/context.ghul
@@ -3,20 +3,138 @@ namespace Syntax.Parsers is
     
     use Logging;
     use Source;
-    
+
+    struct TOKEN_LOOKAHEAD_SPECULATE_THEN_COMMIT: Disposable is
+        _context: CONTEXT;
+
+        is_speculating: bool => _context != null;
+
+        init(context: CONTEXT) is
+            debug_enter();
+            debug(">> token lookahead speculate then commit...");
+
+            _context = context;
+            _context.tokenizer_speculate();
+        si
+
+        backtrack() is
+            debug("-- token lookahead state: explicit backtrack");
+
+            _context.tokenizer_backtrack();
+            _context = null;
+        si
+
+        backtrack_if_speculating() is
+            if _context != null then
+                debug("-- token lookahead state: explicit backtrack");
+
+                _context.tokenizer_backtrack();
+                _context = null;
+            fi
+        si
+
+        commit() is
+            debug("-- token lookahead state: explicit commit");
+
+            _context.tokenizer_commit();
+            _context = null;
+        si
+
+        commit_if_speculating() is
+            if _context != null then
+                debug("-- token lookahead state: explicit commit");
+
+                _context.tokenizer_commit();
+                _context = null;
+            fi
+        si
+        
+        cancel() is
+            debug("-- token lookahead state: explicit cancel");
+            _context = null;
+        si        
+
+        dispose() is
+            if _context != null then
+                debug("-- token lookahead state: implicit commit");                
+                _context.tokenizer_commit();
+                _context = null;
+            fi
+
+            debug("<< token state exit");
+            debug_exit();
+        si
+    si
+
+    struct TOKEN_LOOKAHEAD_SPECULATE_THEN_BACKTRACK: Disposable is
+        _context: CONTEXT;
+
+        is_speculating: bool => _context != null;
+
+        init(context: CONTEXT) is
+            debug_enter();
+            debug(">> token lookahead speculate then backtrack...");
+
+            _context = context;
+            _context.tokenizer_speculate();
+        si
+
+        backtrack() is
+            debug("-- token lookahead state: explicit backtrack");
+
+            _context.tokenizer_backtrack();
+            _context = null;
+        si
+
+        backtrack_if_speculating() is
+            if _context != null then
+                debug("-- token lookahead state: explicit backtrack");
+
+                _context.tokenizer_backtrack();
+                _context = null;
+            fi
+        si
+
+        commit() is
+            debug("-- token lookahead state: explicit commit");
+
+            _context.tokenizer_commit();
+            _context = null;
+        si
+
+        commit_if_speculating() is
+            if _context != null then
+                debug("-- token lookahead state: explicit commit");
+
+                _context.tokenizer_commit();
+                _context = null;
+            fi
+        si
+
+        cancel() is
+            debug("-- token lookahead state: explicit cancel");
+
+            _context = null;
+        si        
+
+        dispose() is
+            if _context != null then
+                debug("-- token lookahead state: implicit backtrack");
+                
+                _context.tokenizer_backtrack();
+                _context = null;
+            fi
+
+            debug("<< token state exit");       
+            debug_exit();
+        si
+    si
+
     class CONTEXT is
         _repeated_error_count_at_eof: int;
 
         last_error_location: LOCATION;
         last_error_message: string;
-
-        // speculative_parse_tokens_stack: Collections.STACK[Collections.MutableList[Lexical.TOKEN_PAIR]];
-        // speculative_parse_tokens: Collections.MutableList[Lexical.TOKEN_PAIR] =>
-        //     if speculative_parse_tokens_stack.count > 0 then
-        //         speculative_parse_tokens_stack.peek();
-        //     else
-        //         null
-        //     fi;
 
         allow_tuple_element: bool public;
         in_trait: bool public;
@@ -70,15 +188,25 @@ namespace Syntax.Parsers is
             last_error_message = "";
         si
 
-        speculate() is
+        tokenizer_speculate_then_commit() -> TOKEN_LOOKAHEAD_SPECULATE_THEN_COMMIT =>
+            new TOKEN_LOOKAHEAD_SPECULATE_THEN_COMMIT(self);
+        
+        tokenizer_speculate_then_backtrack() -> TOKEN_LOOKAHEAD_SPECULATE_THEN_BACKTRACK =>
+            new TOKEN_LOOKAHEAD_SPECULATE_THEN_BACKTRACK(self);
+
+        logger_speculate_then_commit() -> LOGGER_SPECULATE_THEN_COMMIT => logger.speculate_then_commit();
+
+        logger_speculate_then_backtrack() -> LOGGER_SPECULATE_THEN_BACKTRACK => logger.speculate_then_backtrack();
+
+        tokenizer_speculate() is
             tokenizer.speculate();
         si
 
-        commit() is
+        tokenizer_commit() is
             tokenizer.commit();
         si
 
-        backtrack() is
+        tokenizer_backtrack() is
             current = tokenizer.backtrack();
         si
         

--- a/src/syntax/parsers/definitions/class.ghul
+++ b/src/syntax/parsers/definitions/class.ghul
@@ -124,41 +124,34 @@ namespace Syntax.Parsers.Definitions is
 
             let line = context.current.location.start_line;
 
-            try
-                context.speculate();
+            let use logger_snapshot = context.logger_speculate_then_backtrack();
 
                 // search on the current line for an 'is'
-                while context.current.location.start_line == line /\ context.current.location.start_column >= context.global_indent do
-                    if context.current.token == Lexical.TOKEN.IS then
-                        want_backtrack = false;
-                        context.next_token();
-                        context.commit();
-
-                        // is on the same line as the start of the class definition means it's likely the block is associated with the
-                        // class, and we should parse it as such, even if the first part of the class definition is invalid
-                        return true;
-                    fi
+            while context.current.location.start_line == line /\ context.current.location.start_column >= context.global_indent do
+                if context.current.token == Lexical.TOKEN.IS then
+                    logger_snapshot.commit();
 
                     context.next_token();
-                od
 
-                if context.current_token == Lexical.TOKEN.IS /\ context.current.location.start_column >= context.global_indent then
-                    want_backtrack = false;
-                    context.next_token();
-                    context.commit();
-
-                    // again, if the `is` is on the line immediately following the class definition, and it's properly indented, 
-                    // it's likely the block is associated with the class, and we should parse it as such, even if the first part of
-                    // the class definition is invalid
+                    // is on the same line as the start of the class definition means it's likely the block is associated with the
+                    // class, and we should parse it as such, even if the first part of the class definition is invalid
                     return true;
                 fi
 
-                return false;
-            finally
-                if want_backtrack then
-                    context.backtrack();
-                fi
-            yrt
+                context.next_token();
+            od
+
+            if context.current_token == Lexical.TOKEN.IS /\ context.current.location.start_column >= context.global_indent then
+                logger_snapshot.commit();
+                context.next_token();
+
+                // again, if the `is` is on the line immediately following the class definition, and it's properly indented, 
+                // it's likely the block is associated with the class, and we should parse it as such, even if the first part of
+                // the class definition is invalid
+                return true;
+            fi
+
+            return false;
         si
     si
 si

--- a/src/syntax/parsers/definitions/member.ghul
+++ b/src/syntax/parsers/definitions/member.ghul
@@ -31,44 +31,32 @@ namespace Syntax.Parsers.Definitions is
         si
 
         parse(context: CONTEXT) -> Trees.Definitions.Definition is
-            let need_commit = false;
+            if context.current.token == Lexical.TOKEN.SQUARE_OPEN then
+                return indexer_parser.parse(context);
+            elif context.current.token == Lexical.TOKEN.AT then
+                return pragma_parser.parse(context);
+            fi
 
-            try
-                if context.current.token == Lexical.TOKEN.SQUARE_OPEN then
-                    return indexer_parser.parse(context);
-                elif context.current.token == Lexical.TOKEN.AT then
-                    return pragma_parser.parse(context);
-                fi
-    
-                need_commit = true;
-                context.speculate();
+            let use tokenizer_snapshot = context.tokenizer_speculate_then_commit();
 
-                context.next_token();
+            context.next_token();
 
-                if property_tokens | .any(t => t == context.current.token) then
-                    context.backtrack();
-                    need_commit = false;
+            if property_tokens | .any(t => t == context.current.token) then
+                tokenizer_snapshot.backtrack();
 
-                    return property_parser.parse(context);
-                elif 
-                    context.current.token == Lexical.TOKEN.SQUARE_OPEN \/
-                    context.current.token == Lexical.TOKEN.PAREN_OPEN
-                then
-                    need_commit = false;
-                    context.backtrack();
+                return property_parser.parse(context);
+            elif 
+                context.current.token == Lexical.TOKEN.SQUARE_OPEN \/
+                context.current.token == Lexical.TOKEN.PAREN_OPEN
+            then
+                tokenizer_snapshot.backtrack();
 
-                    return function_parser.parse(context);
-                fi
+                return function_parser.parse(context);
+            fi
 
-                need_commit = false;
-                context.commit();
+            tokenizer_snapshot.commit();
 
-                other_token(context);    
-            finally
-                if need_commit then
-                    context.commit();
-                fi
-            yrt
+            other_token(context);    
         si
     si
 si

--- a/src/syntax/parsers/expressions/secondary.ghul
+++ b/src/syntax/parsers/expressions/secondary.ghul
@@ -36,209 +36,205 @@ namespace Syntax.Parsers.Expressions is
         si
 
         parse(context: CONTEXT) -> Trees.Expressions.Expression is
-            let commit = true;
+            let use tokenizer_state = context.tokenizer_speculate_then_commit();
 
-            try
-                context.speculate();
-                commit = true;
-    
-                let start = context.location;
-                let result: Trees.Expressions.Expression = expression_primary_parser.parse(context);
-    
-                do
-                    case context.current.token
-                    when Lexical.TOKEN.PAREN_OPEN:
-                        context.next_token();
-                        let arguments: Trees.Expressions.LIST;
-                        if context.current.token != Lexical.TOKEN.PAREN_CLOSE then
-                            arguments = expression_list_parser.parse(context);
-                        else
-                            arguments = new Trees.Expressions.LIST(context.location, new Collections.LIST[Trees.Expressions.Expression]());
-                        fi
-                        result = new Trees.Expressions.CALL(start::context.location, result, arguments);
-                        context.next_token(Lexical.TOKEN.PAREN_CLOSE, syntax_error_message);
-    
-                    when Lexical.TOKEN.SQUARE_OPEN:
-                        context.next_token();
-                        let index = expression_parser.parse(context);
-                        result = new Trees.Expressions.INDEX(start::context.location, result, index);
-                        context.next_token(Lexical.TOKEN.SQUARE_CLOSE, syntax_error_message);
-    
-                    when Lexical.TOKEN.DOT:
-                        let completion_target_start = context.location;
-    
-                        context.next_token();
-    
-                        if
-                            context.current.token == Lexical.TOKEN.IDENTIFIER
-                            // \/ context.current.token == Lexical.TOKEN.OPERATOR
-                        then
-                            let member = identifier_parser.parse(context);
-                            result = new Trees.Expressions.MEMBER(start::member.location, result, member, completion_target_start::member.location);
-                        else
-                            context.expect_token(Lexical.TOKEN.IDENTIFIER);                        
-                            result = new Trees.Expressions.MEMBER(start..context.location, result, null, completion_target_start::context.location);
-                        fi
-    
-                    when Lexical.TOKEN.ARROW_THIN, Lexical.TOKEN.ARROW_FAT, Lexical.TOKEN.IS:
-                        // we could be in a global function or in a method. If the left part looks like it could be a function or method definition
-                        // then it's an error and we need to recover. 
-    
-                        // we'll need a heuristic to try to decide if the user is trying to define a nested function or if they've missed off a closing `si`
-                        // and actually this is a method definition (if we're in a classy context) or a global function definition (if we're not in a classy context)
-    
-                        let is_nested_function_definition = false;
-    
-                        if result.could_be_nested_function_definition then
-                            // TODO need same logic but for nested within a global function
-                            if context.in_member then
-                                if result.location.start_column > context.member_indent then
-                                    // probably an attempt at nesting a named function definition
-                                    is_nested_function_definition = true;
-                                elif 
-                                    result.location.start_column <= context.member_indent /\
-                                    result.location.start_column > context.global_indent    
-                                then
-                                    // probably a missing `si` in a preceding member definition
-                                    context.error(result.location, "expected 'si' after member definition");
-    
-                                    commit = false;
+            let start = context.location;
+            let result: Trees.Expressions.Expression = expression_primary_parser.parse(context);
 
-                                    throw new UNWIND_TO_MEMBER_EXCEPTION(null);
-                                fi
-                            elif context.in_global_function then
-                                if result.location.start_column > context.global_indent then
-                                    // probably an attempt at nesting a named function definition
-                                    is_nested_function_definition = true;
-                                else
-                                    // probably a missing `si` in a preceding member definition
-                                    context.error(result.location, "expected 'si' after member definition");
-    
-                                    commit = false;
+            do
+                case context.current.token
+                when Lexical.TOKEN.PAREN_OPEN:
+                    context.next_token();
+                    let arguments: Trees.Expressions.LIST;
+                    if context.current.token != Lexical.TOKEN.PAREN_CLOSE then
+                        arguments = expression_list_parser.parse(context);
+                    else
+                        arguments = new Trees.Expressions.LIST(context.location, new Collections.LIST[Trees.Expressions.Expression]());
+                    fi
+                    result = new Trees.Expressions.CALL(start::context.location, result, arguments);
+                    context.next_token(Lexical.TOKEN.PAREN_CLOSE, syntax_error_message);
 
-                                    throw new UNWIND_TO_GLOBAL_EXCEPTION(null);
-                                fi
-                            elif context.in_classy then
-                                // not clear how we might have ended up here
-                                commit = false;
+                when Lexical.TOKEN.SQUARE_OPEN:
+                    context.next_token();
+                    let index = expression_parser.parse(context);
+                    result = new Trees.Expressions.INDEX(start::context.location, result, index);
+                    context.next_token(Lexical.TOKEN.SQUARE_CLOSE, syntax_error_message);
+
+                when Lexical.TOKEN.DOT:
+                    let completion_target_start = context.location;
+
+                    context.next_token();
+
+                    if
+                        context.current.token == Lexical.TOKEN.IDENTIFIER
+                    then
+                        let member = identifier_parser.parse(context);
+                        result = new Trees.Expressions.MEMBER(start::member.location, result, member, completion_target_start::member.location);
+                    else
+                        context.expect_token(Lexical.TOKEN.IDENTIFIER);                        
+                        result = new Trees.Expressions.MEMBER(start..context.location, result, null, completion_target_start::context.location);
+                    fi
+
+                when Lexical.TOKEN.ARROW_THIN, Lexical.TOKEN.ARROW_FAT, Lexical.TOKEN.IS:
+                    // we could be in a global function or in a method. If the left part looks like it could be a function or method definition
+                    // then it's an error and we need to recover. 
+
+                    // we'll need a heuristic to try to decide if the user is trying to define a nested function or if they've missed off a closing `si`
+                    // and actually this is a method definition (if we're in a classy context) or a global function definition (if we're not in a classy context)
+
+                    let is_nested_function_definition = false;
+
+                    if result.could_be_nested_function_definition /\ tokenizer_state.is_speculating then
+                        // TODO need same logic but for nested within a global function
+                        if context.in_member then
+                            if result.location.start_column > context.member_indent then
+                                // probably an attempt at nesting a named function definition
+                                is_nested_function_definition = true;
+                            elif 
+                                result.location.start_column <= context.member_indent /\
+                                result.location.start_column > context.global_indent    
+                            then
+                                // probably a missing `si` in a preceding member definition
+                                context.error(result.location, "expected 'si' after member definition");
+
+                                tokenizer_state.backtrack();
+
+                                throw new UNWIND_TO_MEMBER_EXCEPTION(null);
+                            fi
+                        elif context.in_global_function then
+                            if result.location.start_column > context.global_indent then
+                                // probably an attempt at nesting a named function definition
+                                is_nested_function_definition = true;
+                            else
+                                // probably a missing `si` in a preceding member definition
+                                context.error(result.location, "expected 'si' after member definition");
+
+                                tokenizer_state.backtrack();
 
                                 throw new UNWIND_TO_GLOBAL_EXCEPTION(null);
                             fi
-                        fi
+                        elif context.in_classy then
+                            // not clear how we might have ended up here
+                            tokenizer_state.backtrack();
 
-                        // it's unlikely to be new member or new global function definition, so we should
-                        // parse it as a function literal, even if it has a name or is otherwise garbled.
-                        // In particular, if has a block body delimited with with is / si, then we want to
-                        // consume that block, otherwise our view of the block structure will get out of sync
-                        // and we'll think we've let the enclosing function or method when we reach the closing
-                        // `si` of the function literal
+                            throw new UNWIND_TO_GLOBAL_EXCEPTION(null);
+                        fi
+                    fi
+
+                    // it's unlikely to be new member or new global function definition, so we should
+                    // parse it as a function literal, even if it has a name or is otherwise garbled.
+                    // In particular, if has a block body delimited with with is / si, then we want to
+                    // consume that block, otherwise our view of the block structure will get out of sync
+                    // and we'll think we've let the enclosing function or method when we reach the closing
+                    // `si` of the function literal
+
+                    let should_poison = false;
+                    
+                    if result.could_be_nested_function_definition then
+                        should_poison = true;
+                        context.error(result.location, "nested function definition");
+                    elif !result.could_be_formal_argument then
+                        should_poison = true;
+                        context.error(result.location, "expected function literal formal arguments");
+                    fi
     
-                        let should_poison = false;
-                        
-                        if result.could_be_nested_function_definition then
-                            should_poison = true;
-                            context.error(result.location, "nested function definition");
-                        elif !result.could_be_formal_argument then
-                            should_poison = true;
-                            context.error(result.location, "expected function literal formal arguments");
-                        fi
-        
-                        let type_expression: Trees.TypeExpressions.TypeExpression;
-                        let arguments: Trees.Expressions.LIST;
+                    let type_expression: Trees.TypeExpressions.TypeExpression;
+                    let arguments: Trees.Expressions.LIST;
 
-                        if context.current.token == Lexical.TOKEN.ARROW_THIN then
-                            context.next_token();
-                            type_expression = type_parser.parse(context);
-                            type_expression.check_is_not_reference(context.logger, "function cannot return a reference");
-                        else
-                            type_expression = new Trees.TypeExpressions.INFER(start::result.location);
-                        fi
-
-                        if context.expect_token([Lexical.TOKEN.ARROW_FAT, Lexical.TOKEN.IS]) then
-                            if should_poison then
-                                // error already reported
-                                arguments = new Trees.Expressions.LIST(start::result.location, new Collections.LIST[Trees.Expressions.Expression]());                                
-                            elif isa Trees.Expressions.TUPLE(result) then
-                                arguments = cast Trees.Expressions.TUPLE(result).elements;
-                                arguments.rewrite_as_variables();
-                            else
-                                let elements = new Collections.LIST[Trees.Expressions.Expression]();
-                                elements.add(result);
-                                arguments = new Trees.Expressions.LIST(start::result.location, elements);
-                            fi
-                            let body = body_parser.parse(context);
-                            result = new Trees.Expressions.FUNCTION(start::body.location, arguments, type_expression, body);
-
-                            if should_poison then
-                                result.poison();
-                            fi
-
-                            return result;
-                        else
-                            // TODO: is this possible?
-                            return new Trees.Expressions.Literals.NONE(start::context.location);
-                        fi
-    
-                    when Lexical.TOKEN.QUESTION:
-                        result = new Trees.Expressions.HAS_VALUE(start::context.location, result);
+                    if context.current.token == Lexical.TOKEN.ARROW_THIN then
                         context.next_token();
-    
-                    when Lexical.TOKEN.REF:
-                        result = new Trees.Expressions.REFERENCE(start::context.location, result);
-                        context.next_token();
-    
-                    when Lexical.TOKEN.OPERATOR:
-                        if context.current_string =~ "|" then
-                            let location = context.location;
-    
-                            let pipes = new Trees.Identifiers.Identifier(location, "Pipes");
-                            let pipe = new Trees.Identifiers.QUALIFIED(location, pipes, "Factory", location, location);
-                            let from = new Trees.Identifiers.QUALIFIED(location, pipe, "from", location, location);
-    
-                            let function = new Trees.Expressions.IDENTIFIER(location, from);
-    
-                            let arguments = new Trees.Expressions.LIST(
-                                result.location,
-                                [result]
-                            );
-    
-                            result = 
-                                new Trees.Expressions.CALL(
-                                    start::location,
-                                    function,
-                                    arguments
-                                );
-                                
-                            context.next_token();                            
+                        type_expression = type_parser.parse(context);
+                        type_expression.check_is_not_reference(context.logger, "function cannot return a reference");
+                    else
+                        type_expression = new Trees.TypeExpressions.INFER(start::result.location);
+                    fi
+
+                    if context.expect_token([Lexical.TOKEN.ARROW_FAT, Lexical.TOKEN.IS]) then
+                        if should_poison then
+                            // error already reported
+                            arguments = new Trees.Expressions.LIST(start::result.location, new Collections.LIST[Trees.Expressions.Expression]());                                
+                        elif isa Trees.Expressions.TUPLE(result) then
+                            arguments = cast Trees.Expressions.TUPLE(result).elements;
+                            arguments.rewrite_as_variables();
                         else
-                            return result;
+                            let elements = new Collections.LIST[Trees.Expressions.Expression]();
+                            elements.add(result);
+                            arguments = new Trees.Expressions.LIST(start::result.location, elements);
                         fi
-    
-                    when Lexical.TOKEN.SQUARE_OPEN_TICK:
-                        context.next_token();
-                        
-                        let types = type_list_parser.parse(context);
-    
-                        result =
-                            new Trees.Expressions.EXPLICIT_SPECIALIZATION(
-                                start::context.location,
-                                result,
-                                types
-                            );
-    
-                        context.next_token(Lexical.TOKEN.SQUARE_CLOSE);
-                    default
+                        let body = body_parser.parse(context);
+                        result = new Trees.Expressions.FUNCTION(start::body.location, arguments, type_expression, body);
+
+                        if should_poison then
+                            result.poison();
+                        fi
+
                         return result;
-                    esac
-                od
-    
-            finally
-                if commit then
-                    context.commit();
-                else
-                    context.backtrack();
-                fi
-            yrt
+                    else
+                        // TODO: is this possible?
+                        return new Trees.Expressions.Literals.NONE(start::context.location);
+                    fi
+
+                when Lexical.TOKEN.QUESTION:
+                    result = new Trees.Expressions.HAS_VALUE(start::context.location, result);
+                    tokenizer_state.commit_if_speculating();
+
+                    context.next_token();
+
+                when Lexical.TOKEN.REF:
+                    result = new Trees.Expressions.REFERENCE(start::context.location, result);
+                    tokenizer_state.commit_if_speculating();
+
+                    context.next_token();
+
+                when Lexical.TOKEN.OPERATOR:
+                    tokenizer_state.commit_if_speculating();
+
+                    if context.current_string =~ "|" then
+                        let location = context.location;
+
+                        let pipes = new Trees.Identifiers.Identifier(location, "Pipes");
+                        let pipe = new Trees.Identifiers.QUALIFIED(location, pipes, "Factory", location, location);
+                        let from = new Trees.Identifiers.QUALIFIED(location, pipe, "from", location, location);
+
+                        let function = new Trees.Expressions.IDENTIFIER(location, from);
+
+                        let arguments = new Trees.Expressions.LIST(
+                            result.location,
+                            [result]
+                        );
+
+                        result = 
+                            new Trees.Expressions.CALL(
+                                start::location,
+                                function,
+                                arguments
+                            );
+                            
+                        context.next_token();                            
+                    else
+                        return result;
+                    fi
+
+                when Lexical.TOKEN.SQUARE_OPEN_TICK:
+                    tokenizer_state.commit_if_speculating();
+                    
+                    context.next_token();
+                    
+                    let types = type_list_parser.parse(context);
+
+                    result =
+                        new Trees.Expressions.EXPLICIT_SPECIALIZATION(
+                            start::context.location,
+                            result,
+                            types
+                        );
+
+                    context.next_token(Lexical.TOKEN.SQUARE_CLOSE);
+
+                default
+                    return result;
+                esac
+            od
         si
     si
 si

--- a/src/syntax/parsers/statements/node.ghul
+++ b/src/syntax/parsers/statements/node.ghul
@@ -443,30 +443,23 @@ namespace Syntax.Parsers.Statements is
             if context.current.token == Lexical.TOKEN.IDENTIFIER then
                 let want_backtrack = true;
 
-                try
-                    context.speculate();
+                let use tokenizer_snapshot = context.tokenizer_speculate_then_backtrack();
 
-                    let label = identifier_parser.parse(context);
-    
-                    if context.current.token == Lexical.TOKEN.COLON then
-                        context.next_token();
-    
-                        if labellable_statement_tokens.contains(context.current.token) then
-                            // TODO: maybe we don't actually want to commit yet - could this be a broken
-                            // property definition?
+                let label = identifier_parser.parse(context);
 
-                            context.commit();
-                            want_backtrack = false;
+                if context.current.token == Lexical.TOKEN.COLON then
+                    context.next_token();
 
-                            let statement = self.parse(context);
-                            return new Trees.Statements.LABELLED(label.location::statement.location, label, statement);
-                        fi
+                    if labellable_statement_tokens.contains(context.current.token) then
+                        // TODO: maybe we don't actually want to commit yet - could this be a broken
+                        // property definition?
+
+                        tokenizer_snapshot.commit();
+
+                        let statement = self.parse(context);
+                        return new Trees.Statements.LABELLED(label.location::statement.location, label, statement);
                     fi
-                finally
-                    if want_backtrack then
-                        context.backtrack();
-                    fi
-                yrt
+                fi
             fi
 
             let left = expression_parser.parse(context);
@@ -477,12 +470,8 @@ namespace Syntax.Parsers.Statements is
                 context.next_token();
                 let right = expression_parser.parse(context);
 
-                // context.next_token(Lexical.TOKEN.SEMICOLON);
-
                 return new Trees.Statements.ASSIGNMENT(left.location::right.location, left, right);
             else
-                // context.next_token(Lexical.TOKEN.SEMICOLON);
-
                 return new Trees.Statements.EXPRESSION(left.location, left);
             fi
         si

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -1170,21 +1170,19 @@ namespace Syntax.Process is
             if binary_function_symbol? /\ isa Semantic.Symbols.FUNCTION_GROUP(binary_function_symbol) then
                 binary_function_group = cast Semantic.Symbols.FUNCTION_GROUP(binary_function_symbol);
 
-                try
-                    _logger.speculate();
+                let use logger_snapshot = _logger.speculate_then_backtrack();
 
-                    binary_overload_result =
-                        _overload_resolver
-                            .resolve(
-                                binary.location,
-                                binary_function_group,
-                                new Collections.LIST[Type]([binary.left.value.type, binary.right.value.type]),
-                                false,
-                                _symbol_table.current_instance_context?
-                            );
-                finally
-                    binary_errors = _logger.roll_back();
-                yrt
+                binary_overload_result =
+                    _overload_resolver
+                        .resolve(
+                            binary.location,
+                            binary_function_group,
+                            new Collections.LIST[Type]([binary.left.value.type, binary.right.value.type]),
+                            false,
+                            _symbol_table.current_instance_context?
+                        );
+                        
+                binary_errors = logger_snapshot.backtrack();
             fi
 
             let member_overload_result: Semantic.OVERLOAD_RESOLVE_RESULT;
@@ -1198,21 +1196,19 @@ namespace Syntax.Process is
                 if member_function_symbol? /\ isa Semantic.Symbols.FUNCTION_GROUP(member_function_symbol) then
                     member_function_group = cast Semantic.Symbols.FUNCTION_GROUP(member_function_symbol);
     
-                    try
-                        _logger.speculate();
+                    let use logger_snapshot = _logger.speculate_then_backtrack();
 
-                        member_overload_result = 
-                            _overload_resolver
-                                .resolve(
-                                    binary.location,
-                                    cast Semantic.Symbols.FUNCTION_GROUP(member_function_group),
-                                    new Collections.LIST[Type]([binary.right.value.type]),
-                                    false,
-                                    binary.left.value.is_consumable
-                                );
-                    finally
-                        member_errors = _logger.roll_back();
-                    yrt
+                    member_overload_result = 
+                        _overload_resolver
+                            .resolve(
+                                binary.location,
+                                cast Semantic.Symbols.FUNCTION_GROUP(member_function_group),
+                                new Collections.LIST[Type]([binary.right.value.type]),
+                                false,
+                                binary.left.value.is_consumable
+                            );
+
+                    member_errors = logger_snapshot.backtrack();
                 fi
             fi
 
@@ -1373,19 +1369,17 @@ namespace Syntax.Process is
 
                 let overload_result: Semantic.OVERLOAD_RESOLVE_RESULT;
 
-                try
-                    _logger.speculate();
+                let use logger_snapshot = _logger.speculate_then_backtrack();
 
-                    overload_result =
-                        _overload_resolver.resolve(
-                            index.location,
-                            cast Semantic.Symbols.FUNCTION_GROUP(symbol),
-                            argument_types,
-                            false,
-                            true);
-                finally
-                    _logger.roll_back();
-                yrt
+                overload_result =
+                    _overload_resolver.resolve(
+                        index.location,
+                        cast Semantic.Symbols.FUNCTION_GROUP(symbol),
+                        argument_types,
+                        false,
+                        true);
+
+                logger_snapshot.backtrack();
 
                 if overload_result == null then
                     if need_store then


### PR DESCRIPTION
Technical
- Create disposable wrappers around the tokenizer and logger speculation mechanisms
- Use `let use` rather than `try` / `finally` where possible to ensure speculation always properly back-tracked or committed