### PR TITLE
Clear phantom-cache between builds in COMPILE_EXPRESSIONS

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.8.90",
+      "version": "0.8.91",
       "commands": [
         "ghul-compiler"
       ],

--- a/analysis-tests/fixtures/iterative-inference-state-leak/iterative-inference-state-leak.ghul
+++ b/analysis-tests/fixtures/iterative-inference-state-leak/iterative-inference-state-leak.ghul
@@ -1,0 +1,41 @@
+// Repro fixture for the COMPILE-after-EDIT phantom-cache leak: the
+// COMPILE_EXPRESSIONS visitor caches phantom Variables for unbound
+// owner type-args at constructor sites (`LIST()`, `MAP()`...) keyed
+// by AST node. The visitor is long-lived (one per IoC container, not
+// one per build), so a re-compile on the same AST hits stale phantoms
+// whose `_lub_map` carries Type instances from the previous build's
+// symbol table — which `clear_symbols` has just wiped and recreated.
+// The reused phantoms feed the stale Types back into specialization
+// and the resolved generic argument types end up referencing a class
+// instance that no member lookup will match. The visible symptom is
+// "no overload found" / "X is not assignable to Y" diagnostics where
+// X and Y print identically.
+
+namespace IterativeInferenceLeak is
+    use IO.Std;
+    use Collections.LIST;
+
+    class WIDGET is
+        init() is si
+        name: string => "widget";
+    si
+
+    class CONTAINER is
+        items: Collections.List[WIDGET] public;
+
+        init(items: Collections.List[WIDGET]) is
+            self.items = items;
+        si
+    si
+
+    entry() is
+        let widgets = LIST();
+        widgets.add(WIDGET());
+
+        let c = CONTAINER(widgets);
+
+        for w in c.items do
+            Std.write_line(w.name);
+        od
+    si
+si

--- a/analysis-tests/src/tests/iterative_inference_state_leak_tests.ghul
+++ b/analysis-tests/src/tests/iterative_inference_state_leak_tests.ghul
@@ -1,0 +1,115 @@
+namespace Analysis.Tests is
+    use Collections.LIST;
+
+    use IO.File;
+
+    use Analysis.Protocol.ANALYSER_PROCESS;
+    use Analysis.Protocol.DIAGNOSTIC;
+    use Analysis.Protocol.RESPONSE;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    // Regression marker for the COMPILE-after-EDIT phantom-cache leak in
+    // COMPILE_EXPRESSIONS. The visitor caches phantom Variables for unbound
+    // owner type-args at constructor sites (e.g. `LIST()`) keyed by AST
+    // node reference. The visitor is constructed once per IoC container,
+    // not per build, so on a second compile the same AST nodes hit cache
+    // entries holding phantoms whose `_lub_map` references Type instances
+    // from the previous build's symbol table — wiped by `clear_symbols`.
+    //
+    // Symptom on the compiler's own source (after the dogfood drop in
+    // #1226): 18 spurious "no overload found" / "X is not assignable to Y"
+    // diagnostics on COMPILE that are absent from EDIT. Tiny fixture
+    // exercises the same shape.
+    class ITERATIVE_INFERENCE_STATE_LEAK_TESTS is
+        @test()
+
+        init() is si
+
+        load_source() -> string is
+            let path = fixture_path("iterative-inference-state-leak/iterative-inference-state-leak.ghul");
+            assert File.exists(path) else "fixture not copied to test output: {path}";
+            return File.read_all_text(path);
+        si
+
+        prime(analyser: ANALYSER_PROCESS, source: string) is
+            analyser.send_edit("iterative-inference-state-leak.ghul", source);
+
+            let edit_diagnostics = analyser.read_response();
+            Assert.are_equal("DIAGNOSTICS", edit_diagnostics.header);
+
+            let edit_user = LIST[DIAGNOSTIC](edit_diagnostics.user_diagnostics);
+            Assert.are_equal(
+                0,
+                edit_user.count,
+                diagnostics_summary("EDIT response had unexpected user diagnostics", edit_user)
+            );
+
+            let edit_done = analyser.read_response();
+            Assert.are_equal("PARTIAL DONE", edit_done.header);
+        si
+
+        compile_after_edit_should_not_leak_phantom_cache() is
+            @test()
+
+            let source = load_source();
+            let use analyser = ANALYSER_PROCESS();
+
+            prime(analyser, source);
+
+            analyser.send_compile();
+
+            let compile_diagnostics = analyser.read_response();
+            Assert.are_equal("DIAGNOSTICS", compile_diagnostics.header);
+
+            let compile_user = LIST[DIAGNOSTIC](compile_diagnostics.user_diagnostics);
+            Assert.are_equal(
+                0,
+                compile_user.count,
+                diagnostics_summary(
+                    "COMPILE response had spurious diagnostics — phantom cache leak " +
+                    "across builds (COMPILE_EXPRESSIONS._type_arg_placeholder_origins " +
+                    "not cleared between apply() invocations)",
+                    compile_user
+                ) +
+                "\n--- analyser stderr ---\n" + analyser.stderr_capture
+            );
+
+            let compile_done = analyser.read_response();
+            Assert.are_equal("FULL DONE", compile_done.header);
+        si
+
+        // Two consecutive COMPILEs (no EDIT between) — the second compile
+        // is what surfaces the cache pile-up most reliably; this is a
+        // belt-and-braces probe.
+        two_consecutive_compiles_after_edit_should_both_be_clean() is
+            @test()
+
+            let source = load_source();
+            let use analyser = ANALYSER_PROCESS();
+
+            prime(analyser, source);
+
+            for i in 0..2 do
+                analyser.send_compile();
+
+                let compile_diagnostics = analyser.read_response();
+                Assert.are_equal("DIAGNOSTICS", compile_diagnostics.header);
+
+                let compile_user = LIST[DIAGNOSTIC](compile_diagnostics.user_diagnostics);
+                Assert.are_equal(
+                    0,
+                    compile_user.count,
+                    diagnostics_summary(
+                        "COMPILE #{i + 1} after EDIT had spurious diagnostics",
+                        compile_user
+                    ) +
+                    "\n--- analyser stderr ---\n" + analyser.stderr_capture
+                );
+
+                let compile_done = analyser.read_response();
+                Assert.are_equal("FULL DONE", compile_done.header);
+            od
+        si
+    si
+si

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -85,7 +85,20 @@ namespace Syntax.Process is
 
             IR.LABEL.reset_id();
             IR.LABEL.set_pass("E");
