### PR TITLE
Clear AST state in FULL_COMPILER.compile_all

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.8.82",
+      "version": "0.8.87",
       "commands": [
         "ghul-compiler"
       ],

--- a/analysis-tests/src/tests/query_after_edit_state_tests.ghul
+++ b/analysis-tests/src/tests/query_after_edit_state_tests.ghul
@@ -1,0 +1,209 @@
+namespace Analysis.Tests is
+    use Collections.LIST;
+
+    use IO.File;
+
+    use Analysis.Protocol.ANALYSER_PROCESS;
+    use Analysis.Protocol.DIAGNOSTIC;
+    use Analysis.Protocol.RESPONSE;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    // Companion to COMPILE_AFTER_EDIT_TESTS: probes that semantic-query
+    // handlers which fall back to FULL_COMPILER.compile_all (HOVER,
+    // DEFINITION, DECLARATION, REFERENCES on a no-symbol position;
+    // COMPLETION, IMPLEMENTATION, RENAMEREQUEST unconditionally; SYMBOLS
+    // with an empty path) do not surface the same retained-AST state-leak
+    // false positives that #1219 fixed for the COMPILE handler.
+    //
+    // The bug shape: after an initial EDIT primes the AST, the query's
+    // compile_all clears symbols and re-runs compile-expressions on the
+    // same AST. Per-build state cached on the AST during the first
+    // compile-expressions still references the just-wiped symbols, so
+    // overload resolution (in particular lambda-arg back-feed for
+    // generic methods) misfires and produces "no overload found" errors.
+    class QUERY_AFTER_EDIT_STATE_TESTS is
+        @test()
+
+        init() is si
+
+        load_object_oriented_source() -> string is
+            let source_path = fixture_path("object-oriented/object-oriented.ghul");
+
+            assert File.exists(source_path)
+                else "fixture not copied to test output: {source_path}";
+
+            return File.read_all_text(source_path);
+        si
+
+        prime(analyser: ANALYSER_PROCESS, source: string) is
+            analyser.send_edit("object-oriented.ghul", source);
+
+            let edit_diagnostics = analyser.read_response();
+            Assert.are_equal("DIAGNOSTICS", edit_diagnostics.header);
+
+            let edit_user_diagnostics = LIST[DIAGNOSTIC](edit_diagnostics.user_diagnostics);
+            Assert.are_equal(
+                0,
+                edit_user_diagnostics.count,
+                diagnostics_summary("EDIT response had unexpected user diagnostics", edit_user_diagnostics)
+            );
+
+            let edit_partial_done = analyser.read_response();
+            Assert.are_equal("PARTIAL DONE", edit_partial_done.header);
+        si
+
+        // Common assertion: after the query, read the DIAGNOSTICS frame
+        // (produced by FULL_COMPILER.compile_all) and assert it has no
+        // user diagnostics. Then read the actual query response frame
+        // and check its header matches `expected_header`.
+        assert_query_diagnostics_clean(
+            analyser: ANALYSER_PROCESS,
+            expected_header: string
+        ) is
+            let diagnostics = analyser.read_response();
+            Assert.are_equal(
+                "DIAGNOSTICS",
+                diagnostics.header,
+                "expected DIAGNOSTICS frame from query's compile_all, got '{diagnostics.header}'"
+            );
+
+            let user_diagnostics = LIST[DIAGNOSTIC](diagnostics.user_diagnostics);
+            Assert.are_equal(
+                0,
+                user_diagnostics.count,
+                diagnostics_summary(
+                    "{expected_header} compile_all surfaced spurious diagnostics " +
+                    "(state leak on retained AST — see project_analysis_mode_workflow)",
+                    user_diagnostics
+                ) +
+                "\n--- analyser stderr ---\n" + analyser.stderr_capture
+            );
+
+            let response = analyser.read_response();
+            Assert.are_equal(
+                expected_header,
+                response.header,
+                "expected {expected_header} frame after DIAGNOSTICS, got '{response.header}'"
+            );
+        si
+
+        // HOVER on a position where no symbol is registered (column 1 of the
+        // first line, which is the `use` keyword) falls through to
+        // FULL_COMPILER.compile_all. The DIAGNOSTICS frame that compile_all
+        // emits should not surface false-positive overload errors.
+        hover_on_no_symbol_position_should_not_leak_diagnostics() is
+            @test()
+
+            let source = load_object_oriented_source();
+            let use analyser = ANALYSER_PROCESS();
+
+            prime(analyser, source);
+
+            // Column 1 of line 1 is on the `use` keyword — no symbol use.
+            analyser.send_hover("object-oriented.ghul", 1, 1);
+
+            assert_query_diagnostics_clean(analyser, "HOVER");
+        si
+
+        // DEFINITION on a no-symbol position falls through to compile_all.
+        definition_on_no_symbol_position_should_not_leak_diagnostics() is
+            @test()
+
+            let source = load_object_oriented_source();
+            let use analyser = ANALYSER_PROCESS();
+
+            prime(analyser, source);
+
+            analyser.send_definition("object-oriented.ghul", 1, 1);
+
+            assert_query_diagnostics_clean(analyser, "DEFINITION");
+        si
+
+        // DECLARATION on a no-symbol position falls through to compile_all.
+        declaration_on_no_symbol_position_should_not_leak_diagnostics() is
+            @test()
+
+            let source = load_object_oriented_source();
+            let use analyser = ANALYSER_PROCESS();
+
+            prime(analyser, source);
+
+            analyser.send_declaration("object-oriented.ghul", 1, 1);
+
+            assert_query_diagnostics_clean(analyser, "DECLARATION");
+        si
+
+        // REFERENCES on a no-symbol position falls through to compile_all.
+        references_on_no_symbol_position_should_not_leak_diagnostics() is
+            @test()
+
+            let source = load_object_oriented_source();
+            let use analyser = ANALYSER_PROCESS();
+
+            prime(analyser, source);
+
+            analyser.send_references("object-oriented.ghul", 1, 1);
+
+            assert_query_diagnostics_clean(analyser, "REFERENCES");
+        si
+
+        // COMPLETION unconditionally calls compile_all.
+        completion_should_not_leak_diagnostics() is
+            @test()
+
+            let source = load_object_oriented_source();
+            let use analyser = ANALYSER_PROCESS();
+
+            prime(analyser, source);
+
+            analyser.send_completion("object-oriented.ghul", 1, 1);
+
+            assert_query_diagnostics_clean(analyser, "COMPLETION");
+        si
+
+        // IMPLEMENTATION unconditionally calls compile_all.
+        implementation_should_not_leak_diagnostics() is
+            @test()
+
+            let source = load_object_oriented_source();
+            let use analyser = ANALYSER_PROCESS();
+
+            prime(analyser, source);
+
+            analyser.send_implementation("object-oriented.ghul", 1, 1);
+
+            assert_query_diagnostics_clean(analyser, "IMPLEMENTATION");
+        si
+
+        // RENAMEREQUEST unconditionally calls compile_all.
+        rename_request_should_not_leak_diagnostics() is
+            @test()
+
+            let source = load_object_oriented_source();
+            let use analyser = ANALYSER_PROCESS();
+
+            prime(analyser, source);
+
+            analyser.send_rename_request("object-oriented.ghul", 1, 1, "renamed");
+
+            assert_query_diagnostics_clean(analyser, "RENAMEREQUEST");
+        si
+
+        // SYMBOLS with an empty path triggers compile_all (workspace
+        // symbols flow). With a per-file path, compile_all is not invoked
+        // and the test would not exercise the bug.
+        workspace_symbols_should_not_leak_diagnostics() is
+            @test()
+
+            let source = load_object_oriented_source();
+            let use analyser = ANALYSER_PROCESS();
+
+            prime(analyser, source);
+
+            analyser.send_symbols("");
+
+            assert_query_diagnostics_clean(analyser, "SYMBOLS");
+        si
+    si
+si

