### PR TITLE
Fix code generation issue with scoped disposal

### DIFF
--- a/src/syntax/process/generate_il.ghul
+++ b/src/syntax/process/generate_il.ghul
@@ -91,7 +91,6 @@ namespace Syntax.Process is
             // there is only one overload of dispose:
             _dispose = cast Semantic.Symbols.FUNCTION_GROUP(idisposable_type.find_member("dispose")).functions[0];
 
-
             // Materialize the various methods of the string interpolation handler:
             _interpolation_handler = _innate_symbol_lookup.get_interpolated_string_handler_type();
             
@@ -786,7 +785,7 @@ namespace Syntax.Process is
                 while i >= 0 do
                     let v = to_dispose[i];
 
-                    let skip_label: LABEL;
+                    let skip_label: LABEL = null;
 
                     if !v.type.is_value_type then
                         skip_label = new LABEL();


### PR DESCRIPTION
Bugs fixed:
- Multiple `let use` in the same scope mixing reference and value types could result in invalid IL