### PR TITLE
Suppress error cascades

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.8.13",
+      "version": "0.8.14",
       "commands": [
         "ghul-compiler"
       ]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.8.14-alpha.7</Version>
+    <Version>0.8.15-alpha.6</Version>
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/analysis/command_handlers.ghul
+++ b/src/analysis/command_handlers.ghul
@@ -363,8 +363,6 @@ namespace Analysis is
 
                 _watchdog.request_restart();
             finally
-                // Semantic.Types.NAMED.dump_stats();
-
                 _compiler.clear_queue(); 
 
                 IoC.CONTAINER.instance.logger.end_analysis();

--- a/src/logging/diagnostics_store.ghul
+++ b/src/logging/diagnostics_store.ghul
@@ -65,7 +65,7 @@ namespace Logging is
 
         format(diagnostic: DIAGNOSTIC_MESSAGE) -> string is
             if diagnostic.is_fatal then
-                IO.Std.error.write_line("suppress fatal diagnostic: {diagnostic}");
+                // IO.Std.error.write_line("suppress fatal diagnostic: {diagnostic}");
                 return null;
             fi
 
@@ -155,6 +155,9 @@ namespace Logging is
         any_warnings: bool => _diagnostics | .any(d => d.severity == DIAGNOSTIC_SEVERITY.WARN);
         
         count: int => _diagnostics.count;
+        syntax_count: int => _diagnostics | .filter(d => !d.is_analysis) .count();
+        analysis_count: int => _diagnostics | .filter(d => d.is_analysis) .count();
+
         diagnostics: List[DIAGNOSTIC_MESSAGE] => _diagnostics;
 
         init(path: string) is
@@ -181,8 +184,6 @@ namespace Logging is
                 _dirty = true;
                 _diagnostics.clear();
             else
-                // _diagnostics = _diagnostics | .filter(d => !d.is_analysis /\ !analysis_only).collect();
-
                 let n = new LIST[DIAGNOSTIC_MESSAGE](_diagnostics.count);
 
                 for d in _diagnostics do
@@ -213,6 +214,31 @@ namespace Logging is
                 fi
             od            
         si
+
+        write_filtered_diagnostics(writer: TextWriter, formatter: DiagnosticFormatter) is
+            if _diagnostics | .filter(d => !d.is_analysis) .count() == 0 then
+                // clear errors in the client if none are present
+
+                // FIXME: we only want to do this for the LSP connection
+                writer.write(_path);
+                writer.write("\n");
+
+                return;
+            fi
+
+            // only write the first 15 syntax diagnostics per source file, on the assumption that
+            // the first few are probably the root cause of the whole error cascade. Note this
+            // relies on errors being written in the order they are discovered, which is guaranteed
+            // for syntax errors, but not for analysis errors.
+            for diagnostic in _diagnostics | .filter(d => !d.is_analysis) | .take(15) do
+                let formatted = formatter.format(diagnostic);
+
+                if formatted? then
+                    writer.write(formatted);
+                    writer.write("\n");
+                fi
+            od            
+        si
     si
 
     class DIAGNOSTICS_STATE is
@@ -221,6 +247,10 @@ namespace Logging is
         any_errors: bool => _diagnostics_by_source_path.values | .any(d => d.any_errors);
         any_warnings: bool => _diagnostics_by_source_path.values | .any(d => d.any_warnings);
 
+        is_possible_error_cascade: bool =>
+            (_diagnostics_by_source_path.values | .any(d => d.syntax_count > 0)) /\ 
+            (_diagnostics_by_source_path.values | .reduce(0, (r, d) => r + d.analysis_count) > 30);
+        
         _diagnostics_by_source_path: MutableMap[string, DIAGNOSTICS_LIST];
 
         init() is
@@ -276,6 +306,12 @@ namespace Logging is
         write_all_diagnostics(writer: TextWriter, formatter: DiagnosticFormatter) is
             for list in _diagnostics_by_source_path.values do
                 list.write_all_diagnostics(writer, formatter);
+            od
+        si
+
+        write_filtered_diagnostics(writer: TextWriter, formatter: DiagnosticFormatter) is
+            for list in _diagnostics_by_source_path.values do
+                list.write_filtered_diagnostics(writer, formatter);
             od
         si
     si
@@ -373,7 +409,13 @@ namespace Logging is
         si
 
         write_all_diagnostics(writer: TextWriter, formatter: DiagnosticFormatter) is
-            only.write_all_diagnostics(writer, formatter);
+            let state = only;
+
+            if state.is_possible_error_cascade then
+                state.write_filtered_diagnostics(writer, formatter);
+            else
+                state.write_all_diagnostics(writer, formatter);
+            fi
         si
 
         exception(location: LOCATION, exception: Exception, message: string) is

--- a/src/syntax/parsers/definitions/member_list.ghul
+++ b/src/syntax/parsers/definitions/member_list.ghul
@@ -29,6 +29,10 @@ namespace Syntax.Parsers.Definitions is
                     fi
                 catch ue: UNWIND_TO_MEMBER_EXCEPTION
                     // carry on from here
+
+                catch ubp: UNWIND_BAD_PROPERTY_EXCEPTION
+                    break;
+                    
                 catch e: Exception
                     IoC.CONTAINER.instance.logger.exception(context.current.location, e, "parse exception: {e.message}");
 

--- a/src/syntax/parsers/definitions/property.ghul
+++ b/src/syntax/parsers/definitions/property.ghul
@@ -166,9 +166,13 @@ namespace Syntax.Parsers.Definitions is
                 fi
     
                 if fail /\ !progress then
-                    IO.Std.error.write_line("no progress parsing property at {context.location}");
+                    IO.Std.error.write_line("no progress parsing property at {context.location}: from {new System.Diagnostics.StackTrace().to_string().replace_line_endings(" ")}");
                     IoC.CONTAINER.instance.watchdog.request_restart();
-                    throw new System.Exception("no progress parsing property");
+
+                    context.error(context.location, "no progress parsing property");
+                    context.next_token();
+
+                    throw new UNWIND_BAD_PROPERTY_EXCEPTION(null);
                 fi
         
                 result.poison(fail);

--- a/src/syntax/parsers/unwind_exception.ghul
+++ b/src/syntax/parsers/unwind_exception.ghul
@@ -20,4 +20,10 @@ namespace Syntax.Parsers is
             super.init(definition);
         si
     si
+
+    class UNWIND_BAD_PROPERTY_EXCEPTION: UnwindException is
+        init(definition: Syntax.Trees.Definitions.Definition) is
+            super.init(definition);
+        si
+    si
 si


### PR DESCRIPTION
Enhancements:
- If a cascade of errors is detected and syntax errors are present, show only the first 15 syntax errors per file (see #1086)