### PR TITLE
Actual type arguments in hover info

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.8.33",
+      "version": "0.8.34",
       "commands": [
         "ghul-compiler"
       ]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.8.34-alpha.5</Version>
+    <Version>0.8.35-alpha.7</Version>
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/analysis/command_handlers.ghul
+++ b/src/analysis/command_handlers.ghul
@@ -40,12 +40,12 @@ namespace Analysis is
             
             try
                 if !_watchdog.want_restart then
-                    let symbol = _symbol_use_locations.find_definition_from_use(path, line, column);
+                    let symbol = _symbol_use_locations.find_hover_use(path, line, column);
 
                     if !symbol? then
                         _full_compiler.compile_all(writer);
 
-                        symbol = _symbol_use_locations.find_definition_from_use(path, line, column);
+                        symbol = _symbol_use_locations.find_hover_use(path, line, column);
                     fi
 
                     writer.write_line("HOVER");
@@ -55,8 +55,8 @@ namespace Analysis is
                         writer.write_line(symbol.collapse_group_if_single_member().description);
                     fi
                 fi
-            catch e: Exception
-                debug_always("HOVER: {e.get_type()} {e.message}");
+            catch ex: Exception
+                debug_always("HOVER caught: {ex.get_type()} {ex.message}");
 
                 _watchdog.request_restart();
 
@@ -115,7 +115,7 @@ namespace Analysis is
                     fi
                 fi
             catch e: Exception
-                debug_always("DEFINITION: {e.get_type()}: {e.message}");
+                debug_always("DEFINITION caught: {e.get_type()}: {e.message}");
                 _watchdog.request_restart();
 
                 if !written_header then
@@ -174,7 +174,7 @@ namespace Analysis is
                 fi
 
             catch e: Exception
-                debug_always("DECLARATION: {e.get_type()}: {e.message}");
+                debug_always("DECLARATION caught: {e.get_type()}: {e.message}");
 
                 if !written_header then
                     writer.write_line("DECLARATION");
@@ -235,7 +235,7 @@ namespace Analysis is
                 _watchdog.enable();
 
             catch e: Exception
-                debug_always("FULL_COMPILER: {e.get_type()}: {e.message}");
+                debug_always("FULL_COMPILE caught: {e.get_type()}: {e.message}");
 
                 _watchdog.request_restart();
             finally
@@ -320,7 +320,7 @@ namespace Analysis is
                 if string.is_null_or_white_space(path) then
                     break;
                 fi
-
+                
                 paths.add(path);
             od
 
@@ -342,8 +342,8 @@ namespace Analysis is
                 for path in paths do
                     parse_and_add_file(path, writer, reader, false);
                 od
-            catch e: Exception
-                debug_always("PARSE: caught exception {e}");
+            catch ex: Exception
+                debug_always("PARSE caught: {ex.get_type()} {ex.message}");
             yrt
 
             try
@@ -367,8 +367,8 @@ namespace Analysis is
 
                 _watchdog.enable();
 
-            catch e: Exception
-                debug_always("ANALYSE: {e.get_type()}: {e}");
+            catch ex: Exception
+                debug_always("ANALYSE caught: {ex.get_type()} {ex.message}");
 
                 _watchdog.request_restart();
             finally
@@ -441,8 +441,8 @@ namespace Analysis is
  
                 _watchdog.enable();
 
-            catch e: Exception
-                debug_always("FULL COMPILE: {e.get_type()}: {e.message}");
+            catch ex: Exception
+                debug_always("FULL COMPILE caught: {ex.get_type()} {ex.message}");
 
                 _watchdog.request_restart();
             finally
@@ -455,7 +455,7 @@ namespace Analysis is
                 writer.write_line(_timers.compile_timer.max_average_milliseconds);
                 writer.write("{cast char(12)}");
                 writer.flush();
-            yrt
+            yrt 
         si
     si
 
@@ -501,8 +501,8 @@ namespace Analysis is
                         od
                     fi
                 fi
-            catch e: Exception
-                debug_always("COMPLETION: {e.get_type()}: {e.to_string().replace_line_endings(" ")}");
+            catch ex: Exception
+                debug_always("COMPLETION caught: {ex.get_type()} {ex.message}");
 
                 _watchdog.request_restart();
 
@@ -569,8 +569,8 @@ namespace Analysis is
                         od
                     fi
                 fi
-            catch e: Exception
-                debug_always("SIGNATURE: {e.get_type()}: {e.message}");
+            catch ex: Exception
+                debug_always("SIGNATURE caught: {ex.get_type()} {ex.message}");
 
                 _watchdog.request_restart();
 
@@ -651,8 +651,8 @@ namespace Analysis is
                         od
                     fi
                 fi
-            catch e: Exception
-                debug_always("SYMBOLS: {e.get_type()}: {e.message} {e.to_string()}");
+            catch ex: Exception
+                debug_always("SYMBOLS caught: {ex.get_type()} {ex.message}");
 
                 _watchdog.request_restart();
 
