### PR TITLE
Unify overload-resolution implications with constraints

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.8.72",
+      "version": "0.8.73",
       "commands": [
         "ghul-compiler"
       ],

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -28,8 +28,6 @@ namespace Syntax.Process is
         _value_converter: VALUE_CONVERTER;
         _value_boxer: VALUE_BOXER;
 
-        _partial_argument_function_type: Type;
-
         _will_generate_code: bool;
 
         _stub_depth: int;
@@ -953,17 +951,11 @@ namespace Syntax.Process is
 
             // have we been passed expected arguments types? If so we'll use them
             // to argument types of any anonymous function literal arguments.
-            // Two channels feed this: the older _partial_argument_function_type
-            // implication (set by overload resolution while retrying with
-            // function-literal args), and the newer set_constraint pathway
-            // used by the parent context (LHS of an assignment, typed variable
-            // initializer). Prefer the implication when both are set — it
-            // reflects the most-recent overload-resolution decision and is
-            // already specialised for the call site.
-            if _partial_argument_function_type? then
-                implied_argument_types = _partial_argument_function_type.arguments;
-                _partial_argument_function_type = null;
-            elif function.constraint? /\ function.constraint.is_function then
+            // Single source of truth: function.constraint, set by the parent
+            // context — LHS of an assignment, typed variable initializer, or
+            // overload-resolution second-pass when this lambda was an actual
+            // arg whose chosen-formal type is now known (#1174).
+            if function.constraint? /\ function.constraint.is_function then
                 implied_argument_types = function.constraint.arguments;
             fi
 
@@ -1955,14 +1947,9 @@ namespace Syntax.Process is
                     elif a.value? /\ isa Trees.Expressions.FUNCTION(a) then
                         let f = overload_result.function.arguments[index];
 
-                        try
-                            _partial_argument_function_type = f;
+                        a.set_constraint(f, "{{0}} is not assignable to {{1}}");
+                        a.walk(self);
 
-                            a.walk(self);
-                        finally
-                            _partial_argument_function_type = null;
-                        yrt
-                        
                         argument_types[index] = a.value.type;
                     else
                         // ensure any error messages are committed
@@ -3330,14 +3317,9 @@ namespace Syntax.Process is
                             elif a.value? /\ isa Trees.Expressions.FUNCTION(a) then
                                 let f = overload_result.function.arguments[index];
 
-                                try
-                                    _partial_argument_function_type = f;
+                                a.set_constraint(f, "{{0}} is not assignable to {{1}}");
+                                a.walk(self);
 
-                                    a.walk(self);
-                                finally
-                                    _partial_argument_function_type = null;
-                                yrt
-                                
                                 argument_types[index] = a.value.type;
                             else
                                 // ensure any error messages are committed


### PR DESCRIPTION
Function-literal argument-type inference had two channels for receiving
type information from a parent context: the older
`_partial_argument_function_type` global field (set by overload
resolution's PARTIAL second-pass) and the newer `function.constraint`
field (set by LHS pushdowns from assignments, typed initializers,
etc.). Producers and consumers of either channel could not see what
the other channel had set.

Both PARTIAL second-pass sites now call `set_constraint` on the
function-literal AST node (the same channel everything else uses).
The lambda visit reads `function.constraint` only.

Enhancements:
- Overload resolution now produces type constraints, not implications
  (closes part of #1174)
- Function-literal argument-type inference now consumes type
  constraints, not implications (closes part of #1174)

Technical:
- Remove the `_partial_argument_function_type` field and its
  prefer-over-constraint read site
- Bump pinned ghul.compiler to 0.8.73

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>