### PR TITLE
Fix LUB widening when subtype seen before its ancestor

### DIFF
--- a/src/syntax/process/least_upper_bound_map.ghul
+++ b/src/syntax/process/least_upper_bound_map.ghul
@@ -112,7 +112,7 @@ namespace Syntax.Process is
                 if !best? then
                     best = type;
                 elif type.is_assignable_from(best) then
-                    type = best;
+                    best = type;
                 elif !best.is_assignable_from(type) then
                     return null;
                 fi

--- a/unit-tests/src/syntax/process/least_upper_bound_map_tests.ghul
+++ b/unit-tests/src/syntax/process/least_upper_bound_map_tests.ghul
@@ -1,0 +1,167 @@
+namespace Syntax.Process.UnitTests is
+    use Collections.LIST;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    use Source.LOCATION;
+
+    use Semantic.Symbols.CLASS;
+    use Semantic.Types.Type;
+
+    // Tests for LEAST_UPPER_BOUND_MAP — the helper that backs ghūl's "what
+    // common type satisfies all of these elements?" inference for list
+    // literals, `if` expression branches, and (in the future) generic
+    // function/constructor type-argument inference.
+    //
+    // The implementation has three increasingly broad strategies:
+    //
+    // 1. ONLY_ELEMENT_TYPES: pick the most-derived input type that is
+    //    assignable from all the others (the original heuristic).
+    // 2. ANY_CONCRETE: walk all element types and their concrete ancestors,
+    //    intersect, pick the most-derived survivor (worst case: object).
+    // 3. ANY_TRAIT: same but over implemented traits.
+    //
+    // These tests pin the externally-observable contract of `add` /
+    // `get_result` for the easily-constructable cases. Tuple-element-name
+    // preservation and trait selection are deliberately out of scope here
+    // — they need fuller fixtures and would obscure the basic behaviour.
+    class LEAST_UPPER_BOUND_MAP_TESTS is
+        @test()
+
+        init() is si
+
+        loc() -> LOCATION => LOCATION("test.ghul", 1, 1, 1, 1);
+
+        empty_names() -> LIST[string] => LIST[string]();
+
+        // Build a tiny class hierarchy:
+        //
+        //   object_class
+        //     ├── animal
+        //     │     ├── cat
+        //     │     └── dog
+        //     └── plant
+        //
+        // Returned as a tuple so individual tests can reference each level.
+        build_hierarchy() -> (object_class: CLASS, animal: CLASS, cat: CLASS, dog: CLASS, plant: CLASS) is
+            let object_class = CLASS(loc(), loc(), null, "object", empty_names(), false, null);
+            object_class.mark_is_object();
+
+            let animal = CLASS(loc(), loc(), null, "animal", empty_names(), false, null);
+            animal.add_ancestor(object_class.type);
+
+            let cat = CLASS(loc(), loc(), null, "cat", empty_names(), false, null);
+            cat.add_ancestor(animal.type);
+
+            let dog = CLASS(loc(), loc(), null, "dog", empty_names(), false, null);
+            dog.add_ancestor(animal.type);
+
+            let plant = CLASS(loc(), loc(), null, "plant", empty_names(), false, null);
+            plant.add_ancestor(object_class.type);
+
+            return (object_class, animal, cat, dog, plant);
+        si
+
+        Calling__get_result__on_an_empty_map__should_return_null() is
+            @test()
+
+            let lub = LEAST_UPPER_BOUND_MAP();
+
+            Assert.is_null(lub.get_result());
+        si
+
+        Calling__get_result__after_adding_a_single_type__should_return_that_type() is
+            @test()
+
+            let h = build_hierarchy();
+            let lub = LEAST_UPPER_BOUND_MAP();
+
+            lub.add(h.cat.type);
+
+            Assert.are_same(h.cat.type, lub.get_result());
+        si
+
+        Calling__get_result__after_adding_two_identical_types__should_return_that_type() is
+            @test()
+
+            let h = build_hierarchy();
+            let lub = LEAST_UPPER_BOUND_MAP();
+
+            lub.add(h.cat.type);
+            lub.add(h.cat.type);
+
+            Assert.are_same(h.cat.type, lub.get_result());
+        si
+
+        Calling__get_result__on_a_subtype_and_its_ancestor__should_return_the_ancestor() is
+            @test()
+
+            let h = build_hierarchy();
+            let lub = LEAST_UPPER_BOUND_MAP();
+
+            // Ancestor first, then subtype.
+            lub.add(h.animal.type);
+            lub.add(h.cat.type);
+
+            Assert.are_same(h.animal.type, lub.get_result());
+        si
+
+        Calling__get_result__on_a_subtype_first_then_its_ancestor__should_still_return_the_ancestor() is
+            @test()
+
+            let h = build_hierarchy();
+            let lub = LEAST_UPPER_BOUND_MAP();
+
+            // Subtype first — the heuristic must replace `best` with the
+            // ancestor when it sees one that's assignable from the current best.
+            lub.add(h.cat.type);
+            lub.add(h.animal.type);
+
+            Assert.are_same(h.animal.type, lub.get_result());
+        si
+
+        Calling__get_result__on_two_siblings__should_return_their_common_concrete_ancestor() is
+            @test()
+
+            let h = build_hierarchy();
+            let lub = LEAST_UPPER_BOUND_MAP();
+
+            lub.add(h.cat.type);
+            lub.add(h.dog.type);
+
+            // Neither cat nor dog is assignable from the other, so the
+            // first heuristic returns null. The ANY_CONCRETE pass walks
+            // both ancestor chains, intersects, and picks the most-derived
+            // survivor — animal.
+            Assert.are_same(h.animal.type, lub.get_result());
+        si
+
+        Calling__get_result__on_unrelated_concrete_types__should_return_object() is
+            @test()
+
+            let h = build_hierarchy();
+            let lub = LEAST_UPPER_BOUND_MAP();
+
+            lub.add(h.cat.type);
+            lub.add(h.plant.type);
+
+            // No common ancestor below object — ANY_CONCRETE returns object,
+            // ANY_TRAIT returns null (no traits in this fixture), so object wins.
+            Assert.are_same(h.object_class.type, lub.get_result());
+        si
+
+        Calling__get_result__after_adding_three_types_at_different_depths__should_return_the_common_ancestor() is
+            @test()
+
+            let h = build_hierarchy();
+            let lub = LEAST_UPPER_BOUND_MAP();
+
+            lub.add(h.cat.type);
+            lub.add(h.animal.type);
+            lub.add(h.dog.type);
+
+            // animal is the most-derived type assignable from all three.
+            Assert.are_same(h.animal.type, lub.get_result());
+        si
+    si
+si


