### PR TITLE
Drop unnecessary GHCR source; fix examples nupkg path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,9 +177,6 @@ jobs:
         name: ghul-compiler-tool
         path: bootstrap-tool
 
-    - name: Add GHCR package source
-      run: dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/degory/index.json"
-
     # Use the public-latest ghul.compiler (from .config/dotnet-tools.json) to
     # *build* the test runner, but spawn the bootstrapped artefact's ghul.dll
     # as the *compiler under test* — decouples the compiler being validated
@@ -257,12 +254,9 @@ jobs:
         name: ghul-compiler-package
         path: nupkg
 
-    - name: Add GHCR package source
-      run: dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/degory/index.json"
-
     - name: Install bootstrapped ghul.compiler in ghul-examples
       working-directory: ghul-examples
-      run: dotnet tool update --local ghul.compiler --version ${{ needs.version.outputs.package }} --add-source ${{ github.workspace }}/nupkg
+      run: dotnet tool update --local ghul.compiler --version ${{ needs.version.outputs.package }} --add-source ../nupkg
 
     - name: Restore local .NET tools
       working-directory: ghul-examples


### PR DESCRIPTION
Follow-up to #1221.

Technical:
- analysis_tests and examples_tests don't need the GHCR feed; bootstrapped ghul.compiler comes from the local nupkg artefact, everything else (ghul.runtime, ghul.test) is on public NuGet.
- examples_tests --add-source path was using \`${{ github.workspace }}\` which expands to the host path on the runner; inside the container the artefact is reachable via relative \`../nupkg\` from \`working-directory: ghul-examples\`, matching how integration_tests references it.