### PR TITLE
Adaptive timeouts for backgound compilation

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.8.14",
+      "version": "0.8.15",
       "commands": [
         "ghul-compiler"
       ]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.8.15-alpha.6</Version>
+    <Version>0.8.16-alpha.10</Version>
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/analysis/analyser.ghul
+++ b/src/analysis/analyser.ghul
@@ -53,13 +53,13 @@ namespace Analysis is
 
             build_flags.want_compile_up_to_expressions = true;
 
-            let file_edited_handler = new FILE_EDITED_HANDLER(watchdog, compiler, build_flags, library_files, symbol_table);
+            let file_edited_handler = new FILE_EDITED_HANDLER(watchdog, timers, compiler, build_flags, library_files, symbol_table);
 
-            let full_compile_handler = new FULL_COMPILE_HANDLER(watchdog, compiler, file_edited_handler, build_flags);
+            let full_compile_handler = new FULL_COMPILE_HANDLER(watchdog, timers, compiler, file_edited_handler, build_flags);
 
             let full_compiler: FULL_COMPILER = new FULL_COMPILER(watchdog, compiler, file_edited_handler, timers);
 
-            let hover_handler = new HOVER_HANDLER(watchdog, symbol_use_locations, full_compiler);
+            let hover_handler = new HOVER_HANDLER(watchdog, timers, symbol_use_locations, full_compiler);
             let definition_handler = new DEFINITION_HANDLER(watchdog, symbol_use_locations, full_compiler);
             let declaration_handler = new DECLARATION_HANDLER(watchdog, symbol_use_locations, full_compiler);
             let completion_handler = new COMPLETION_HANDLER(watchdog, completer, file_edited_handler, full_compiler);

--- a/src/analysis/command_despatcher.ghul
+++ b/src/analysis/command_despatcher.ghul
@@ -64,12 +64,10 @@ namespace Analysis is
 
                     let timer_name = command.to_lower_invariant();
 
-                    @IF.not.release()
                     _timers.start(timer_name);
 
                     handler.handle(_reader, _writer);
 
-                    @IF.not.release()
                     _timers.finish(timer_name);
                     
                     @IF.not.release()

--- a/src/analysis/command_handlers.ghul
+++ b/src/analysis/command_handlers.ghul
@@ -13,11 +13,13 @@ namespace Analysis is
 
     class HOVER_HANDLER: CommandHandler is
         _watchdog: WATCHDOG;
+        _timers: TIMERS;
         _symbol_use_locations: Semantic.SYMBOL_USE_LOCATIONS;
         _full_compiler: FULL_COMPILER;
 
         init(
             watchdog: WATCHDOG,
+            timers: TIMERS,
             symbol_use_locations: Semantic.SYMBOL_USE_LOCATIONS,
             full_compiler: FULL_COMPILER
         )
@@ -257,6 +259,7 @@ namespace Analysis is
     // compile (up to but not including expressions) of all other files
     class FILE_EDITED_HANDLER: CommandHandler, SourceFileLookup, Iterable[SOURCE_FILE] is
         _watchdog: WATCHDOG;
+        _timers: TIMERS;
         _compiler: COMPILER;
         _build_flags: BUILD_FLAGS;
         _library_files: Iterable[string];
@@ -271,12 +274,14 @@ namespace Analysis is
 
         init(
             watchdog: WATCHDOG,
+            timers: TIMERS,
             compiler: COMPILER,
             build_flags: BUILD_FLAGS,
             library_files: Iterable[string],
             symbol_table: Semantic.SYMBOL_TABLE
         ) is
             _watchdog = watchdog;
+            _timers = timers;
             _compiler = compiler;
             _build_flags = build_flags;
             _library_files = library_files;
@@ -369,6 +374,7 @@ namespace Analysis is
 
                 writer.write("{cast char(12)}");
                 writer.write_line("PARTIAL DONE");
+                writer.write_line(_timers.edit_timer.max_average_milliseconds);
                 writer.write("{cast char(12)}");
                 writer.flush();
             yrt
@@ -379,16 +385,19 @@ namespace Analysis is
     class FULL_COMPILE_HANDLER: CommandHandler is
         _watchdog: WATCHDOG;
         _compiler: COMPILER;
+        _timers: TIMERS;
         _source_files: Iterable[SOURCE_FILE];
         _build_flags: BUILD_FLAGS;
 
         init(
             watchdog: WATCHDOG,
+            timers: TIMERS,
             compiler: COMPILER,
             source_files: Iterable[SOURCE_FILE],
             build_flags: BUILD_FLAGS
         ) is
             _watchdog = watchdog;
+            _timers = timers;
             _compiler = compiler;
             _source_files = source_files;
             _build_flags = build_flags;
@@ -435,10 +444,10 @@ namespace Analysis is
 
                 writer.write("{cast char(12)}");
                 writer.write_line("FULL DONE");