-            
+
+            // Phantom Variables for unbound owner type-args at constructor
+            // sites are cached on this visitor (not the AST), keyed by AST
+            // node reference. The visitor instance is long-lived — one per
+            // IoC container, not one per build — so cache entries from a
+            // previous pass would still hit on the same AST nodes after a
+            // re-compile, returning phantoms whose `_lub_map` references
+            // Type instances from the previous build's symbol table (now
+            // wiped by clear_symbols). Body-retry iterations of one
+            // function need stable phantoms, but those happen inside
+            // visit(function: FUNCTION) below this point, so clearing at
+            // the start of apply is safe.
+            _type_arg_placeholder_origins.clear();
+
             root.walk(self);
 
             assert _keep_depth == 0;


### PR DESCRIPTION
Bugs fixed:
- Loading the compiler's own source in analysis mode produced 18 spurious "no overload found" / "X is not assignable to Y" diagnostics on the COMPILE that follows the initial multi-file EDIT, with X and Y printing identically. Errors disappeared when the user switched to the affected file (which re-EDITs and re-parses it) and returned on the next debounced COMPILE.

Technical:
- COMPILE_EXPRESSIONS caches phantom Variables for unbound owner type-args at constructor sites in `_type_arg_placeholder_origins`, keyed by AST node reference. The visitor instance is owned by the IoC container — one per analyser process — so on a re-compile against retained ASTs the same AST nodes hit cache entries holding phantoms whose `_lub_map` references Type instances from the previous build's symbol table that `clear_symbols` has wiped and recreated. Reused phantoms feed those stale Types back through `_try_specialize_owner_with_placeholders`, producing the identity-mismatch errors. Body-retry iterations of one function need stable phantoms but happen inside `visit(function: FUNCTION)`, so clearing at the start of `apply` is safe.
- New `ITERATIVE_INFERENCE_STATE_LEAK_TESTS` (`compile_after_edit_should_not_leak_phantom_cache`, `two_consecutive_compiles_after_edit_should_both_be_clean`) and a tiny multi-file fixture exercising bare `LIST()` inference plus a typed handoff that surfaces the identity mismatch. Both fail before the fix and pass after.
- Pin bump 0.8.90 -> 0.8.91.