### PR TITLE
Give inherited-generic-members project test its own C# library

### DIFF
--- a/project-tests/cs-test-assembly/cs-test-assembly.cs
+++ b/project-tests/cs-test-assembly/cs-test-assembly.cs
@@ -61,49 +61,5 @@
     }
 }
 
-namespace InheritedGenericMembers {
-    // Generic base with parameters used in method signatures and field types,
-    // including a self-referencing constraint (CRTP / F-bounded). Patterns
-    // like this — used by FluentAssertions and similar libraries — surface
-    // inherited members on the constructed base via reflection with their
-    // type-parameter references substituted to concrete types. ghūl must
-    // recover the open-generic form when emitting methodref/fieldref tokens.
-    public class GenericBase<TSubject, TAssertions>
-        where TAssertions : GenericBase<TSubject, TAssertions>
-    {
-        public TSubject SubjectField = default!;
-        public TAssertions SelfField = default!;
-        public AndConstraint<TAssertions> WrappedSelfField = default!;
-
-        public string DescribeSubject(TSubject subject) {
-            return $"DescribeSubject({subject})";
-        }
-
-        public TAssertions ReturnSelf() {
-            return (TAssertions)(object)this;
-        }
-
-        public string TakeSelf(TAssertions other) {
-            return $"TakeSelf({other})";
-        }
-
-        public AndConstraint<TAssertions> WrapSelf() {
-            return new AndConstraint<TAssertions> { And = (TAssertions)(object)this };
-        }
-    }
-
-    public class AndConstraint<T> {
-        public T And = default!;
-    }
-
-    public class Concrete: GenericBase<object, Concrete> {
-        public Concrete() {
-            SubjectField = "subject-init";
-            SelfField = this;
-            WrappedSelfField = new AndConstraint<Concrete> { And = this };
-        }
-    }
-}
-
 
 

--- a/project-tests/inherited-generic-members/inherited-generic-members.ghulproj
+++ b/project-tests/inherited-generic-members/inherited-generic-members.ghulproj
@@ -9,6 +9,6 @@
 
   <ItemGroup>
     <GhulSources Include="**/*.ghul" />
-    <ProjectReference Include="../cs-test-assembly/cs-test-assembly.csproj" />
+    <ProjectReference Include="lib/lib.csproj" />
   </ItemGroup>
 </Project>

--- a/project-tests/inherited-generic-members/lib/lib.cs
+++ b/project-tests/inherited-generic-members/lib/lib.cs
@@ -1,0 +1,43 @@
+namespace InheritedGenericMembers {
+    // Generic base with parameters used in method signatures and field types,
+    // including a self-referencing constraint (CRTP / F-bounded). Patterns
+    // like this — used by FluentAssertions and similar libraries — surface
+    // inherited members on the constructed base via reflection with their
+    // type-parameter references substituted to concrete types. ghūl must
+    // recover the open-generic form when emitting methodref/fieldref tokens.
+    public class GenericBase<TSubject, TAssertions>
+        where TAssertions : GenericBase<TSubject, TAssertions>
+    {
+        public TSubject SubjectField = default!;
+        public TAssertions SelfField = default!;
+        public AndConstraint<TAssertions> WrappedSelfField = default!;
+
+        public string DescribeSubject(TSubject subject) {
+            return $"DescribeSubject({subject})";
+        }
+
+        public TAssertions ReturnSelf() {
+            return (TAssertions)(object)this;
+        }
+
+        public string TakeSelf(TAssertions other) {
+            return $"TakeSelf({other})";
+        }
+
+        public AndConstraint<TAssertions> WrapSelf() {
+            return new AndConstraint<TAssertions> { And = (TAssertions)(object)this };
+        }
+    }
+
+    public class AndConstraint<T> {
+        public T And = default!;
+    }
+
+    public class Concrete: GenericBase<object, Concrete> {
+        public Concrete() {
+            SubjectField = "subject-init";
+            SelfField = this;
+            WrappedSelfField = new AndConstraint<Concrete> { And = this };
+        }
+    }
+}

--- a/project-tests/inherited-generic-members/lib/lib.csproj
+++ b/project-tests/inherited-generic-members/lib/lib.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>inherited-generic-members-lib</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Remove="ghul.runtime" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- move the `InheritedGenericMembers` C# fixtures out of the shared `cs-test-assembly.csproj` into a private `lib/lib.csproj` inside the inherited-generic-members test directory
- restore `cs-test-assembly.csproj` to its original purpose (only used by `ambiguous-method-hiding-1`)
- update `inherited-generic-members.ghulproj` to `<ProjectReference>` the local `lib/lib.csproj` instead of the shared one

## Background

Two project tests (`inherited-generic-members` and `ambiguous-method-hiding-1`) were both `<ProjectReference>`-ing `cs-test-assembly.csproj`. When `ghul-test --use-dotnet-build` runs them in parallel (8 workers in CI), both `dotnet build` invocations enter MSBuild's `GenerateDepsFile` task for the same `.deps.json` output, which is opened with `FileShare.None`. The second invocation fails:

```
error MSB4018: System.IO.IOException: The process cannot access the file
'.../cs-test-assembly/bin/Debug/net8.0/cs-test-assembly.deps.json'
because it is being used by another process.
```

This race surfaced on the main-branch CI build of #1202 (the PR gate happened to schedule them serially, so the bug only became visible post-merge), and is currently blocking the publish step. Giving each project test its own private C# library makes `dotnet build` invocations independent, eliminating the shared write target.

A more general fix in the test runner (build each test's project references in an isolated working directory) would prevent any future re-occurrence regardless of how project tests are structured, but is out of scope here — this PR is the minimal local fix to unblock publish.

## Testing
- 10 consecutive runs of `dotnet ghul-test --use-dotnet-build project-tests` all green (no race observed).
- `inherited-generic-members` test continues to fail with the inherited-generic bug it was written to catch when run against an unfixed compiler — the only change is in how the C# fixtures are packaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)