+                writer.write_line(_timers.full_compile_timer.max_average_milliseconds);
                 writer.write("{cast char(12)}");
                 writer.flush();
             yrt
-
         si
     si
 

--- a/src/driver/arguments_parser.ghul
+++ b/src/driver/arguments_parser.ghul
@@ -20,17 +20,15 @@ namespace Driver is
                     return results;
                 fi
                 
-                let a: (argument: string, more: bool);
+                let argument: string;
 
                 if input.current == cast char(34) then
-                    a = _parse_quoted_argument(input);
+                    (argument, more) = _parse_quoted_argument(input);
                 else 
-                    a = _parse_unquoted_argument(input);
+                    (argument, more) = _parse_unquoted_argument(input);
                 fi
 
-                more = a.more;
-
-                results.add(a.argument);
+                results.add(argument);
             od
 
             return results;

--- a/src/lexical/tokenizer.ghul
+++ b/src/lexical/tokenizer.ghul
@@ -642,30 +642,8 @@ namespace Lexical is
             return (fragment.to_string(), c);
         si
 
-        read_format_string() -> (format: string, c: char) is
-            let format = new System.Text.StringBuilder();
-
-            let c = next_char();
-
-            while c != '\n' /\ c != '}' /\ c != '"' do
-                if c == cast char(92) then
-                    c = read_escape();
-                    format.append(c);
-                    c = next_char();
-                else
-                    format.append(c);
-                    c = next_char();
-                fi
-            od
-
-            return (format.to_string(), c);
-        si
-
         string_enter() -> TOKEN_PAIR is
-            let fragment_c = read_string_fragment();
-
-            let fragment = fragment_c.fragment;
-            let c = fragment_c.c;
+            let (fragment, c) = read_string_fragment();
 
             if c == '\n' then
                 _interpolation_depth = 0;
@@ -698,10 +676,7 @@ namespace Lexical is
             let fragment = "";
 
             if c == '}' then
-                let fragment_c = read_string_fragment();
-
-                fragment = fragment_c.fragment;
-                c = fragment_c.c;
+                (fragment, c) = read_string_fragment();
             fi
 
             if c == '\n' then

--- a/src/logging/diagnostics_store.ghul
+++ b/src/logging/diagnostics_store.ghul
@@ -56,10 +56,13 @@ namespace Logging is
     si
 
     trait DiagnosticFormatter is
+        want_filter_error_cascades: bool;
         format(diagnostic: DIAGNOSTIC_MESSAGE) -> string;
     si
 
     class TAB_DELIMITED_DIAGNOSTIC_FORMATTER: DiagnosticFormatter is
+        want_filter_error_cascades: bool => true;
+
         init() is
         si
 
@@ -91,6 +94,8 @@ namespace Logging is
     si
 
     class HUMAN_READABLE_DIAGNOSTIC_FORMATTER: DiagnosticFormatter is
+        want_filter_error_cascades: bool => false;
+
         init() is
         si
 
@@ -122,6 +127,8 @@ namespace Logging is
     si
 
     class MSBUILD_DIAGNOSTIC_FORMATTER: DiagnosticFormatter is
+        want_filter_error_cascades: bool => false;
+
         init() is
         si
 
@@ -249,7 +256,7 @@ namespace Logging is
 
         is_possible_error_cascade: bool =>
             (_diagnostics_by_source_path.values | .any(d => d.syntax_count > 0)) /\ 
-            (_diagnostics_by_source_path.values | .reduce(0, (r, d) => r + d.analysis_count) > 30);
+            (_diagnostics_by_source_path.values | .reduce(0, (r, d) => r + d.count) > 30);
         
         _diagnostics_by_source_path: MutableMap[string, DIAGNOSTICS_LIST];
 
@@ -388,7 +395,7 @@ namespace Logging is
                 return;
             fi
 
-            IO.Std.error.write_line("diagnostics store: re-sync from depth {_states.count} to {mark}");
+            // IO.Std.error.write_line("diagnostics store: re-sync from depth {_states.count} to {mark}");
 
             while _states.count > mark do
                 pop();
@@ -411,7 +418,7 @@ namespace Logging is
         write_all_diagnostics(writer: TextWriter, formatter: DiagnosticFormatter) is
             let state = only;
 
-            if state.is_possible_error_cascade then
+            if formatter.want_filter_error_cascades /\ state.is_possible_error_cascade then
                 state.write_filtered_diagnostics(writer, formatter);
             else
                 state.write_all_diagnostics(writer, formatter);

--- a/src/logging/timers.ghul
+++ b/src/logging/timers.ghul
@@ -11,9 +11,24 @@ namespace Logging is
 
         _started_at: System.DateTime;
 
+        valid: bool => execute_count > 0;
         execute_count: int;
         average_milliseconds: double => _execute_time.divide(cast double(execute_count)).total_milliseconds;
         moving_average_milliseconds: double;
