### PR TITLE
Clear AST state between full analyser builds

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.8.80",
+      "version": "0.8.81",
       "commands": [
         "ghul-compiler"
       ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,32 @@ jobs:
     - name: Run unit tests
       run: dotnet test unit-tests
 
+  analysis_tests:
+    name: Run analysis tests
+    needs: [version]
+    runs-on: ubuntu-latest
+
+    container:
+      image: mcr.microsoft.com/dotnet/sdk:8.0-jammy
+
+    timeout-minutes: 5
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Add GHCR package source
+      run: dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/degory/index.json"
+
+    - name: Restore local .NET tools
+      run: dotnet tool restore
+
+    - name: Set build number
+      run: |
+        echo "namespace Source is class BUILD is number: string static => \"${{ needs.version.outputs.tag }}\"; si si" >src/source/build.ghul
+
+    - name: Run analysis tests
+      run: dotnet test analysis-tests
+
   bootstrap:
     name: Bootstrap compiler
     needs: [version]
@@ -139,6 +165,39 @@ jobs:
         name: test-results
         path: test-results.txt
 
+  analysis_tests_release:
+    needs: [version, bootstrap]
+    name: Run analysis tests against release-candidate compiler
+
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/dotnet/sdk:8.0-jammy
+
+    timeout-minutes: 5
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Download ghul.compiler package
+      uses: actions/download-artifact@v4
+      with:
+        name: ghul-compiler-package
+        path: nupkg
+
+    - name: Add GHCR package source
+      run: dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/degory/index.json"
+
+    - name: Install ghul.compiler
+      run: dotnet tool update --local ghul.compiler --version ${{ needs.version.outputs.package }} --add-source nupkg
+
+    - name: Restore local .NET tools
+      run: dotnet tool restore
+
+    - name: Run analysis tests against installed compiler
+      env:
+        ANALYSIS_TESTS_USE_INSTALLED_TOOL: "1"
+      run: dotnet test analysis-tests -p:SkipCompilerProjectRef=true
+
   project_tests:
     needs: [version, bootstrap]
     name: Run project tests
@@ -173,7 +232,7 @@ jobs:
         path: project-test-results.txt
 
   publish_beta_package:
-    needs: [version, unit_tests, integration_tests, project_tests]
+    needs: [version, unit_tests, analysis_tests, integration_tests, project_tests, analysis_tests_release]
     name: Publish beta package
 
     timeout-minutes: 5
@@ -315,7 +374,7 @@ jobs:
       run: docker push degory/ghul-devcontainer:dotnet
 
   publish_release_package:
-    needs: [version, unit_tests, project_tests, container_tests]
+    needs: [version, unit_tests, analysis_tests, project_tests, analysis_tests_release, container_tests]
     name: Publish release package
 
     timeout-minutes: 5

--- a/analysis-tests/analysis-tests.ghulproj
+++ b/analysis-tests/analysis-tests.ghulproj
@@ -11,8 +11,11 @@
     <!-- ProjectReference forces the compiler to be rebuilt from this PR's
          source and ghul.dll copied into our bin/. The analyser tests spawn
          that freshly-built compiler. We don't consume any compiler types
-         in our own source code; the reference is purely for the artefact. -->
-    <ProjectReference Include="../ghul.ghulproj" />
+         in our own source code; the reference is purely for the artefact.
+         Set SkipCompilerProjectRef=true to skip the rebuild — release
+         validation in CI does this since it spawns the installed bootstrap
+         artifact via ANALYSIS_TESTS_USE_INSTALLED_TOOL instead. -->
+    <ProjectReference Include="../ghul.ghulproj" Condition="'$(SkipCompilerProjectRef)' != 'true'" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MSTest.TestAdapter" />

--- a/src/analysis/command_handlers.ghul
+++ b/src/analysis/command_handlers.ghul
@@ -420,7 +420,7 @@ namespace Analysis is
                     writer.write_line("DIAGNOSTICS");
 
                     Semantic.Types.NAMED.clear_cache();
-    
+
                     for i in _source_files do
                         IoC.CONTAINER.instance.logger.clear(i.file_name, true);
 
@@ -428,8 +428,19 @@ namespace Analysis is
                         i.build_flags.want_compile_expressions = true;
                     od
 
+                    // Clear per-build state cached on the (retained) AST nodes
+                    // by previous compile-expressions invocations. Without this
+                    // the rebuild reads stale Expression.value / .constraint /
+                    // TypeExpression.type referencing symbols that clear_symbols
+                    // is about to wipe and recreate. See
+                    // project_analysis_mode_workflow memory for the model.
+                    let clear_state = Syntax.Process.CLEAR_STATE_VISITOR();
+                    for i in _source_files do
+                        clear_state.apply(i.definition);
+                    od
+
                     IoC.CONTAINER.instance.logger.start_analysis();
-                    
+
                     _compiler.clear_symbols();
 
                     _compiler.queue(_source_files);

--- a/src/syntax/process/clear_ast_state.ghul
+++ b/src/syntax/process/clear_ast_state.ghul
@@ -1,0 +1,159 @@
+namespace Syntax.Process is
+    use Trees;
+
+    // Walk an AST resetting per-build mutable state on each node.
+    //
+    // Each visit override calls `node.clear()` (non-recursive — Node.clear
+    // resets only its own state). Traversal is handled by the existing walk
+    // methods on each tree class, which already know how to recurse.
+    //
+    // Run between compile-expressions invocations on the same AST (analyser
+    // COMPILE-after-EDIT, multi-file rebuilds). See project_analysis_mode_workflow
+    // memory for why this is needed: ad-hoc resets in individual visit
+    // methods cover most state, but the constraint mechanism's narrowing-only
+    // upgrade can leave stale entries across `apply` calls. This visitor
+    // makes clearing structural rather than ad-hoc.
+    // Inherits from StrictVisitor (rather than Visitor) so that any AST
+    // node type added to the codebase later will throw NotImplementedException
+    // here until someone adds an override — forces us to consider whether
+    // the new node has clearable state. The default override per node type
+    // calls node.clear() which is itself a no-op unless the subclass adds
+    // state to clear, so the cost of adding a new node type is one trivial
+    // override here.
+    class CLEAR_STATE_VISITOR: StrictVisitor is
+        init() is
+            super.init();
+        si
+
+        apply(root: Trees.Node) is
+            root.walk(self);
+        si
+
+        // StrictVisitor.pre(STATEMENT) throws. Override here to allow normal
+        // recursion into the wrapped statement.
+        pre(statement: Trees.Expressions.STATEMENT) -> bool is
+            return false;
+        si
+
+        // Identifiers
+        visit(identifier: Identifiers.Identifier) is identifier.clear(); si
+        visit(identifier: Identifiers.QUALIFIED) is identifier.clear(); si
+
+        // Modifiers / pragmas
+        visit(modifier: Modifiers.Modifier) is modifier.clear(); si
+        visit(modifiers: Modifiers.LIST) is modifiers.clear(); si
+        visit(pragma: Pragmas.PRAGMA) is pragma.clear(); si
+
+        // Definitions
+        visit(definition: Definitions.Definition) is definition.clear(); si
+        visit(definitions: Definitions.LIST) is definitions.clear(); si
+        visit(pragma: Definitions.PRAGMA) is pragma.clear(); si
+        visit(`namespace: Definitions.NAMESPACE) is `namespace.clear(); si
+        visit(`use: Definitions.USE) is `use.clear(); si
+        visit(`class: Definitions.CLASS) is `class.clear(); si
+        visit(`trait: Definitions.TRAIT) is `trait.clear(); si
+        visit(`struct: Definitions.STRUCT) is `struct.clear(); si
+        visit(`union: Definitions.UNION) is `union.clear(); si
+        visit(variant: Definitions.VARIANT) is variant.clear(); si
+        visit(`enum: Definitions.ENUM) is `enum.clear(); si
+        visit(enum_member: Definitions.ENUM_MEMBER) is enum_member.clear(); si
+        visit(function: Definitions.FUNCTION) is function.clear(); si
+        visit(functions: Definitions.FUNCTION_GROUP) is functions.clear(); si
+        visit(property: Definitions.PROPERTY) is property.clear(); si
+        visit(indexer: Definitions.INDEXER) is indexer.clear(); si
+
+        // Variables (definition-side)
+        visit(variable: Variables.VARIABLE) is variable.clear(); si
+        visit(variables: Variables.LIST) is variables.clear(); si
+        visit(left: Trees.Variables.SIMPLE_VARIABLE_LEFT) is left.clear(); si
+        visit(destructure_left: Trees.Variables.DESTRUCTURING_VARIABLE_LEFT) is destructure_left.clear(); si
+
+        // Type expressions
+        visit(type_expression: TypeExpressions.TypeExpression) is type_expression.clear(); si
+        visit(type_expression: TypeExpressions.INFER) is type_expression.clear(); si
+        visit(structured: TypeExpressions.Structured) is structured.clear(); si
+        visit(array: TypeExpressions.ARRAY_) is array.clear(); si
+        visit(pointer: TypeExpressions.POINTER) is pointer.clear(); si
+        visit(reference: TypeExpressions.REFERENCE) is reference.clear(); si
+        visit(member: TypeExpressions.MEMBER) is member.clear(); si
+        visit(named: TypeExpressions.NAMED) is named.clear(); si
+        visit(types: TypeExpressions.LIST) is types.clear(); si
+        visit(generic: TypeExpressions.GENERIC) is generic.clear(); si
+        visit(function: TypeExpressions.FUNCTION) is function.clear(); si
+        visit(functions: TypeExpressions.FUNCTION_GROUP) is functions.clear(); si
+        visit(tuple: TypeExpressions.TUPLE) is tuple.clear(); si
+        visit(element: TypeExpressions.NAMED_TUPLE_ELEMENT) is element.clear(); si
+        visit(element: TypeExpressions.UNDEFINED) is element.clear(); si
+
+        // Expressions
+        visit(expression: Expressions.Expression) is expression.clear(); si
+        visit(identifier: Expressions.IDENTIFIER) is identifier.clear(); si
+        visit(literal: Expressions.Literals.Literal) is literal.clear(); si
+        visit(`string: Expressions.Literals.STRING) is `string.clear(); si
+        visit(interpolation: Expressions.STRING_INTERPOLATION) is interpolation.clear(); si
+        visit(integer: Expressions.Literals.INTEGER) is integer.clear(); si
+        visit(float: Expressions.Literals.FLOAT) is float.clear(); si
+        visit(character: Expressions.Literals.CHARACTER) is character.clear(); si
+        visit(boolean: Expressions.Literals.BOOLEAN) is boolean.clear(); si
+        visit(variable: Expressions.VARIABLE) is variable.clear(); si
+        visit(variable: Expressions.TUPLE_ELEMENT) is variable.clear(); si
+        visit(none: Expressions.Literals.NONE) is none.clear(); si
+        visit(`null: Expressions.NULL) is `null.clear(); si
+        visit(`self: Expressions.SELF) is `self.clear(); si
+        visit(`super: Expressions.SUPER) is `super.clear(); si
+        visit(`new: Expressions.NEW) is `new.clear(); si
+        visit(`cast: Expressions.CAST) is `cast.clear(); si
+        visit(`isa: Expressions.ISA) is `isa.clear(); si
+        visit(`isa: Expressions.TYPEOF) is `isa.clear(); si
+        visit(function: Expressions.FUNCTION) is function.clear(); si
+        visit(recurse: Expressions.RECURSE) is recurse.clear(); si
+        visit(tuple: Expressions.TUPLE) is tuple.clear(); si
+        visit(sequence: Expressions.SEQUENCE) is sequence.clear(); si
+        visit(list: Expressions.LIST) is list.clear(); si
+        visit(call: Expressions.CALL) is call.clear(); si
+        visit(member: Expressions.MEMBER) is member.clear(); si
+        visit(member: Expressions.EXPLICIT_SPECIALIZATION) is member.clear(); si
+        visit(ambiguous_expression: Expressions.AMBIGUOUS_EXPRESSION) is ambiguous_expression.clear(); si
+        visit(ambiguous_expression: Expressions.GENERIC_APPLICATION) is ambiguous_expression.clear(); si
+        visit(index: Expressions.INDEX) is index.clear(); si
+        visit(has_value: Expressions.HAS_VALUE) is has_value.clear(); si
+        visit(unwrap: Expressions.UNWRAP) is unwrap.clear(); si
+        visit(reference: Expressions.REFERENCE) is reference.clear(); si
+        visit(unary: Expressions.UNARY) is unary.clear(); si
+        visit(binary: Expressions.BINARY) is binary.clear(); si
+        visit(statement: Expressions.STATEMENT) is statement.clear(); si
+        visit(statement: Expressions.LET_IN) is statement.clear(); si
+
+        // Left-side expressions
+        visit(left: Trees.Expressions.SIMPLE_LEFT_EXPRESSION) is left.clear(); si
+        visit(destructure_left: Trees.Expressions.DESTRUCTURING_LEFT_EXPRESSION) is destructure_left.clear(); si
+
+        // Statements
+        visit(statement: Statements.Statement) is statement.clear(); si
+        visit(statements: Statements.LIST) is statements.clear(); si
+        visit(l: Statements.LET) is l.clear(); si
+        visit(assign: Statements.ASSIGNMENT) is assign.clear(); si
+        visit(expression: Statements.EXPRESSION) is expression.clear(); si
+        visit(`return: Statements.RETURN) is `return.clear(); si
+        visit(`throw: Statements.THROW) is `throw.clear(); si
+        visit(assert__: Statements.ASSERT) is assert__.clear(); si
+        visit(`if: Statements.IF) is `if.clear(); si
+        visit(if_branch: Statements.IF_BRANCH) is if_branch.clear(); si
+        visit(`case: Statements.CASE) is `case.clear(); si
+        visit(case_match: Statements.CASE_MATCH) is case_match.clear(); si
+        visit(`try: Statements.TRY) is `try.clear(); si
+        visit(`catch: Statements.CATCH) is `catch.clear(); si
+        visit(`do: Statements.DO) is `do.clear(); si
+        visit(`for: Statements.FOR) is `for.clear(); si
+        visit(labelled: Statements.LABELLED) is labelled.clear(); si
+        visit(`break: Statements.BREAK) is `break.clear(); si
+        visit(`continue: Statements.CONTINUE) is `continue.clear(); si
+        visit(pragma: Statements.PRAGMA) is pragma.clear(); si
+
+        // Bodies
+        visit(expression: Bodies.EXPRESSION) is expression.clear(); si
+        visit(block: Bodies.BLOCK) is block.clear(); si
+        visit(block: Bodies.NULL) is block.clear(); si
+        visit(block: Bodies.INNATE) is block.clear(); si
+    si
+si

--- a/src/syntax/trees/expressions/expression.ghul
+++ b/src/syntax/trees/expressions/expression.ghul
@@ -49,6 +49,15 @@ namespace Syntax.Trees.Expressions is
         set_constraint(constraint: Semantic.Types.Type, error_message: string) is si
         clear_constraint() is si
 
+        // Non-recursive clear of per-build state on this expression. Resets
+        // `value` (set by compile-expressions) and any constraint storage
+        // (set by parent context propagation in compile-expressions). See
+        // Node.clear() and CLEAR_STATE_VISITOR for the orchestration.
+        clear() is
+            value = null;
+            clear_constraint();
+        si
+
         // Default upgrade: install the new constraint when there is no
         // existing one, or when the new one is the same / strictly
         // narrower than the existing (i.e. existing is_assignable_from

--- a/src/syntax/trees/expressions/statement.ghul
+++ b/src/syntax/trees/expressions/statement.ghul
@@ -25,6 +25,11 @@ namespace Syntax.Trees.Expressions is
             statement.clear_constraint();
         si
 
+        clear() is
+            super.clear();
+            temp = null;
+        si
+
         accept(visitor: Visitor) is
             visitor.visit(self);
         si

--- a/src/syntax/trees/node.ghul
+++ b/src/syntax/trees/node.ghul
@@ -19,14 +19,30 @@ namespace Syntax.Trees is
             self.location = location;
         si
 
-        clone() -> Node => cast Node(memberwise_clone());   
-        
+        clone() -> Node => cast Node(memberwise_clone());
+
         accept(visitor: Visitor) is
             visitor.visit(self);
         si
 
         walk(visitor: Visitor) is
             accept(visitor);
+        si
+
+        // Reset per-build state cached on this node by previous compilation
+        // passes. Non-recursive — clears only this node's own state, never
+        // children. CLEAR_STATE_VISITOR is responsible for traversal and
+        // calling clear() on each node it visits.
+        //
+        // Default is a no-op: most node types have no per-build mutable
+        // state. Subclasses with state (Expression, TypeExpression, ...)
+        // override.
+        //
+        // Run between compile-expressions invocations on the same AST
+        // (analyser COMPILE-after-EDIT, multi-file rebuilds where retained
+        // ASTs already have prior compile-expressions output) — see
+        // project_analysis_mode_workflow.
+        clear() is
         si
 
         poison(should_poison: bool) is

--- a/src/syntax/trees/type_expressions/type_expression.ghul
+++ b/src/syntax/trees/type_expressions/type_expression.ghul
@@ -45,6 +45,13 @@ namespace Syntax.Trees.TypeExpressions is
         
         set_type(value: Type) is type = value; si
 
+        // Non-recursive clear of per-build state on this type expression.
+        // Resets `type` (set by resolve-type-expressions). See Node.clear()
+        // and CLEAR_STATE_VISITOR for the orchestration.
+        clear() is
+            type = null;
+        si
+
         init(location: LOCATION) is
             super.init(location);
         si


### PR DESCRIPTION
Fixes the COMPILE-after-EDIT false-positive on the object-oriented example (and the broader class of "spurious errors that disappear on subsequent EDIT" the maintainer has long observed).

## Bug

In analysis mode, `COMPILE` reuses the AST nodes that `EDIT` already ran compile-expressions on. The new build runs `clear_symbols()` to wipe global structures, but doesn't clear per-build state cached on the AST nodes themselves: `Expression.value`, `Expression.constraint` (from iterative-inference back-feed, where `upgrade_constraint` is narrowing-only), `TypeExpression.type`, etc. Those fields still reference symbol instances that `clear_symbols` is about to recreate. The reused stale references manifest as identity-mismatch errors during overload resolution.

The "disappears on next EDIT" pattern fits because EDIT re-parses the active file, throwing away the AST and any per-build state on it. COMPILE doesn't re-parse — that's the optimisation that makes EDIT cheap, but it's also where the leak lives.

## Fix

- New polymorphic non-recursive `clear()` on `Trees.Node`. Default no-op. Subclasses with per-build mutable state override: `Expression` clears `value` and calls `clear_constraint()`; `TypeExpression` clears `type`; `Expressions.STATEMENT` additionally clears its `IR.TEMP`.
- New `CLEAR_STATE_VISITOR` (in `src/syntax/process/clear_ast_state.ghul`) inheriting `StrictVisitor`. Each per-node-type visit override calls `node.clear()`. The `StrictVisitor` base means any AST node type added later will throw `NotImplementedException` here until someone adds the corresponding override — forces consideration of clearable state by default.
- `COMPILE_HANDLER` walks every source file's AST through the visitor before `_compiler.build()`. `FILE_EDITED_HANDLER` doesn't need this: edited files are fresh by re-parse; non-edited files don't run compile-expressions during EDIT so don't accumulate the relevant state.

## Tests

- The smoking-gun test added in #1217 now passes (was failing by design as the regression marker).
- 618/618 integration tests pass.
- Bootstrap produces byte-identical IL pass 3 vs pass 4 (~63s).

## CI

- `analysis_tests` job (PR validation): mirrors `unit_tests`, `needs: [version]`, parallel with `bootstrap`. The `<ProjectReference>` in `analysis-tests.ghulproj` rebuilds the compiler from PR source for these tests.
- `analysis_tests_release` job (release validation): mirrors `integration_tests` shape, `needs: [version, bootstrap]`. Downloads the bootstrapped nupkg, installs it as the local tool, runs `analysis-tests` with `ANALYSIS_TESTS_USE_INSTALLED_TOOL=1` so the compiler-under-test is the actual release-candidate artefact. `-p:SkipCompilerProjectRef=true` skips the (redundant in this job) compiler rebuild via a new conditional ProjectReference in `analysis-tests.ghulproj`.
- Both jobs added to `publish_beta_package` and `publish_release_package` `needs` so neither beta nor release ships without analysis-tests passing.

Pin bump 0.8.80 → 0.8.81.