### PR TITLE
Command line argument quoting

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.8.44",
+      "version": "0.8.45",
       "commands": [
         "ghul-compiler"
       ]

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ test_types
 .nfs*
 *.vsix
 
-.build.rsp
+**/.*.rsp
 
 obj/
 bin/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.8.45-alpha.5</Version>
+    <Version>0.8.46-alpha.4</Version>
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/driver/arguments_parser.ghul
+++ b/src/driver/arguments_parser.ghul
@@ -23,10 +23,10 @@ namespace Driver is
                 let argument: string;
 
                 (argument, more) =
-                    if input.current == cast char(34) then
-                        _parse_quoted_argument(input);
+                    if input.current == '"' \/ input.current == '\'' then
+                        _parse_quoted_argument(input, input.current)
                     else 
-                        _parse_unquoted_argument(input);
+                        _parse_unquoted_argument(input)
                     fi;
 
                 results.add(argument);
@@ -45,13 +45,13 @@ namespace Driver is
             return more;
         si
 
-        _parse_quoted_argument(input: Iterator[char]) -> (argument: string, more: bool) is
+        _parse_quoted_argument(input: Iterator[char], quote: char) -> (argument: string, more: bool) is
             // FIXME: doesn't support nested/escaped quotes, but neither do the MSBuild targets
             let result = System.Text.StringBuilder();
 
             let more = input.move_next(); // skip opening quote
 
-            while more /\ input.current != cast char(34) do
+            while more /\ input.current != quote do
                 result.append(input.current);
 
                 more = input.move_next();

--- a/src/driver/main.ghul
+++ b/src/driver/main.ghul
@@ -215,7 +215,7 @@ namespace Driver is
                 elif s =~ "-l" \/ s =~ "--library" then
                     library_locations.add(get_next_argument(args_iterator));
                 elif s =~ "-a" \/ s =~ "--assembly" then
-                    assemblies.add(get_next_argument(args_iterator));
+                        assemblies.add(get_next_argument(args_iterator));
                 elif s =~ "--assembly-info-string" then
                     let info_arg = get_next_argument(args_iterator);
                     let info = info_arg.split(['=']);
@@ -233,7 +233,6 @@ namespace Driver is
                     let version: System.Version;
 
                     try
-
                         if 
                             version_string_first_part.has_value
                         then


### PR DESCRIPTION
Technical:
- Accept single quotes as well as double quotes around compiler command line arguments