+
+        max_average_milliseconds: double is
+            if !valid then
+                return 0.0D;
+            fi
+
+            let result = average_milliseconds;
+
+            if result > moving_average_milliseconds then
+                return result
+            else
+                return moving_average_milliseconds
+            fi
+        si
 
         init(name: string) is
             _name = name;
@@ -66,6 +81,14 @@ namespace Logging is
 
             return _timers[name];                
         si
+
+        edit_timer: TIMER is
+            return _timers["edit"];
+        si
+
+        full_compile_timer: TIMER is
+            return _timers["compile"];
+        si
         
         start(name: string) is
             self[name].start();
@@ -77,7 +100,7 @@ namespace Logging is
 
         to_string() -> string is
             let result = new StringBuilder();
-
+            
             for t in _timers.values do
                 if t.execute_count > 0 then
                     result

--- a/src/semantic/scope/namespace_search_result.ghul
+++ b/src/semantic/scope/namespace_search_result.ghul
@@ -50,7 +50,6 @@ namespace Semantic is
         
         add_function(function: Function) is
             if !function.arguments? then
-                debug_always("NAMESPACE_SEARCH.add_function: ignore {function.name} because null arguments");
                 return;
             fi
 

--- a/src/syntax/parsers/definitions/property.ghul
+++ b/src/syntax/parsers/definitions/property.ghul
@@ -166,7 +166,7 @@ namespace Syntax.Parsers.Definitions is
                 fi
     
                 if fail /\ !progress then
-                    IO.Std.error.write_line("no progress parsing property at {context.location}: from {new System.Diagnostics.StackTrace().to_string().replace_line_endings(" ")}");
+                    IO.Std.error.write_line("no progress parsing property at {context.location}");
                     IoC.CONTAINER.instance.watchdog.request_restart();
 
                     context.error(context.location, "no progress parsing property");

--- a/src/syntax/parsers/expressions/primary.ghul
+++ b/src/syntax/parsers/expressions/primary.ghul
@@ -308,9 +308,7 @@ namespace Syntax.Parsers.Expressions is
                     return new Trees.Expressions.Literals.STRING(start::context.location, "");
                 fi
     
-                success_line = parse_single_interpolated_expression(context, fragments);
-                success = success_line.success;
-                line = success_line.line;
+                (success, line) = parse_single_interpolated_expression(context, fragments);
 
                 if !success then
                     skip_to_end_of_string_with_interpolations(context, line);

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -1961,7 +1961,7 @@ namespace Syntax.Process is
                     elif sign_char == 's' \/ sign_char == 'S' then
                         cutoff = cutoff - 1;
                     fi
-                 fi
+                fi
 
                 case last_char
                 when 'b', 'B': 

--- a/src/syntax/process/generate_il.ghul
+++ b/src/syntax/process/generate_il.ghul
@@ -539,25 +539,6 @@ namespace Syntax.Process is
             super.visit(function);
         si
 
-        /*
-        pre(tuple: Trees.Expressions.TUPLE) -> bool is
-            super.pre(tuple);
-            return false;
-        si
-
-        visit(tuple: Trees.Expressions.TUPLE) is
-            super.visit(tuple);  
-        si
-        */
-
-        /*
-        visit(left: Trees.Expressions.SINGLE_EXPRESSION_LEFT) is
-        si
-
-        visit(destructure_left: Trees.Expressions.DESTRUCTURE_LEFT) is
-        si
-        */
-
         pre(statement: Expressions.STATEMENT) -> bool is
             super.pre(statement);
 
@@ -565,7 +546,6 @@ namespace Syntax.Process is
         si
 
         visit(statement: Expressions.STATEMENT) is
-
         si
 
         visit(assign: Statements.ASSIGNMENT) is
@@ -787,12 +767,7 @@ namespace Syntax.Process is
             let outer_try: LOOP_LABELS;
 
             if list.want_dispose then
-
-                let ot_rn_rv = get_exception_handler_temps();
-
-                outer_try = ot_rn_rv.outer_try;
-                return_needed = ot_rn_rv.return_needed;
-                return_value = ot_rn_rv.return_value;
+                (outer_try, return_needed, return_value) = get_exception_handler_temps();
         
                 for v in list.variables_to_dispose do
                     let buffer = new System.Text.StringBuilder();
@@ -1090,11 +1065,7 @@ namespace Syntax.Process is
 
             let return_type = current_function.return_type;
             
-            let ot_rn_rv = get_exception_handler_temps();
-
-            let outer_try = ot_rn_rv.outer_try;
-            let return_needed = ot_rn_rv.return_needed;
-            let return_value = ot_rn_rv.return_value;
+            let (outer_try, return_needed, return_value) = get_exception_handler_temps();
         
             let label = _loops.enter_try(return_needed, return_value);
 


### PR DESCRIPTION
Enhancements:
- Automatically adjust how long to wait after edits before running partial and complete compilations (requires VSCE 0.6.19 or later)