### PR TITLE
Run examples_tests on main pushes too so it can gate publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,15 +232,15 @@ jobs:
 
     timeout-minutes: 10
 
-    if: ${{ github.event_name == 'pull_request' }}
-
     # Build ghul-examples (latest main, no version pin) against the
     # bootstrapped compiler. ghul-examples has its own CI gating its
     # main, and the language is generally backwards-compatible, so the
     # contract is symmetric: the new compiler must build current
     # ghul-examples main, and current main ghul-examples must build
     # under the previously-published compiler. This job enforces the
-    # first half.
+    # first half. Runs on both PR and main push: it gates
+    # publish_release_package, so a skipped run would silently block
+    # publish on the post-merge run.
     steps:
     - name: Checkout ghul-examples
       uses: actions/checkout@v3


### PR DESCRIPTION
Bugs fixed:
- publish_release_package was silently skipped on the last two main pushes because examples_tests is in its \`needs:\` and was \`if: pull_request\`-only; a skipped dep blocks the dependent. analysis_tests has the same shape (gates publish, no \`if:\`) — match it.