### PR TITLE
Per-position structural merge in LEAST_UPPER_BOUND_MAP

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.8.89",
+      "version": "0.8.90",
       "commands": [
         "ghul-compiler"
       ],

--- a/src/semantic/least_upper_bound_map.ghul
+++ b/src/semantic/least_upper_bound_map.ghul
@@ -27,6 +27,56 @@ namespace Semantic is
         si
 
         add(type: Type) is
+            // Per-position structural merge: if an already-collected
+            // constraint shares a head with `type` and they're each
+            // concrete in slots the other isn't, collapse them into a
+            // single refined entry instead of leaving both in the LUB
+            // pool where one would out-rank the other and lose the
+            // complementary information. Required for iterative
+            // inference cases where two back-feed channels each pin a
+            // different position of the same Function shape.
+            //
+            // Only useful when at least one side is a structurally-
+            // recursable GENERIC carrying placeholder slots — for the
+            // common (and very hot) flat-type case (int + int, bool +
+            // bool, ...) the existing LUB picker does the right thing
+            // and the merge would be pure overhead.
+            if isa Types.GENERIC(type) /\ type.contains_inferred then
+                for i in 0..types.count do
+                    let merged = _try_merge_per_position(types[i], type);
+
+                    if merged? then
+                        types[i] = merged;
+
+                        if type.is_unsafe_constraints then
+                            _any_unsafe_constraints = true;
+                        fi
+
+                        _update_element_names_from(merged);
+                        return;
+                    fi
+                od
+            else
+                for i in 0..types.count do
+                    let existing = types[i];
+
+                    if isa Types.GENERIC(existing) /\ existing.contains_inferred then
+                        let merged = _try_merge_per_position(existing, type);
+
+                        if merged? then
+                            types[i] = merged;
+
+                            if type.is_unsafe_constraints then
+                                _any_unsafe_constraints = true;
+                            fi
+
+                            _update_element_names_from(merged);
+                            return;
+                        fi
+                    fi
+                od
+            fi
+
             types.add(type);
 
             if type.is_unsafe_constraints then
@@ -34,6 +84,95 @@ namespace Semantic is
             fi
 
             _update_element_names_from(type);
+        si
+
+        // Returns a per-position structural refinement of a and b, or
+        // null if the two aren't shape-compatible. At each position the
+        // non-placeholder side wins; recurses through generic args to
+        // handle nested cases like Function[Function[?, int], bool].
+        _try_merge_per_position(a: Type, b: Type) -> Type is
+            if !a? then return b; fi
+            if !b? then return a; fi
+
+            // Inference placeholder at the top — defer to the other.
+            if a.is_inferred then return b; fi
+            if b.is_inferred then return a; fi
+
+            // Otherwise both must be GENERIC with the same head and arity.
+            if !isa Types.GENERIC(a) \/ !isa Types.GENERIC(b) then
+                if a =~ b then return a; fi
+                return null;
+            fi
+
+            let ga = cast Types.GENERIC(a);
+            let gb = cast Types.GENERIC(b);
+
+            let sa = cast Symbols.GENERIC(ga.symbol);
+            let sb = cast Symbols.GENERIC(gb.symbol);
+
+            if !sa? \/ !sb? \/ sa.symbol != sb.symbol then return null; fi
+            if ga.arguments.count != gb.arguments.count then return null; fi
+
+            let merged_args = LIST[Types.Type](ga.arguments.count);
+
+            for j in 0..ga.arguments.count do
+                let merged_arg = _try_merge_per_position(ga.arguments[j], gb.arguments[j]);
+
+                if !merged_arg? then return null; fi
+
+                merged_args.add(merged_arg);
+            od
+
+            // Tuples carry element names alongside element types.
+            // Reconciliation rules: both unnamed → unnamed; one named one
+            // unnamed → take the name; both named the same → that name;
+            // both named differently → take the name from the side whose
+            // arg is concrete, or fail the merge if both are concrete.
+            if a.is_value_tuple /\ b.is_value_tuple then
+                let merged_names = LIST[string](ga.arguments.count);
+                let any_name = false;
+
+                for j in 0..ga.arguments.count do
+                    let name_a = ga.symbol.get_element_name(j);
+                    let name_b = gb.symbol.get_element_name(j);
+
+                    let name = _try_merge_element_name(name_a, name_b, ga.arguments[j], gb.arguments[j]);
+
+                    if name_a? /\ name_b? /\ name_a !~ name_b /\ !name? then
+                        return null;
+                    fi
+
+                    if name? then any_name = true; fi
+
+                    merged_names.add(name);
+                od
+
+                let names = if any_name then merged_names else null fi;
+
+                return IoC.CONTAINER.instance.innate_symbol_lookup.get_tuple_type(merged_args, names);
+            fi
+
+            return ga.create(ga.symbol.location, sa.symbol, merged_args);
+        si
+
+        _try_merge_element_name(name_a: string, name_b: string, arg_a: Types.Type, arg_b: Types.Type) -> string is
+            // Auto-generated positional names like `0 / `1 don't carry
+            // user intent; treat them as absent.
+            if name_a? /\ name_a.starts_with('`') then name_a = null; fi
+            if name_b? /\ name_b.starts_with('`') then name_b = null; fi
+
+            if !name_a? /\ !name_b? then return null; fi
+            if !name_a? then return name_b; fi
+            if !name_b? then return name_a; fi
+            if name_a =~ name_b then return name_a; fi
+
+            // Names differ. If one side's element type is still a
+            // placeholder we trust the named side's intent more than
+            // the placeholder's; otherwise the conflict is real.
+            if !arg_a.contains_inferred /\ arg_b.contains_inferred then return name_a; fi
+            if arg_a.contains_inferred /\ !arg_b.contains_inferred then return name_b; fi
+
+            return null;
         si
 
         _add(type: Type) is

