### PR TITLE
Translate non-innate `<>` operator result to bool (#283)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.8.92",
+      "version": "0.8.93",
       "commands": [
         "ghul-compiler"
       ],

--- a/integration-tests/execution/non-innate-order-operator-issue-283/disabled
+++ b/integration-tests/execution/non-innate-order-operator-issue-283/disabled
@@ -1,7 +1,0 @@
-Disabled regression test for issue #283: non-innate `<>` operator results are not translated to bool when consumed by relational operators.
-
-Innate `<>` (e.g. on `int`) translates to `clt` / `cgt` IL and works. A user-defined `<>(other) -> int` is currently consumed as if its int return is the boolean directly — `5 - 10 = -5` is non-zero so it reads as `true`, regardless of which side is bigger. Every relational comparison in the test prints `True`.
-
-Expected behaviour: `a > b` should compile to `a.<>(b) > 0`, `a < b` to `a.<>(b) < 0`, `a >= b` to `a.<>(b) >= 0`, etc.
-
-Re-enable by deleting this `disabled` file once the relevant lowering applies a comparison-with-zero around non-innate `<>` calls.

--- a/src/ir/values/compare_order_to_zero.ghul
+++ b/src/ir/values/compare_order_to_zero.ghul
@@ -1,0 +1,57 @@
+namespace IR.Values is
+    use TypeTyped = Semantic.Types.Typed;
+    use Semantic.Types.Type;
+
+    class COMPARE_ORDER_TO_ZERO: Value, TypeTyped is
+        value: Value;
+        actual_operation: string;
+        type: Type;
+
+        has_Type: bool => type?;
+        is_value_type: bool => true;
+
+        init(value: Value, actual_operation: string, type: Type) is
+            super.init();
+
+            assert value?;
+            assert actual_operation?;
+            assert type?;
+
+            self.value = value;
+            self.actual_operation = actual_operation;
+            self.type = type;
+        si
+
+        gen(context: IR.CONTEXT) is
+            let instruction: string;
+            let needs_not = false;
+
+            if actual_operation =~ ">" then
+                instruction = "cgt";
+            elif actual_operation =~ ">=" then
+                instruction = "clt";
+                needs_not = true;
+            elif actual_operation =~ "<" then
+                instruction = "clt";
+            elif actual_operation =~ "<=" then
+                instruction = "cgt";
+                needs_not = true;
+            else
+                throw System.Exception("unexpected compare order operation: {actual_operation}");
+            fi
+
+            Value.gen(value, context);
+
+            context.write_line("ldc.i4 0");
+            context.write_line(instruction);
+
+            if needs_not then
+                context.write_line("ldc.i4 0");
+                context.write_line("ceq");
+            fi
+        si
+
+        to_string() -> string =>
+            "compare-order-to-zero[{actual_operation}]({value})";
+    si
+si

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -2382,14 +2382,11 @@ namespace Syntax.Process is
                 let force_type: Type;
                 let want_not = false;
 
-                if binary.operation.name =~ "<>" then                        
+                if binary.operation.name =~ "<>" then
                     if function.return_type !~ _innate_symbol_lookup.get_int_type() then
                         // FIXME: do this check on the definition:
                         _logger.error(binary.location, "<> order operator must return int");
                     fi
-
-                    // FIXME: for non-innate implementations of <> operator, need to translate the result to bool
-                    // based on actual operation
 
                     force_type = _innate_symbol_lookup.get_bool_type();
                 elif binary.operation.name =~ "==" then
@@ -2427,7 +2424,11 @@ namespace Syntax.Process is
                         value = innate_value.lower();
                     fi
                 fi
-                
+
+                if !function.is_innate /\ binary.operation.name =~ "<>" then
+                    value = COMPARE_ORDER_TO_ZERO(value, binary.actual_operation, _innate_symbol_lookup.get_bool_type());
+                fi
+
                 if want_not then
                     value = NOT(value);
                 fi


### PR DESCRIPTION
## Summary

Closes #283.

For innate `<>` (built-in numeric types), the lowering wraps the subtraction with `cgt`/`clt`/`ceq` IL based on the actual comparison the user wrote (`>`, `>=`, `<`, `<=`). For user-defined `<>(other) -> int` operators the call result was being treated as the boolean directly — non-zero read as `true` regardless of which side was bigger, so every `>`, `>=`, `<`, `<=` against a class that defines `<>` reported `True`.

This adds `IR.Values.COMPARE_ORDER_TO_ZERO` and wraps the call result with it when the resolved operator is `<>` and the function isn't innate. The wrapper emits the int call value followed by `ldc.i4 0` and the appropriate comparison instruction (`cgt`, `clt`, with a follow-up `ldc.i4 0; ceq` for `>=` / `<=`), matching the lowering used for the innate path.

The disabled regression test from #1231 (`integration-tests/execution/non-innate-order-operator-issue-283`) is enabled here — it now passes.

## Test plan

- [x] `dotnet ghul-test integration-tests` — 627/627 pass
- [x] `./build/bootstrap.sh` — IL byte-identical between passes 3 and 4 (~340s)
- [ ] CI green

[Claude]