### PR TITLE
Iterative inference for mutually-recursive lambdas

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.8.88",
+      "version": "0.8.89",
       "commands": [
         "ghul-compiler"
       ],

--- a/integration-tests/execution/anon-function-mutual-recursion/ghul.json
+++ b/integration-tests/execution/anon-function-mutual-recursion/ghul.json
@@ -1,0 +1,6 @@
+{
+    "compiler": "dotnet ../../../publish/ghul.dll",
+    "source": [
+        "."
+    ]
+}

--- a/integration-tests/execution/anon-function-mutual-recursion/run.expected
+++ b/integration-tests/execution/anon-function-mutual-recursion/run.expected
@@ -1,0 +1,2 @@
+is_even(10): True
+is_odd(10): False

--- a/integration-tests/execution/anon-function-mutual-recursion/test.ghul
+++ b/integration-tests/execution/anon-function-mutual-recursion/test.ghul
@@ -1,0 +1,9 @@
+use IO.Std.write_line;
+
+entry() is
+    let is_even = (n, is_odd) => if n == 0 then true else is_odd(n - 1) fi;
+    let is_odd = (n) rec => if n == 0 then false else is_even(n - 1, rec) fi;
+
+    write_line("is_even(10): {is_even(10, is_odd)}");
+    write_line("is_odd(10): {is_odd(10)}");
+si

--- a/integration-tests/execution/anon-function-mutual-recursion/test.ghulproj
+++ b/integration-tests/execution/anon-function-mutual-recursion/test.ghulproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+
+    <GhulCompiler>dotnet ghul-compiler</GhulCompiler>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <GhulSources Include="**/*.ghul" />
+    <PackageReference Include="ghul.runtime" />
+    <PackageReference Include="ghul.pipes" />
+    <PackageReference Include="ghul.targets" />
+  </ItemGroup>
+</Project>

--- a/src/semantic/symbols/variable.ghul
+++ b/src/semantic/symbols/variable.ghul
@@ -58,7 +58,7 @@ namespace Semantic.Symbols is
                 return false;
             fi
 
-            if !constraint? \/ constraint.is_inferred \/ constraint.is_error then
+            if !constraint? \/ constraint.contains_inferred \/ constraint.is_error then
                 return false;
             fi
 

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -3653,6 +3653,28 @@ namespace Syntax.Process is
             if function_type? /\ function_type.is_error then
                 call.value = DUMMY(Semantic.Types.ERROR(), call.location);
                 return;
+            elif isa Semantic.Types.INFERRED_VARIABLE_TYPE(function_type) then
+                // Iterative-inference back-feed when the call's receiver is
+                // itself an unresolved placeholder. Synthesize a function
+                // shape from the actual arg types plus a deferred return
+                // type and push it as a constraint on the placeholder's
+                // origin, so the next body-retry iteration sees the symbol
+                // resolved to a function type and the call can be compiled.
+                // Required for mutually-recursive lambdas where each side's
+                // signature depends on the other.
+                let placeholder = cast Semantic.Types.INFERRED_VARIABLE_TYPE(function_type);
+
+                if !argument_types | .any(a => !a? \/ a.contains_inferred \/ a.is_error) then
+                    let function_type_components = Collections.LIST[Type](argument_types);
+                    function_type_components.add(Semantic.Types.INFERED_RETURN_TYPE());
+                    let synthesized = _innate_symbol_lookup.get_function_type(function_type_components);
+                    if placeholder.origin.add_constraint(synthesized) then
+                        _logger.mark_consumed_any();
+                    fi
+                fi
+
+                call.value = DUMMY(Semantic.Types.ERROR(), call.location);
+                return;
             elif !function_type? \/ !isa Semantic.Types.NAMED(function_type) then
                 _logger.error(call.function.location, "cannot call value of non-function type {call.function.value.type}");
                 call.value = DUMMY(Semantic.Types.ERROR(), call.location);


### PR DESCRIPTION
Bugs fixed:
- Mutually-recursive anonymous functions whose argument types depend on each other (e.g. `is_even` calling `is_odd` and vice versa) leaked an `INFERRED_VARIABLE_TYPE` placeholder into emitted IL, ilasm rejected the malformed `Func\`3<int32, Func\`2 </* inferred variable type placeholder */, bool>, bool>` signature.

Technical:
- Add an `INFERRED_VARIABLE_TYPE` branch to `_visit(call)` that synthesizes a function shape from the actual arg types plus a deferred return type and back-feeds it as a constraint on the placeholder's origin `Variable`; the next body-retry iteration sees the receiver resolved and the call compiles normally.
- Tighten `Variable.add_constraint` to reject any constraint that `contains_inferred` (was: only `is_inferred`), so closure-frozen function types with placeholder slots from a still-iterating sibling don't pollute the LUB and out-rank the clean back-fed shape.
- New integration test `integration-tests/execution/anon-function-mutual-recursion`.
- Pin bump 0.8.88 -> 0.8.89.