### PR TITLE
Add analysis-tests project for analysis-mode protocol coverage

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.8.78",
+      "version": "0.8.79",
       "commands": [
         "ghul-compiler"
       ],

--- a/analysis-tests/.gitignore
+++ b/analysis-tests/.gitignore
@@ -1,0 +1,6 @@
+bin/
+obj/
+TestResults/
+.assemblies.json
+.build.rsp
+.analyser.rsp

--- a/analysis-tests/analysis-tests.ghulproj
+++ b/analysis-tests/analysis-tests.ghulproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <GhulCompiler>dotnet ghul-compiler</GhulCompiler>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="FluentAssertions" />
+
+    <GhulSources Include="src/**/*.ghul" />
+
+    <None Include="fixtures/**/*" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <Target Name="EnsureAssembliesJson" BeforeTargets="Build" DependsOnTargets="GenerateAssembliesJson" />
+</Project>

--- a/analysis-tests/fixtures/object-oriented.ghul
+++ b/analysis-tests/fixtures/object-oriented.ghul
@@ -1,0 +1,123 @@
+use IO.Std.write_line;
+
+entry() is
+    let int_calculator = CALCULATOR(
+        [
+            // we don't have covariance in tuples, so we need
+            // to specify the type of the operation explicitly
+            ("+", op: Operation[int] = INTEGER_ADDITION()),
+            ("-", op: Operation[int] = INTEGER_SUBTRACTION()),
+            ("*", op: Operation[int] = INTEGER_MULTIPLICATION()),
+            ("/", op: Operation[int] = INTEGER_DIVISION())
+        ]
+    );
+
+    write_line("1 + 2 = {int_calculator.calculate("+", 1, 2)}");
+    write_line("1 - 2 = {int_calculator.calculate("-", 1, 2)}");
+    write_line("1 * 2 = {int_calculator.calculate("*", 1, 2)}");
+    write_line("1 / 2 = {int_calculator.calculate("/", 1, 2)}");
+
+    write_line("1 + 2 - 3 = {int_calculator.calculate_from_memory("-", 3)}");
+
+    let string_calculator = CALCULATOR(
+        [
+            ("+", op: Operation[string] = STRING_CONCATENATION()),
+            ("-", op: Operation[string] = STRING_SUBTRACTION())
+        ]
+    );
+
+    write_line("hello + world = {string_calculator.calculate("+", "hello", "world")}");
+    write_line("helloworld - world = {string_calculator.calculate("-", "helloworld", "world")}");
+
+    string_calculator.clear_memory();
+
+    write_line("memory is cleared");
+si
+
+trait Operation[T] is
+    execute(left: T, right: T) -> T;
+si
+
+class CALCULATOR[T] is
+    _operations: Collections.MAP[string, Operation[T]];
+
+    memory: T;
+
+    init(operations: Collections.Iterable[(name: string, operation: Operation[T])]) is
+        _operations = 
+            Collections.MAP(
+                operations | 
+                    .map(on => let (name, operation) = on in Collections.KeyValuePair`2(name, operation)));
+    si
+
+    calculate(operation_name: string, left: T, right: T) -> T =>
+        if _operations.contains_key(operation_name) then
+            let operation = _operations[operation_name];
+            memory = operation.execute(left, right);
+
+            memory
+        else
+            throw System.InvalidOperationException("invalid operation {operation_name}")
+        fi;
+
+
+    calculate_from_memory(operation_name: string, right: T) -> T =>
+        if _operations.contains_key(operation_name) then
+            let operation = _operations[operation_name];
+            memory = operation.execute(memory, right);
+
+            memory
+        else
+            throw System.InvalidOperationException("invalid operation {operation_name}")
+        fi;
+
+    clear_memory() is
+        let def: T; // uninitialized variable has default value
+        memory = def;
+    si
+si
+
+class INTEGER_ADDITION: Operation[int] is
+    init() is si
+
+    execute(left: int, right: int) -> int => left + right;
+si
+
+class INTEGER_SUBTRACTION: Operation[int] is
+    init() is si
+
+    execute(left: int, right: int) -> int => left - right;
+si
+
+class INTEGER_MULTIPLICATION: Operation[int] is
+    init() is si
+
+    execute(left: int, right: int) -> int is
+        return left * right;
+    si
+si
+
+class INTEGER_DIVISION: Operation[int] is
+    init() is si
+
+    execute(left: int, right: int) -> int =>
+        if right == 0 then
+            throw System.InvalidOperationException("division by zero");
+        else
+            left / right
+        fi;
+si
+
+class STRING_CONCATENATION: Operation[string] is
+    init() is si
+
+    execute(left: string, right: string) -> string => left + right;
+si
+
+class STRING_SUBTRACTION: Operation[string] is
+    init() is si
+
+    execute(left: string, right: string) -> string => left.replace(right, "");
+si
+
+

--- a/analysis-tests/src/main.ghul
+++ b/analysis-tests/src/main.ghul
@@ -1,0 +1,2 @@
+entry() is
+si

--- a/analysis-tests/src/protocol/analyser_process.ghul
+++ b/analysis-tests/src/protocol/analyser_process.ghul
@@ -1,0 +1,304 @@
+namespace Analysis.Protocol is
+    use System.Exception;
+    use System.Diagnostics.Process;
+    use System.Diagnostics.ProcessStartInfo;
+    use System.Text.StringBuilder;
+    use System.Text.UTF8Encoding;
+
+    use Collections.Iterable;
+    use Collections.MutableList;
+    use Collections.LIST;
+
+    use IO.File;
+    use IO.Path;
+
+    // Form-feed character (ASCII 12). The analyser uses this to terminate every
+    // response frame and to terminate file content in EDIT requests.
+    FORM_FEED: char static => cast char(12);
+
+    // Long-lived wrapper around a `dotnet ghul-compiler --analyse @...` subprocess.
+    // Each test should construct one in [@test_initialize] and dispose() it in
+    // [@test_cleanup] — see project_analysis_protocol_locked memory for why we
+    // can't share processes across tests (the compiler has substantial persistent
+    // global state that the analyser's `clear_symbols` doesn't fully scrub).
+    class ANALYSER_PROCESS: Disposable is
+        _process: Process;
+        _stderr_capture: StringBuilder;
+
+        // Walk up from the running test assembly to find analysis-tests/ — that's
+        // where .config/dotnet-tools.json (via ghul/) and .assemblies.json live.
+        find_project_directory() -> string static is
+            let assembly_path = System.Reflection.Assembly.get_executing_assembly().location;
+            let dir = Path.get_directory_name(assembly_path);
+
+            // bin/Debug/net8.0/<dll> -> walk up three to project root
+            do
+                if dir? /\ File.exists(Path.combine(dir, "analysis-tests.ghulproj")) then
+                    return dir;
+                fi
+
+                let parent = Path.get_directory_name(dir);
+
+                if parent? /\ parent !~ dir then
+                    dir = parent;
+                else
+                    break;
+                fi
+            od
+
+            throw Exception("could not find analysis-tests project directory from assembly path: {assembly_path}");
+        si
+
+        // Read .assemblies.json (produced by the GenerateAssembliesJson MSBuild
+        // target) and return the list of "-a <path>" args plus a trailing "-A".
+        // Format is exactly { "assemblies": ["path1", "path2", ...] }.
+        build_analyser_arguments(project_directory: string) -> Iterable[string] static is
+            let assemblies_json_path = Path.combine(project_directory, ".assemblies.json");
+
+            if !File.exists(assemblies_json_path) then
+                throw Exception(".assemblies.json not found at {assemblies_json_path} — is the GenerateAssembliesJson target wired into Build?");
+            fi
+
+            let content = File.read_all_text(assemblies_json_path);
+
+            // Plain-line parse: split on '"', take every odd-indexed element after
+            // the "assemblies" key. We don't need a real JSON parser — the file is
+            // produced by MSBuild with a fixed shape.
+            let result = LIST[string]();
+            let in_string = false;
+            let current = StringBuilder();
+            let escape_next = false;
+
+            for c in content do
+                if escape_next then
+                    if c == 'n' then
+                        current.append('\n');
+                    elif c == 't' then
+                        current.append('\t');
+                    elif c == '"' then
+                        current.append('"');
+                    elif c == '\\' then
+                        current.append('\\');
+                    else
+                        current.append(c);
+                    fi
+                    escape_next = false;
+                elif c == '\\' /\ in_string then
+                    escape_next = true;
+                elif c == '"' then
+                    if in_string then
+                        let captured = current.to_string();
+
+                        // Skip the literal "assemblies" key and empty strings.
+                        if captured !~ "assemblies" /\ captured.length > 0 then
+                            result.add("-a");
+                            result.add(captured);
+                        fi
+
+                        current.clear();
+                    fi
+
+                    in_string = !in_string;
+                elif in_string then
+                    current.append(c);
+                fi
+            od
+
+            result.add("-A");
+
+            return result;
+        si
+
+        // Compose a response file (`.analyser.rsp`) in the project directory and
+        // spawn `dotnet ghul-compiler @<rsp>`. Mirrors what the VS Code server
+        // does in server-manager.ts.
+        write_response_file(project_directory: string, arguments: Iterable[string]) -> string static is
+            let path = Path.combine(project_directory, ".analyser.rsp");
+
+            let line = arguments
+                | .map(a -> string => "\"{a}\"")
+                .to_string(" ");
+
+            File.write_all_text(path, line);
+
+            return path;
+        si
+
+        init() is
+            let project_directory = find_project_directory();
+            let arguments = build_analyser_arguments(project_directory);
+            let response_file = write_response_file(project_directory, arguments);
+
+            let start_info = ProcessStartInfo();
+
+            start_info.file_name = "dotnet";
+            start_info.arguments = "ghul-compiler @{response_file}";
+            start_info.working_directory = project_directory;
+
+            start_info.use_shell_execute = false;
+            start_info.redirect_standard_input = true;
+            start_info.redirect_standard_output = true;
+            start_info.redirect_standard_error = true;
+
+            // The compiler's stdin/stdout are byte-oriented framing (form-feed
+            // delimiter mid-stream). UTF-8 keeps the multi-byte semantics stable.
+            start_info.standard_input_encoding = UTF8Encoding();
+            start_info.standard_output_encoding = UTF8Encoding();
+            start_info.standard_error_encoding = UTF8Encoding();
+
+            _process = Process.start(start_info);
+
+            if !_process? then
+                throw Exception("failed to start ghul-compiler analyser process");
+            fi
+
+            _stderr_capture = StringBuilder();
+
+            // Drain stderr in the background so a chatty analyser doesn't fill
+            // its stderr pipe and block. Stash text for inclusion in failure
+            // messages.
+            System.Threading.Tasks.Task.run(
+                () is
+                    try
+                        do
+                            let line = _process.standard_error.read_line();
+
+                            if !line? then
+                                break;
+                            fi
+
+                            _stderr_capture.append(line);
+                            _stderr_capture.append('\n');
+                        od
+                    catch ex: Exception
+                    yrt
+                si
+            );
+
+            // Block until the analyser writes its initial LISTEN frame, then
+            // we know it's ready. If anything fails between Process.start and
+            // here, dispose the subprocess so it doesn't leak.
+            try
+                let listen = read_response();
+
+                if listen.header !~ "LISTEN" then
+                    throw Exception("expected LISTEN as first response, got '{listen.header}'.\nstderr so far:\n{_stderr_capture}");
+                fi
+            catch ex: Exception
+                dispose();
+                throw ex;
+            yrt
+        si
+
+        // Read characters from stdout until we hit the form-feed terminator,
+        // then split into header (first line) + body lines (remaining lines,
+        // excluding the empty trailing line that comes from "\n\f").
+        read_response() -> RESPONSE is
+            let buffer = StringBuilder();
+
+            do
+                let c = _process.standard_output.read();
+
+                if c < 0 then
+                    throw Exception(
+                        "analyser stdout closed before form-feed.\n" +
+                        "buffer so far:\n{buffer}\n" +
+                        "stderr so far:\n{_stderr_capture}"
+                    );
+                fi
+
+                if c == 12 then
+                    break;
+                fi
+
+                if c != 13 then
+                    buffer.append(cast char(c));
+                fi
+            od
+
+            let raw = buffer.to_string();
+            let lines = LIST[string](raw.split(['\n']));
+
+            if lines.count == 0 then
+                throw Exception("empty response frame");
+            fi
+
+            let header = lines[0];
+
+            // Drop header and trailing empty entry (from the "\n\f" tail).
+            let body = LIST[string]();
+
+            for i in 1..lines.count do
+                let line = lines[i];
+
+                if i == lines.count - 1 /\ line.length == 0 then
+                    continue;
+                fi
+
+                body.add(line);
+            od
+
+            return RESPONSE(header, body);
+        si
+
+        write(text: string) is
+            _process.standard_input.write(text);
+        si
+
+        flush() is
+            _process.standard_input.flush();
+        si
+
+        // Send `#EDIT#` for a single file. The analyser also accepts EDIT for
+        // multiple files (see requester.ts:sendDocuments) — we'll add that when
+        // we have a multi-file test that needs it.
+        send_edit(path: string, source: string) is
+            write("#EDIT#\n");
+            write("{path}\n");
+            write("\n");           // empty line ends path list
+            write(source);
+            write("{FORM_FEED}");  // form-feed terminates source content
+            flush();
+        si
+
+        send_compile() is
+            write("#COMPILE#\n");
+            flush();
+        si
+
+        send_hover(path: string, line: int, column: int) is
+            write("#HOVER#\n");
+            write("{path}\n");
+            write("{line}\n");
+            write("{column}\n");
+            flush();
+        si
+
+        send_definition(path: string, line: int, column: int) is
+            write("#DEFINITION#\n");
+            write("{path}\n");
+            write("{line}\n");
+            write("{column}\n");
+            flush();
+        si
+
+        // Drain stdout for any lingering frames, then close stdin and wait for
+        // exit. Kill the subprocess if it overruns the wait timeout — a runaway
+        // analyser shouldn't leak across tests.
+        dispose() is
+            try
+                _process.standard_input.close();
+            catch ex: Exception
+            yrt
+
+            if !_process.wait_for_exit(2000) then
+                try
+                    _process.kill();
+                catch ex: Exception
+                yrt
+            fi
+        si
+
+        stderr_capture: string => _stderr_capture.to_string();
+    si
+si

--- a/analysis-tests/src/protocol/response.ghul
+++ b/analysis-tests/src/protocol/response.ghul
@@ -1,0 +1,94 @@
+namespace Analysis.Protocol is
+    use Collections.Iterable;
+    use Collections.MutableList;
+    use Collections.LIST;
+
+    // A DIAGNOSTIC line on the wire is 7 tab-separated fields:
+    //   path \t start_line \t start_col \t end_line \t end_col \t severity \t message
+    // Line and column numbers are 1-based.
+    // Severity 1 = error, others (warn etc) currently observed only as 1 in test fixtures.
+    class DIAGNOSTIC is
+        path: string public;
+        start_line: int public;
+        start_col: int public;
+        end_line: int public;
+        end_col: int public;
+        severity: int public;
+        message: string public;
+
+        // True for diagnostics whose path is "internal" or "reflected" — the analyser
+        // emits these for stdlib symbols and they should be filtered out of test
+        // assertions about user-visible diagnostics. Mirrors response-handler.ts.
+        is_internal: bool => path =~ "internal" \/ path =~ "reflected";
+
+        init(
+            path: string,
+            start_line: int, start_col: int,
+            end_line: int, end_col: int,
+            severity: int,
+            message: string
+        ) is
+            self.path = path;
+            self.start_line = start_line;
+            self.start_col = start_col;
+            self.end_line = end_line;
+            self.end_col = end_col;
+            self.severity = severity;
+            self.message = message;
+        si
+
+        to_string() -> string =>
+            "{path}:{start_line}:{start_col}-{end_line}:{end_col} severity {severity}: {message}";
+    si
+
+    // A RESPONSE is one form-feed-terminated frame from the analyser: a header line
+    // (the response kind) followed by zero or more body lines.
+    class RESPONSE is
+        header: string public;
+        lines: Iterable[string] public;
+
+        init(header: string, lines: Iterable[string]) is
+            self.header = header;
+            self.lines = lines;
+        si
+
+        // Parse body lines as DIAGNOSTIC records. Lines that don't have the
+        // expected 7 tab-separated fields are skipped silently — that mirrors
+        // response-handler.ts's tolerant parser.
+        parse_diagnostics() -> Iterable[DIAGNOSTIC] is
+            let result = LIST[DIAGNOSTIC]();
+
+            for line in lines do
+                let fields = line.split(['\t']);
+
+                if fields.count != 7 then
+                    continue;
+                fi
+
+                try
+                    result.add(
+                        DIAGNOSTIC(
+                            fields[0],
+                            System.Convert.to_int32(fields[1]),
+                            System.Convert.to_int32(fields[2]),
+                            System.Convert.to_int32(fields[3]),
+                            System.Convert.to_int32(fields[4]),
+                            System.Convert.to_int32(fields[5]),
+                            fields[6]
+                        )
+                    );
+                catch ex: System.FormatException
+                yrt
+            od
+
+            return result;
+        si
+
+        // Diagnostics not in "internal" / "reflected" — i.e. those a user would
+        // see in the editor. The analyser emits stdlib-internal diagnostics during
+        // a full COMPILE; tests typically only care about diagnostics in their
+        // own fixture files.
+        user_diagnostics: Iterable[DIAGNOSTIC] =>
+            parse_diagnostics() | .filter(d => !d.is_internal);
+    si
+si

--- a/analysis-tests/src/tests/compile_after_edit_tests.ghul
+++ b/analysis-tests/src/tests/compile_after_edit_tests.ghul
@@ -1,0 +1,104 @@
+namespace Analysis.Tests is
+    use Collections.LIST;
+
+    use IO.File;
+    use IO.Path;
+
+    use Analysis.Protocol.ANALYSER_PROCESS;
+    use Analysis.Protocol.DIAGNOSTIC;
+    use Analysis.Protocol.RESPONSE;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    fixture_path(name: string) -> string =>
+        Path.combine(
+            Path.get_directory_name(System.Reflection.Assembly.get_executing_assembly().location),
+            "fixtures",
+            name
+        );
+
+    diagnostics_summary(label: string, diagnostics: Collections.Iterable[DIAGNOSTIC]) -> string is
+        let result = System.Text.StringBuilder();
+
+        result.append("{label} ({diagnostics| .count()} diagnostics):\n");
+
+        for d in diagnostics do
+            result.append("  {d}\n");
+        od
+
+        return result.to_string();
+    si
+
+    class COMPILE_AFTER_EDIT_TESTS is
+        @test()
+
+        init() is si
+
+        // Smoking-gun reproducer for the analysis-mode false-positive on the
+        // object-oriented example: a clean EDIT response is followed by a
+        // COMPILE response containing two false errors about `Operation[T]`
+        // generic argument identity. The build-mode compiler reports zero
+        // errors on the same source. The bug manifests after `clear_symbols()`
+        // rebinds class type parameters but AST nodes still reference the
+        // pre-clear instances.
+        //
+        // This test is expected to FAIL today and PASS once the
+        // identity-loss-on-clear bug is fixed.
+        object_oriented_example_should_compile_clean_after_edit_then_compile() is
+            @test()
+
+            let source_path = fixture_path("object-oriented.ghul");
+            assert File.exists(source_path)
+                else "fixture not copied to test output: {source_path}";
+
+            let source = File.read_all_text(source_path);
+
+            let use analyser = ANALYSER_PROCESS();
+
+            analyser.send_edit("object-oriented.ghul", source);
+
+            let edit_diagnostics = analyser.read_response();
+
+            Assert.are_equal(
+                "DIAGNOSTICS",
+                edit_diagnostics.header,
+                "expected DIAGNOSTICS as first frame after EDIT, got '{edit_diagnostics.header}'"
+            );
+
+            let edit_user_diagnostics = LIST[DIAGNOSTIC](edit_diagnostics.user_diagnostics);
+
+            Assert.are_equal(
+                0,
+                edit_user_diagnostics.count,
+                diagnostics_summary("EDIT response had unexpected user diagnostics", edit_user_diagnostics)
+            );
+
+            let edit_partial_done = analyser.read_response();
+            Assert.are_equal("PARTIAL DONE", edit_partial_done.header);
+
+            analyser.send_compile();
+
+            let compile_diagnostics = analyser.read_response();
+
+            Assert.are_equal(
+                "DIAGNOSTICS",
+                compile_diagnostics.header,
+                "expected DIAGNOSTICS as first frame after COMPILE, got '{compile_diagnostics.header}'"
+            );
+
+            let compile_user_diagnostics = LIST[DIAGNOSTIC](compile_diagnostics.user_diagnostics);
+
+            // SMOKING GUN: today this assertion fails with two false-positive
+            // errors about `Collections.MAP` and `Operation[T]` identity. Build
+            // mode produces zero diagnostics on the same source.
+            Assert.are_equal(
+                0,
+                compile_user_diagnostics.count,
+                diagnostics_summary("COMPILE response had unexpected user diagnostics", compile_user_diagnostics)
+            );
+
+            let compile_full_done = analyser.read_response();
+            Assert.are_equal("FULL DONE", compile_full_done.header);
+        si
+    si
+si


### PR DESCRIPTION
Technical:
- New MSTest project at `analysis-tests/` mirroring `unit-tests/` shape; drives `dotnet ghul-compiler --analyse` as a per-test out-of-process subprocess, asserting on parsed protocol responses.
- `ANALYSER_PROCESS` implements `Disposable` (`let use` friendly); reads `.assemblies.json` (auto-generated via an `EnsureAssembliesJson` MSBuild target) to construct the `-a foo.dll … -A` argument list at fixture-init time.
- First test reproduces the COMPILE-after-EDIT false-positive on the object-oriented example: clean EDIT response, two false errors on COMPILE about `Operation[T]` generic-argument identity. Documented in `docs/claude/analysis-mode.md`.
- The test fails today by design — it's the regression marker for the underlying `clear_symbols` / AST-binding identity bug, which is not yet fixed. **CI integration deliberately omitted from this PR**; the bug-fix PR will both fix the bug and add `analysis-tests` to `.github/workflows/ci.yml`, so CI gating activates as the test goes green.
- Pin bump 0.8.78 → 0.8.79.