### PR TITLE
Fix NotImplementedException in INFERRED_VARIABLE_TYPE.walk

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.8.74",
+      "version": "0.8.76",
       "commands": [
         "ghul-compiler"
       ],

--- a/src/semantic/types/infered_return_type.ghul
+++ b/src/semantic/types/infered_return_type.ghul
@@ -49,6 +49,15 @@ namespace Semantic.Types is
             buffer.append("/* inferred type placeholder */");
         si
 
+        // Leaf type for walk(action) — same rationale as
+        // INFERRED_VARIABLE_TYPE: placeholders have no children
+        // and aren't a bug to catch. Without this override the
+        // default throws, breaking eager closure-freeze paths
+        // that walk the type for capture analysis.
+        walk(action: (Type) -> void) is
+            action(self);
+        si
+
         to_string() -> string => "***";
     si
 si

--- a/src/semantic/types/inferred_variable_type.ghul
+++ b/src/semantic/types/inferred_variable_type.ghul
@@ -56,6 +56,20 @@ namespace Semantic.Types is
             buffer.append("/* inferred variable type placeholder */");
         si
 
+        // Treated as a leaf type for walk-based analyses. The
+        // default Type.walk(action) throws to catch genuine bugs
+        // where compound types forget to override; placeholders
+        // have no children to recurse into and aren't bugs to
+        // catch — they're an expected first-walk transient state.
+        // is_type_variable returns false on this type, so callers
+        // like Closure._get_actual_arguments that check it for
+        // type-variable references see a no-op visit, which is
+        // correct: the placeholder isn't a generic-argument
+        // reference, just an unresolved local type.
+        walk(action: (Type) -> void) is
+            action(self);
+        si
+
         to_string() -> string => "***";
     si
 si

--- a/src/syntax/process/add_accessors_for_properties.ghul
+++ b/src/syntax/process/add_accessors_for_properties.ghul
@@ -765,9 +765,9 @@ namespace Syntax.Process is
     si
 
     get_init_method_for_variant(variant: Trees.Definitions.VARIANT) -> Definitions.FUNCTION is
-        let arguments = 
-            variant.fields | 
-                .map((v: Variables.VARIABLE) -> Variables.VARIABLE =>
+        let arguments =
+            variant.fields |
+                .map((v) -> Variables.VARIABLE =>
                     Variables.VARIABLE(
                         v.location,
                         v.name.copy(),
@@ -776,12 +776,12 @@ namespace Syntax.Process is
                         false,
                         null
                     )
-                )            
+                )
                 .collect_list();
 
-        let initializers = 
-            variant.fields | 
-                .map((v: Variables.VARIABLE) -> Trees.Statements.Statement is
+        let initializers =
+            variant.fields |
+                .map((v) -> Trees.Statements.Statement is
                     let member_access = 
                         Trees.Expressions.MEMBER(
                             variant.location,
@@ -918,7 +918,7 @@ namespace Syntax.Process is
                 location,
                 Trees.Expressions.LIST(
                     location,
-                    fields | .map((v: Variables.VARIABLE) -> Expressions.Expression => 
+                    fields | .map((v) -> Expressions.Expression =>
                         Trees.Expressions.IDENTIFIER(
                             location,
                             Identifiers.Identifier(


### PR DESCRIPTION
Both inference placeholder types (`INFERRED_VARIABLE_TYPE` and
`INFERED_RETURN_TYPE`) inherited the throwing default
`Type.walk(action)` — meant to catch genuine compiler bugs where
compound types forget to override. Placeholders are leaves and
shouldn't trigger that guard. The closure-freeze path
(`Symbols.Closure._get_actual_arguments`) walks captured-value
types looking for type-variable references, and crashes
catastrophically when a captured value's type is still a
placeholder during the body retry loop's first iteration.

Override `walk(action)` on both placeholder types to act as a leaf
(call `action(self)`). `is_type_variable` returns false on these,
so the closure capture analysis sees a no-op visit, which is correct.

Bugs fixed:
- `NotImplementedException` in `INFERRED_VARIABLE_TYPE.walk(action)`
  when an inner lambda captures an outer lambda's
  placeholder-typed argument before iterative inference has
  resolved it (e.g. nested `.filter(t => ... | .any(u => ...))`
  where `t` starts unresolved)

Technical:
- Note: a separate, larger issue remains where closure freeze
  emits IL field declarations with the placeholder's `gen_type`
  comment string when a placeholder leaks past iter 1. That
  surfaces post-walk-fix in the same scenarios but requires
  deferring closure freeze until after retry-loop convergence
  (or rewriting frozen IL on later iterations) — orthogonal,
  separate work