@@ -678,7 +678,6 @@ namespace Analysis is
                         );
     
                     catch ex: Exception
-                        // log?
                     yrt
                 od
             fi
@@ -795,8 +794,8 @@ namespace Analysis is
                     fi
                 fi
 
-            catch e: Exception
-                debug_always("REFERENCES: {e.get_type()}: {e.message}");
+            catch ex: Exception
+                debug_always("REFERENCES caught: {ex.get_type()} {ex.message}");
 
                 if !written_header then
                     writer.write_line("REFERENCES");
@@ -849,8 +848,8 @@ namespace Analysis is
                     fi
                 fi
 
-            catch e: Exception
-                debug_always("IMPLEMENTATION: {e.get_type()} {e.message}");
+            catch ex: Exception
+                debug_always("IMPLEMENTATION caught: {ex.get_type()} {ex.message}");
 
                 if !written_header then
                     writer.write_line("IMPLEMENTATION");
@@ -908,8 +907,8 @@ namespace Analysis is
                     fi
                 fi
 
-            catch e: Exception
-                debug_always("RENAMEREQUEST: {e.get_type()}: {e.message}");
+            catch ex: Exception
+                debug_always("RENAMEREQUEST caught: {ex.get_type()} {ex.message}");
 
                 if !written_header then
                     writer.write_line("RENAMEREQUEST");

--- a/src/semantic/symbol_use_locations.ghul
+++ b/src/semantic/symbol_use_locations.ghul
@@ -13,6 +13,7 @@ namespace Semantic is
 
     class SYMBOL_USE_LOCATIONS: SymbolUseListener is
         _symbol_use_map: LOCATION_MAP[Symbols.Symbol];
+        _hover_info_map: LOCATION_MAP[Symbols.Symbol];
         _symbol_reference_map: Collections.MAP[Symbols.Symbol,Collections.SET[LOCATION]];
 
         init() is
@@ -26,33 +27,43 @@ namespace Semantic is
 
         clear() is
             _symbol_use_map = LOCATION_MAP[Symbols.Symbol]();
+            _hover_info_map = LOCATION_MAP[Symbols.Symbol]();
             _symbol_reference_map = Collections.MAP[Symbols.Symbol,Collections.SET[LOCATION]](65521);
         si
 
         add_symbol_use(location: LOCATION, symbol: Symbols.Symbol) is
+            if 
+                !symbol? \/
+                location.is_internal \/
+                location.is_reflected \/ 
+                symbol.is_internal
+            then
+                return;
+            fi
+
+            _hover_info_map.put(location, symbol);
+
             if symbol? then
                 symbol = symbol.root_specialized_from;
             fi
 
-            if 
-                symbol? /\ 
-                !symbol.is_internal /\
-                !location.is_internal /\
-                !location.is_reflected
-            then
-                _symbol_use_map.put(location, symbol);
-
-                _add_symbol_reference(location, symbol);
-            fi
+            _symbol_use_map.put(location, symbol);
+            _add_symbol_reference(location, symbol);
         si
 
-        find_definition_from_use(file_name: string, line: int, column: int) -> Symbols.Symbol is
-            let matches = _symbol_use_map.find_all(file_name, line, column);
+        find_hover_use(file_name: string, line: int, column: int) -> Symbols.Symbol =>
+            let matches = _hover_info_map.find_all(file_name, line, column) in
+            find_best_match(matches);
 
+        find_definition_from_use(file_name: string, line: int, column: int) -> Symbols.Symbol =>
+            let matches = _symbol_use_map.find_all(file_name, line, column) in
+            find_best_match(matches);
+
+        find_best_match(matches: Collections.List[LOCATION_SEARCH_RESULT[Symbols.Symbol]]) -> Symbols.Symbol =>
             if !matches? \/ matches.count == 0 then
-                return null;
+                null;
             elif matches.count == 1 then
-                return matches[0].value;
+                matches[0].value;
             else
                 let shortest_length = 1_000_000_000;
                 let best_match: Symbols.Symbol;
@@ -70,9 +81,8 @@ namespace Semantic is
                     fi                                        
                 od
                 
-                return best_match;
-            fi
-        si
+                best_match;
+            fi;
 
         // - include definitions only
         // - don't include the definition location of the seached symbol itself unless no other matches found

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -3046,9 +3046,9 @@ namespace Syntax.Process is
             );
 
             if symbol.is_unsafe_constraints then
-                _logger.warn(location, "type {result} has unchecked constraints");
-            fi    
-
+                _logger.warn(location, "type {result} has unchecked constraints");            
+            fi
+            
             return result;
         si
 


### PR DESCRIPTION
Bugs fixed:
- Formal generic arguments sometimes shown instead of actual when hovering over symbols in some contexts in VSCode