--- a/src/semantic/symbols/variable.ghul
+++ b/src/semantic/symbols/variable.ghul
@@ -58,7 +58,7 @@ namespace Semantic.Symbols is
                 return false;
             fi
 
-            if !constraint? \/ constraint.contains_inferred \/ constraint.is_error then
+            if !constraint? \/ constraint.is_inferred \/ constraint.is_error then
                 return false;
             fi
 

--- a/unit-tests/src/semantic/least_upper_bound_map_tests.ghul
+++ b/unit-tests/src/semantic/least_upper_bound_map_tests.ghul
@@ -6,6 +6,10 @@ namespace Semantic.UnitTests is
     use Source.LOCATION;
 
     use Semantic.Symbols.CLASS;
+    use Semantic.Symbols.INFERRED_TYPE_ARG_ORIGIN;
+    use Semantic.Types.GENERIC;
+    use Semantic.Types.INFERED_RETURN_TYPE;
+    use Semantic.Types.INFERRED_VARIABLE_TYPE;
     use Semantic.Types.Type;
 
     // Tests for LEAST_UPPER_BOUND_MAP — the helper that backs ghūl's "what
@@ -162,6 +166,130 @@ namespace Semantic.UnitTests is
 
             // animal is the most-derived type assignable from all three.
             Assert.are_same(h.animal.type, lub.get_result());
