### PR TITLE
Iterative inference for unit variant constructors of generic unions (closes #1232)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.8.97",
+      "version": "0.8.99",
       "commands": [
         "ghul-compiler"
       ],

--- a/integration-tests/execution/union-unit-variant-from-typed-lhs/ghul.json
+++ b/integration-tests/execution/union-unit-variant-from-typed-lhs/ghul.json
@@ -1,0 +1,6 @@
+{
+    "compiler": "dotnet ../../../publish/ghul.dll",
+    "source": [
+        "."
+    ]
+}

--- a/integration-tests/execution/union-unit-variant-from-typed-lhs/run.expected
+++ b/integration-tests/execution/union-unit-variant-from-typed-lhs/run.expected
@@ -1,0 +1,5 @@
+True
+True
+True
+42
+True

--- a/integration-tests/execution/union-unit-variant-from-typed-lhs/test.ghul
+++ b/integration-tests/execution/union-unit-variant-from-typed-lhs/test.ghul
@@ -1,0 +1,35 @@
+use IO.Std.write_line;
+
+union Option[T] is
+    SOME(value: T);
+    NONE;
+si
+
+union Many[T, U, V] is
+    A(t: T);
+    B(u: U);
+    EMPTY;
+si
+
+entry() is
+    // Unit variant of single-typearg union: T inferred from LHS
+    let n: Option[int] = Option.NONE();
+    write_line(n.is_none);
+
+    // Same, with reassignment to an already-typed variable
+    let m: Option[string];
+    m = Option.NONE();
+    write_line(m.is_none);
+
+    // Unit variant of multi-typearg union: all type args inferred from LHS
+    let e: Many[int, string, bool] = Many.EMPTY();
+    write_line(e.is_empty);
+
+    // Non-unit variants still resolve via the existing arg-driven path
+    let s: Option[int] = Option.SOME(42);
+    write_line(s.value);
+
+    // Already-explicit type args remain valid
+    let n2: Option[int] = Option.NONE[int]();
+    write_line(n2.is_none);
+si

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -2028,7 +2028,22 @@ namespace Syntax.Process is
 
             let constraint_generic = cast Semantic.Symbols.GENERIC(constraint_named.symbol);
 
-            if !constraint_generic? \/ !(constraint_generic.symbol =~ owner_classy) then
+            if !constraint_generic? then
+                return function;
+            fi
+
+            // Direct match: constructor for the constrained type itself.
+            // Variant match: constructor for a variant of the constrained
+            // union. Variants share their parent union's argument_names
+            // (declare_variant passes the union's `argument_names`
+            // through), so the constraint's union-keyed type_map keys
+            // line up with the variant's slots.
+            let is_direct = constraint_generic.symbol =~ owner_classy;
+            let is_variant_of_constraint =
+                owner_classy.is_variant /\
+                cast Semantic.Symbols.Symbol(owner_classy.owner) =~ constraint_generic.symbol;
+
+            if !is_direct /\ !is_variant_of_constraint then
                 return function;
             fi
 


### PR DESCRIPTION
Closes the gap where `Option.NONE()` from a typed declaration LHS fell back to `Option.NONE[Ghul.object]` instead of inferring T from the `Option[int]` constraint. Variants share their parent union's formal type-arg names (`declare_variant` passes the union's `argument_names` through), so the constraint's union-keyed `type_map` keys line up with the variant's slots — no separate machinery needed.

Bugs fixed:
- `let n: Option[int] = Option.NONE();` failed with "Option.NONE[Ghul.object] is not assignable to Option[Ghul.int]" (closes #1232)
- Same failure mode for the multi-typearg analogue (`Many.EMPTY()` → `Many[int, string, bool]`)

Technical:
- `_try_specialize_owner_from_constraint` now accepts both the direct match (`constraint.symbol =~ owner_classy`, the existing case) and the variant-of-constraint match (`owner_classy.is_variant /\ owner_classy.owner =~ constraint.symbol`). Same downstream: `try_create_from(owner_classy, constraint.type_map)` builds the specialised variant.
- New integration test `execution/union-unit-variant-from-typed-lhs` covers single- and multi-typearg unit variants from typed `let`, reassignment to already-typed variable, and the unchanged non-unit and explicit-args paths.
- Pin bump 0.8.94 → 0.8.99 included.