### PR TITLE
IL name override fix

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.8.45",
+      "version": "0.8.46",
       "commands": [
         "ghul-compiler"
       ]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.8.46-alpha.4</Version>
+    <Version>0.8.47-alpha.5</Version>
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/semantic/dotnet/type_details.ghul
+++ b/src/semantic/dotnet/type_details.ghul
@@ -32,22 +32,6 @@ namespace Semantic.DotNet is
             self.version_number = version_number;
         si
 
-        init(
-            dotnet_type: TYPE, 
-            assembly_name: string,
-            version_number: string
-        ) is
-            assert dotnet_type? else "dotnet_type is null";
-
-            self.dotnet_type = dotnet_type;
-
-            self.ghul_namespace = dotnet_type.`namespace;
-            self.ghul_type_name = dotnet_type.name;
-            self.il_name = dotnet_type.name;
-            self.assembly_name = assembly_name;
-            self.version_number = version_number;
-        si
-
         matches(namespace_name: string, name: string) -> bool => 
             namespace_name =~ ghul_namespace /\ name =~ ghul_type_name;
 

--- a/src/semantic/symbols/classy.ghul
+++ b/src/semantic/symbols/classy.ghul
@@ -396,9 +396,9 @@ namespace Semantic.Symbols is
             buffer.append(".");
         si
         
-        gen_dotted_name(buffer: System.Text.StringBuilder, qualifying: Scope) is            
+        gen_dotted_name(buffer: System.Text.StringBuilder, qualifying: Scope) is
             let iln = il_name_override;
-
+            
             if iln? then
                 let parts = il_name_override.split(['[',']']);
 
@@ -406,6 +406,10 @@ namespace Semantic.Symbols is
                     buffer
                         .append(parts[2]);
                 else
+                    if owner? /\ !iln.contains('.') then
+                        owner.gen_dotted_name(buffer, self);
+                    fi    
+
                     buffer.append(iln);
                 fi
             else
@@ -1056,9 +1060,6 @@ namespace Semantic.Symbols is
             let `field = Symbols.INSTANCE_FIELD(LOCATION.internal, self, name);
 
             declare(location, `field, symbol_definition_listener);
-
-            // FIXME: this doesn't seem like it does anything
-            `field.il_name_override = `field.il_name_override;
 
             `field.set_type(type);
 

--- a/src/semantic/symbols/symbol.ghul
+++ b/src/semantic/symbols/symbol.ghul
@@ -124,16 +124,16 @@ namespace Semantic.Symbols is
 
         qualified_name: string =>
             if owner? then
-                return owner.qualify(name);
+                owner.qualify(name);
             else
-                return name;
+                name;
             fi;
                 
         il_name: string =>
             if il_name_override? then
-                return il_name_override;
+                il_name_override;
             else
-                return "'{name}'";
+                "'{name}'";
             fi;
         
         il_name_override: string public;
@@ -151,15 +151,14 @@ namespace Semantic.Symbols is
 
         specialized_from: Symbol public;
 
-        root_specialized_from: Symbol is
-            let sf = specialized_from;
+        root_specialized_from: Symbol =>
+            let sf = specialized_from in
 
             if sf? then
-                return sf.root_specialized_from;
+                sf.root_specialized_from;
             else
-                return self;
-            fi
-        si
+                self;
+            fi;
 
         access: ACCESS => ACCESS.PUBLIC;
 

--- a/src/syntax/process/declare_symbols.ghul
+++ b/src/syntax/process/declare_symbols.ghul
@@ -135,7 +135,7 @@ namespace Syntax.Process is
                     fi
 
                     if is_primitive then
-                        symbol.il_is_primitive_type = true;    
+                        symbol.il_is_primitive_type = true;
                     fi
 
                     symbol.il_name_override = il_name;


### PR DESCRIPTION
Bugs fixed:
- Overriding the IL name of a class with `@IL.name` resulting in incorrect IL