### PR TITLE
Improve Linux SDK path detection

### DIFF
--- a/src/semantic/dotnet/assemblies.ghul
+++ b/src/semantic/dotnet/assemblies.ghul
@@ -39,11 +39,17 @@ namespace Semantic.DotNet is
 
         sdk_root: string is
             if !_sdk_root? then
-                let sdks_search_paths = ["/usr/share/dotnet/packs/Microsoft.NETCore.App.Ref", "c:\\Program Files\\dotnet\\packs\\Microsoft.NETCore.App.Ref"]; 
+                let env_root = System.Environment.get_environment_variable("DOTNET_ROOT");
+                let sdks_search_paths = [
+                    "/usr/share/dotnet/packs/Microsoft.NETCore.App.Ref",
+                    "/usr/lib/dotnet/packs/Microsoft.NETCore.App.Ref",
+                    if env_root? then IO.Path.combine(env_root, "packs", "Microsoft.NETCore.App.Ref") else null fi,
+                    "c:\\Program Files\\dotnet\\packs\\Microsoft.NETCore.App.Ref"
+                ];
                 let sdks_glob = "8.0.*";
 
                 for path in sdks_search_paths do
-                    if !IO.Directory.exists(path) then
+                    if !path? \/ !IO.Directory.exists(path) then
                         continue;
                     fi
 
@@ -159,7 +165,7 @@ namespace Semantic.DotNet is
                 let assembly: System.Reflection.Assembly;
 
                 // FIXME: less fragile check:
-                if !path.starts_with("/usr/share/dotnet") then
+                if !path.starts_with("/usr/share/dotnet") /\ !path.starts_with("/usr/lib/dotnet") then
                     // try to avoid locking assemblies that we might want to rebuild:
                     assembly = _metadata_load_context.load_from_byte_array(IO.File.read_all_bytes(path));
                 else


### PR DESCRIPTION
## Summary
- account for `/usr/lib/dotnet` and `DOTNET_ROOT` when locating reference packs
- avoid locking assemblies from `/usr/lib/dotnet`

## Testing
- `dotnet publish -c Release`
- `dotnet ghul-test integration-tests`

------
https://chatgpt.com/codex/tasks/task_e_68404f1e6cf88324bc1ce78c46d1a71e