--- a/src/analysis/command_handlers.ghul
+++ b/src/analysis/command_handlers.ghul
@@ -221,6 +221,20 @@ namespace Analysis is
                         i.build_flags.want_compile_expressions = true;
                     od
 
+                    // Clear per-build state cached on the (retained) AST nodes
+                    // by previous compile-expressions invocations — without
+                    // this the rebuild reads stale Expression.value /
+                    // .constraint / TypeExpression.type referencing symbols
+                    // that clear_symbols is about to wipe and recreate, which
+                    // surfaces as spurious "no overload found" / "X is not
+                    // assignable to Y" errors during overload resolution. Same
+                    // contract as COMPILE_HANDLER below; see #1219 and the
+                    // project_analysis_mode_workflow memory.
+                    let clear_state = Syntax.Process.CLEAR_STATE_VISITOR();
+                    for i in _source_files do
+                        clear_state.apply(i.definition);
+                    od
+
                     IoC.CONTAINER.instance.logger.start_analysis();
 
                     _compiler.clear_symbols();
@@ -229,9 +243,9 @@ namespace Analysis is
 
                     _compiler.build();
 
-                    IoC.CONTAINER.instance.logger.write_all_diagnostics(writer, IoC.CONTAINER.instance.logger_formatter);        
+                    IoC.CONTAINER.instance.logger.write_all_diagnostics(writer, IoC.CONTAINER.instance.logger_formatter);
                 fi
- 
+
                 _watchdog.enable();
 
             catch e: Exception


### PR DESCRIPTION
Bugs fixed:
- Semantic-query handlers (COMPLETION, IMPLEMENTATION, RENAMEREQUEST, workspace SYMBOLS, plus HOVER/DEFINITION/DECLARATION/REFERENCES on a no-symbol position) reported spurious "no overload found" / "X is not assignable to Y" errors on first-load against retained ASTs. They fall back to FULL_COMPILER.compile_all which lacked the CLEAR_STATE_VISITOR pass that #1219 added to COMPILE_HANDLER, so the rebuild read stale per-build state on retained AST nodes.

Enhancements:
- New QUERY_AFTER_EDIT_STATE_TESTS exercises the eight affected handlers.

Technical:
- Pin bump 0.8.82 -> 0.8.87.