### PR TITLE
Fix tokenizer test assertion

### DIFF
--- a/unit-tests/src/lexical/tokenizer_tests.ghul
+++ b/unit-tests/src/lexical/tokenizer_tests.ghul
@@ -109,9 +109,9 @@ namespace Lexical.UnitTests is
             for expected_identifier in split_at_white_space(source_string) do
                 let result = tokenizer.read_token();
 
-                result.token == TOKEN.IDENTIFIER;
+                assert result.token == TOKEN.IDENTIFIER;
             od
-        si        
+        si
 
         Given_a_list_of_space_separated_identifiers__current_value_string__should_be_each_identifier_in_turn() is
             @test()


### PR DESCRIPTION
## Summary
- ensure the tokenizer test uses an assertion for token type

## Testing
- `dotnet test unit-tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff777568083249734e89949bb8942