+        si
+
+        // --- per-position structural merge in LUB.add ---
+        //
+        // When two constraints share a head and each fills a slot the other
+        // doesn't, add() collapses them into one refined entry instead of
+        // keeping both and letting the LUB picker drop one wholesale. Tests
+        // construct a single-arg generic ("box") and a two-arg generic
+        // ("pair") so we can pin merge behaviour without depending on the
+        // .NET Func / Action wrappers.
+
+        placeholder() -> INFERRED_VARIABLE_TYPE =>
+            INFERRED_VARIABLE_TYPE(INFERRED_TYPE_ARG_ORIGIN(loc(), null, "p"));
+
+        return_placeholder() -> INFERED_RETURN_TYPE => INFERED_RETURN_TYPE();
+
+        box_class(object_class: CLASS) -> CLASS is
+            let c = CLASS(loc(), loc(), null, "box", ["T"], false, null);
+            c.add_ancestor(object_class.type);
+            return c;
+        si
+
+        pair_class(object_class: CLASS) -> CLASS is
+            let c = CLASS(loc(), loc(), null, "pair", ["T", "U"], false, null);
+            c.add_ancestor(object_class.type);
+            return c;
+        si
+
+        Adding__concrete_after_placeholder_in_same_head__should_collapse_to_concrete() is
+            @test()
+
+            let h = build_hierarchy();
+            let owner = box_class(h.object_class);
+            let lub = LEAST_UPPER_BOUND_MAP();
+
+            let placeholder_box = GENERIC(loc(), owner, LIST[Type]([placeholder()]));
+            let concrete_box = GENERIC(loc(), owner, LIST[Type]([h.cat.type]));
+
+            lub.add(placeholder_box);
+            lub.add(concrete_box);
+
+            let result = cast GENERIC(lub.get_result());
+            Assert.is_not_null(result);
+            Assert.are_same(h.cat.type, result.arguments[0]);
+        si
+
+        Adding__two_partials_with_complementary_slots__should_merge_per_position() is
+            @test()
+
+            let h = build_hierarchy();
+            let owner = pair_class(h.object_class);
+            let lub = LEAST_UPPER_BOUND_MAP();
+
+            // pair[cat, ?] then pair[?, dog] → pair[cat, dog]
+            let left = GENERIC(loc(), owner, LIST[Type]([h.cat.type, placeholder()]));
+            let right = GENERIC(loc(), owner, LIST[Type]([placeholder(), h.dog.type]));
+
+            lub.add(left);
+            lub.add(right);
+
+            let result = cast GENERIC(lub.get_result());
+            Assert.is_not_null(result);
+            Assert.are_same(h.cat.type, result.arguments[0]);
+            Assert.are_same(h.dog.type, result.arguments[1]);
+        si
+
+        Adding__INFERED_RETURN_TYPE_then_concrete_in_same_slot__should_collapse_to_concrete() is
+            @test()
+
+            let h = build_hierarchy();
+            let owner = box_class(h.object_class);
+            let lub = LEAST_UPPER_BOUND_MAP();
+
+            // box[INFERED_RETURN_TYPE] vs box[cat] — INFERED_RETURN_TYPE is
+            // the lambda-return-side placeholder; same merge rule applies.
+            let with_return_placeholder = GENERIC(loc(), owner, LIST[Type]([return_placeholder()]));
+            let concrete = GENERIC(loc(), owner, LIST[Type]([h.cat.type]));
+
+            lub.add(with_return_placeholder);
+            lub.add(concrete);
+
+            let result = cast GENERIC(lub.get_result());
+            Assert.is_not_null(result);
+            Assert.are_same(h.cat.type, result.arguments[0]);
+        si
+
+        Adding__different_heads__should_not_merge() is
+            @test()
+
+            let h = build_hierarchy();
+            let lub = LEAST_UPPER_BOUND_MAP();
+
+            // box vs pair — different heads, can't structurally combine.
+            // The LUB picker falls back to ancestor / concrete strategies.
+            let one = GENERIC(loc(), box_class(h.object_class), LIST[Type]([h.cat.type]));
+            let two = GENERIC(loc(), pair_class(h.object_class), LIST[Type]([h.cat.type, h.dog.type]));
+
+            lub.add(one);
+            lub.add(two);
+
+            // Neither is assignable from the other and they share only
+            // object as a concrete ancestor — picker should land on object.
+            Assert.are_same(h.object_class.type, lub.get_result());
+        si
+
+        Adding__placeholder_constraint__should_defer_to_existing_concrete() is
+            @test()
+
+            let h = build_hierarchy();
+            let owner = box_class(h.object_class);
+            let lub = LEAST_UPPER_BOUND_MAP();
+
+            // Reverse order of the first test — concrete was added first,
+            // then a placeholder-shaped constraint arrives. The merge
+            // should keep the concrete entry rather than over-write.
+            let concrete = GENERIC(loc(), owner, LIST[Type]([h.cat.type]));
+            let with_placeholder = GENERIC(loc(), owner, LIST[Type]([placeholder()]));
+
+            lub.add(concrete);
+            lub.add(with_placeholder);
+
+            let result = cast GENERIC(lub.get_result());
+            Assert.is_not_null(result);
+            Assert.are_same(h.cat.type, result.arguments[0]);
         si
     si
 si


### PR DESCRIPTION
Technical:
- `LEAST_UPPER_BOUND_MAP.add` now collapses two collected constraints into one when they share a head and each fills slots the other has as placeholders. Recurses through generic args; fully-concrete and identical-shape pairs short-circuit. Tuple types unify element names per the rules: both unnamed → unnamed; one named one unnamed → take the name; matching names → that name; differing names where one side's element is a placeholder → take the named side; differing names with both concrete → fail the merge.
- Hot path: skip the merge entirely when neither the new type nor any existing type contains placeholder slots — the original LUB picker is correct for that case and the merge would be pure overhead.
- `Variable.add_constraint` reverts to the original `is_inferred` check; the per-position merge supersedes the coarse `contains_inferred` filter that #1227 introduced as a stop-gap and recovers the complementary information that filter dropped.
- New `LEAST_UPPER_BOUND_MAP_TESTS` coverage for the merge: same-head placeholder + concrete, complementary partials with two slots, `INFERED_RETURN_TYPE` collapse, different heads → no merge, placeholder constraint after concrete defers.
- Pin bump 0.8.89 -> 0.8.90.