### PR DESCRIPTION
## Summary
- fix `LEAST_UPPER_BOUND_MAP._try_get_best_assignable` so it actually widens `best` when a later type is an ancestor of the current best (one-character change: `type = best` → `best = type`)
- add unit tests for `LEAST_UPPER_BOUND_MAP` covering the basic contract (empty / single / identical / subtype+ancestor in both orders / siblings / unrelated)

## Background

The intent of the loop in `_try_get_best_assignable` is "walk every input type, keep the most specific one that is a supertype (assignable from) all the others". When a candidate type is encountered that is assignable from the current `best`, `best` should be replaced with it — the candidate is wider, so it is a more correct LUB.

The line read `type = best;` instead of `best = type;`, so the assignment silently no-op'd (it writes to the loop iteration variable, not to `best`). The bug only triggered when the *first* input type was narrower than a later one — in the reverse order the early branch already held the wider type.

The most user-visible symptom: an array literal `[d, b]` (Derived first, then Base) was typed as `Derived[]` rather than `Base[]`. Because the IL then declares the array element type as `Derived` but actually stores a `Base` element, the runtime throws `ArrayTypeMismatchException` on access. The same literal in the opposite order `[b, d]` worked correctly, which is exactly the kind of order-dependent quirk that goes undiagnosed for a long time.

## Tests added

`unit-tests/src/semantic/symbols/...` was where the existing unit tests sat for #1202; this PR adds `unit-tests/src/syntax/process/least_upper_bound_map_tests.ghul` next to the source. The tests build a tiny class hierarchy (`object` → `animal` → `cat`/`dog`; `object` → `plant`) and pin:

- empty input → null
- single input → that type
- identical inputs → that type
- ancestor-then-subtype → ancestor
- subtype-then-ancestor → ancestor *(this was the failing case)*
- two siblings → their common concrete ancestor
- two unrelated concrete types → object
- mixed-depth chain → most-derived common ancestor

The "subtype-then-ancestor" test fails on unfixed main; the "ancestor-then-subtype" test passes regardless. Both pass with the fix.

## Testing
- `dotnet test unit-tests` (82 passing, up from 74)
- `dotnet ghul-test integration-tests` (593/593)
- `dotnet ghul-test --use-dotnet-build project-tests` (4/4)
- end-to-end repro: `let m1 = [Base(), Derived()]; let m2 = [Derived(), Base()];` — `m2` previously crashed with `ArrayTypeMismatchException`; now both produce `Base[]` and run cleanly.

## Notes

This is a deliberately narrow fix. The wider scope of #1173 (extending LUB to generic function/constructor arg inference, function-literal multi-return-type, etc.) is left for follow-up PRs. Adding the unit tests first to the existing LUB infrastructure was suggested as a way to shake out latent issues before extending it — and it did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)