### PR TITLE
Fix scripts

### DIFF
--- a/build/bootstrap.sh
+++ b/build/bootstrap.sh
@@ -97,4 +97,4 @@ END_MILLISECONDS=$(date +%s%N)
 
 ELAPSED_SECONDS=$(awk -v start="$START_MILLISECONDS" -v end="$END_MILLISECONDS" 'BEGIN { printf "%.2f", (end - start) / 1000000000 }')
 
-echo "Successfully Bootsstrapped $(dotnet ghul-compiler) in ${ELAPSED_SECONDS} seconds"
+echo "Successfully Bootstrapped $(dotnet ghul-compiler) in ${ELAPSED_SECONDS} seconds"

--- a/build/bump-version.sh
+++ b/build/bump-version.sh
@@ -8,5 +8,5 @@ if [[ ${CURRENT_VERSION} =~ ${VERSION_REGEX} ]] ; then
 
     NEXT_VERSION=${CURRENT_PREFIX}$((${CURRENT_SUFFIX} + 1))
 
-    sed -i s/${CURRENT_VERSION}/${NEXT_VERSION}/ Directory.Build.props
+    sed -i "s/${CURRENT_VERSION}/${NEXT_VERSION}/" Directory.Build.props
 fi


### PR DESCRIPTION
## Summary
- fix typo in `bootstrap.sh` output
- quote replacement string in `bump-version.sh`

## Testing
- `bash -n build/bump-version.sh`
- `bash -n build/bootstrap.sh`

------
https://chatgpt.com/codex/tasks/task_e_683ff5fd607483248cef75053c81bb61