### PR TITLE
Document bootstrap and integration test duration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,10 +5,12 @@ The unit tests are driven by MSTest.
 The unit tests are minimal, have very poor coverage and are brittle. The existing tests need to pass, and may need to be fixed if impacted by code changes, but I wouldn't advise trying to add new ones. Coding unit tests in ghūl is awkward at best because ghūl has limited support for language features that frameworks like Moq take for granted.
 
 2. bootstrap `./build/bootstrap.sh`
-Bootstraps the compiler by compiling it with itself four times, and verifies that the IL for the third and fourth passes matches
+Bootstraps the compiler by compiling it with itself four times, and verifies that the IL for the third and fourth passes matches. The bootstrap step
+typically takes a little over one minute on the Codex test environment.
 
 3. integration tests `dotnet publish && dotnet ghul-test integration-tests`
 The integration tests are snapshot based - expected errors, warnings, IL and/or compiled binary output are compared against canned expectation files. See integration-tests/README.md for more details. The compiler
+publishing and test run usually finish in about a minute and a quarter in Codex.
 The integration tests are roughly grouped in four subfolders:
  integration-tests/execution - for tests that compile a binary and assert it produces specific output
  integration-tests/il - for tests that produce IL assembly language and assert it matches expected IL


### PR DESCRIPTION
## Summary
- update AGENTS.md with info about how long bootstrap and integration tests take

## Testing
- `dotnet test unit-tests`
- `time ./build/bootstrap.sh`
- `time sh -c 'dotnet publish --output publish && dotnet ghul-test integration-tests'`

------
https://chatgpt.com/codex/tasks/task_e_6840bac667108324918cd30d1dbb1138