### PR TITLE
Drop redundant lambda-arg annotations in add_accessors_for_properties

### DIFF
--- a/src/syntax/process/add_accessors_for_properties.ghul
+++ b/src/syntax/process/add_accessors_for_properties.ghul
@@ -765,9 +765,9 @@ namespace Syntax.Process is
     si
 
     get_init_method_for_variant(variant: Trees.Definitions.VARIANT) -> Definitions.FUNCTION is
-        let arguments = 
-            variant.fields | 
-                .map((v: Variables.VARIABLE) -> Variables.VARIABLE =>
+        let arguments =
+            variant.fields |
+                .map((v) -> Variables.VARIABLE =>
                     Variables.VARIABLE(
                         v.location,
                         v.name.copy(),
@@ -776,12 +776,12 @@ namespace Syntax.Process is
                         false,
                         null
                     )
-                )            
+                )
                 .collect_list();
 
-        let initializers = 
-            variant.fields | 
-                .map((v: Variables.VARIABLE) -> Trees.Statements.Statement is
+        let initializers =
+            variant.fields |
+                .map((v) -> Trees.Statements.Statement is
                     let member_access = 
                         Trees.Expressions.MEMBER(
                             variant.location,
@@ -918,7 +918,7 @@ namespace Syntax.Process is
                 location,
                 Trees.Expressions.LIST(
                     location,
-                    fields | .map((v: Variables.VARIABLE) -> Expressions.Expression => 
+                    fields | .map((v) -> Expressions.Expression =>
                         Trees.Expressions.IDENTIFIER(
                             location,
                             Identifiers.Identifier(


### PR DESCRIPTION
The three `.map((v: Variables.VARIABLE) -> ... => ...)` calls in
`add_accessors_for_properties.ghul` now read as
`.map((v) -> ... => ...)` — the iterative inference work in #1210
lets the lambda's argument type be inferred from the receiver's
element type at the call site.

Technical:
- Drop redundant `: Variables.VARIABLE` annotation on three lambda
  args in get_init_method_for_variant and
  get_value_body_multiple_fields

A fourth candidate at `least_upper_bound_map.ghul:211` was tried
and reverted: the nested `.filter(t => current_list | .any(u => t =~ u))`
shape didn't converge under iterative inference and surfaced a
`Semantic.Types.INFERRED_VARIABLE_TYPE.walk(action)` not-implemented
exception. That looks like a real placeholder-type completeness gap;
left as future work.