### PR TITLE
Fix bootstrap compiler artefact and add ghul-examples to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,20 +97,24 @@ jobs:
         name: ghul-compiler-package
         path: ./nupkg/ghul.compiler.${{ needs.version.outputs.package }}.nupkg
 
-    # Separate artefact for consumers that only need the bootstrapped ghul.dll
-    # itself (e.g. analysis_tests spawning it as the compiler under test) —
-    # avoids each consumer unzipping the nupkg. Extracted here once because
+    # Separate artefact for consumers that need to spawn the bootstrapped
+    # compiler as a process (e.g. analysis_tests). The whole tool tree is
+    # required, not just ghul.dll: the .NET host needs ghul.runtimeconfig.json
+    # / ghul.deps.json beside the dll, and the compiler needs sibling
+    # assemblies (ghul-runtime, System.IO.Abstractions, ...), the bundled
+    # stdlib under lib/dotnet/ghul/, the IL templates under lib/dotnet/il/,
+    # and the native ilasm under runtimes/. Extracted here once because
     # bootstrap.sh's trailing `dotnet clean` wipes bin/.
-    - name: Extract bootstrapped ghul.dll
+    - name: Extract bootstrapped tool tree
       run: |
         apt-get update && apt-get install -y unzip
-        unzip -j -o nupkg/ghul.compiler.${{ needs.version.outputs.package }}.nupkg \
-          'tools/net8.0/any/ghul.dll' -d extracted-dll
+        unzip -o nupkg/ghul.compiler.${{ needs.version.outputs.package }}.nupkg \
+          'tools/net8.0/any/*' -d extracted-tool
 
     - uses: actions/upload-artifact@v4
       with:
-        name: ghul-compiler-dll
-        path: ./extracted-dll/ghul.dll
+        name: ghul-compiler-tool
+        path: ./extracted-tool/tools/net8.0/any
 
   integration_tests:
     needs: [version, bootstrap]
@@ -167,11 +171,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Download bootstrap compiler dll
+    - name: Download bootstrap compiler tool tree
       uses: actions/download-artifact@v4
       with:
-        name: ghul-compiler-dll
-        path: bootstrap-dll
+        name: ghul-compiler-tool
+        path: bootstrap-tool
 
     - name: Add GHCR package source
       run: dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/degory/index.json"
@@ -185,7 +189,7 @@ jobs:
 
     - name: Run analysis tests
       env:
-        ANALYSIS_TESTS_COMPILER_DLL: ${{ github.workspace }}/bootstrap-dll/ghul.dll
+        ANALYSIS_TESTS_COMPILER_DLL: ${{ github.workspace }}/bootstrap-tool/ghul.dll
       run: dotnet test analysis-tests -p:SkipCompilerProjectRef=true
 
   project_tests:
@@ -221,8 +225,59 @@ jobs:
         name: project-test-results
         path: project-test-results.txt
 
+  examples_tests:
+    needs: [version, bootstrap]
+    name: Run examples tests
+
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/dotnet/sdk:8.0-jammy
+
+    timeout-minutes: 10
+
+    if: ${{ github.event_name == 'pull_request' }}
+
+    # Build ghul-examples (latest main, no version pin) against the
+    # bootstrapped compiler. ghul-examples has its own CI gating its
+    # main, and the language is generally backwards-compatible, so the
+    # contract is symmetric: the new compiler must build current
+    # ghul-examples main, and current main ghul-examples must build
+    # under the previously-published compiler. This job enforces the
+    # first half.
+    steps:
+    - name: Checkout ghul-examples
+      uses: actions/checkout@v3
+      with:
+        repository: degory/ghul-examples
+        path: ghul-examples
+
+    - name: Download ghul.compiler package
+      uses: actions/download-artifact@v4
+      with:
+        name: ghul-compiler-package
+        path: nupkg
+
+    - name: Add GHCR package source
+      run: dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/degory/index.json"
+
+    - name: Install bootstrapped ghul.compiler in ghul-examples
+      working-directory: ghul-examples
+      run: dotnet tool update --local ghul.compiler --version ${{ needs.version.outputs.package }} --add-source ${{ github.workspace }}/nupkg
+
+    - name: Restore local .NET tools
+      working-directory: ghul-examples
+      run: dotnet tool restore
+
+    - name: Build examples
+      working-directory: ghul-examples
+      run: dotnet build
+
+    - name: Run examples integration tests
+      working-directory: ghul-examples
+      run: dotnet ghul-test --use-dotnet-build integration-tests
+
   publish_beta_package:
-    needs: [version, unit_tests, analysis_tests, integration_tests, project_tests]
+    needs: [version, unit_tests, analysis_tests, integration_tests, project_tests, examples_tests]
     name: Publish beta package
 
     timeout-minutes: 5
@@ -364,7 +419,7 @@ jobs:
       run: docker push degory/ghul-devcontainer:dotnet
 
   publish_release_package:
-    needs: [version, unit_tests, analysis_tests, project_tests, container_tests]
+    needs: [version, unit_tests, analysis_tests, project_tests, container_tests, examples_tests]
     name: Publish release package
 
     timeout-minutes: 5


### PR DESCRIPTION
Bugs fixed:
- analysis_tests on main was broken because the ghul-compiler-dll artefact contained only ghul.dll; spawning the dll requires sibling files (ghul.runtimeconfig.json, ghul.deps.json, runtime libraries, bundled stdlib under lib/, native ilasm under runtimes/).

Enhancements:
- New examples_tests job: clones ghul-examples main, installs the bootstrapped compiler over its pin, runs dotnet build + integration-tests. No version pin — relies on backwards-compat + ghul-examples' own CI gating its main.

Technical:
- Bootstrap now extracts whole tools/net8.0/any/ tree from the nupkg; artefact renamed ghul-compiler-tool. analysis_tests downloads dll+siblings as one tree.
- publish_beta_package and publish_release_package now depend on examples_tests.