### PR TITLE
Pull down inherited members onto union variants (closes #1233)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.8.100",
+      "version": "0.8.101",
       "commands": [
         "ghul-compiler"
       ],

--- a/integration-tests/execution/union-variant-inherits-object-members/ghul.json
+++ b/integration-tests/execution/union-variant-inherits-object-members/ghul.json
@@ -1,0 +1,6 @@
+{
+    "compiler": "dotnet ../../../publish/ghul.dll",
+    "source": [
+        "."
+    ]
+}

--- a/integration-tests/execution/union-variant-inherits-object-members/run.expected
+++ b/integration-tests/execution/union-variant-inherits-object-members/run.expected
@@ -1,0 +1,7 @@
+union_variant_inherits_object_members__test.Option.SOME[System.Int32]
+True
+SOME
+union_variant_inherits_object_members__test.Option.NONE[System.Int32]
+True
+True
+union_variant_inherits_object_members__test.Option.SOME[System.Int32]

--- a/integration-tests/execution/union-variant-inherits-object-members/test.ghul
+++ b/integration-tests/execution/union-variant-inherits-object-members/test.ghul
@@ -1,0 +1,27 @@
+use IO.Std.write_line;
+
+union Option[T] is
+    SOME(value: T);
+    NONE;
+si
+
+entry() is
+    let s = Option.SOME(42);          // s: Option.SOME[int]
+    let n = Option.NONE[int]();       // n: Option.NONE[int]
+
+    // Members inherited via the union from object — these previously
+    // failed with "member to_string not found" because pull_down was
+    // never run on the variant.
+    write_line(s.to_string());
+    write_line(s.get_hash_code() != 0);
+    write_line(s.get_type().name);
+    write_line(n.to_string());
+
+    // The variant's own synthesised tag accessor still wins.
+    write_line(s.is_some);
+    write_line(n.is_none);
+
+    // Inherited via union after upcast — the path that already worked.
+    let o: Option[int] = s;
+    write_line(o.to_string());
+si

--- a/src/syntax/process/resolve_overrides.ghul
+++ b/src/syntax/process/resolve_overrides.ghul
@@ -89,7 +89,13 @@ namespace Syntax.Process is
             fi
         si
 
-        pre(`union: Trees.Definitions.UNION) -> bool => true;
+        // Walk into the union body so variants get visited (their
+        // `pull_down_super_symbols()` runs in `visit(variant)` below).
+        // Without this, variants never have inherited members like
+        // `to_string` pulled into their scope, so member lookup on a
+        // variant type misses anything inherited via the union from
+        // `object`.
+        pre(`union: Trees.Definitions.UNION) -> bool => false;
 
         visit(`union: Definitions.UNION) is
             let symbol = symbol_for(`union);


### PR DESCRIPTION
Variants are `Classy` descendants of their parent union (which is itself a `Classy` descendant of `object`), but `RESOLVE_OVERRIDES` never visited them — `pre(union: Definitions.UNION) -> bool => true` skipped the union body, so the existing `visit(variant)` that calls `pull_down_super_symbols` was unreachable. Without pull-down, members inherited via the union from `object` never landed in the variant's scope, and `s.to_string()` on `s: Option.SOME[int]` failed with "member to_string not found".

Bugs fixed:
- `let s = Option.SOME(42); s.to_string()` failed with "member to_string not found in Option.SOME[Ghul.int]" (closes #1233). Same for `equals`, `get_hash_code`, `get_type` and any other member reachable through the union → object chain.
- Member access via the union (`(o: Option[int]).to_string()`) was unaffected and continues to work.

Technical:
- `pre(union)` in `RESOLVE_OVERRIDES` now returns `false` instead of `true`, so the AST walker recurses into the union body. The variant's own `visit(variant)` then runs and triggers `pull_down_super_symbols`. Pull-down is idempotent and ancestor-recursive, so order between the union's own pull-down and its variants' pull-downs doesn't matter.
- The narrow `VARIANT.find_member` filter that hides union-owned synthesised accessors (`is_xxx`, `value`, etc.) is unchanged — pulled-down `object` members have `owner = object`, not the union, so they pass the filter naturally.
- New integration test `execution/union-variant-inherits-object-members` covers `to_string` / `get_hash_code` / `get_type` on both unit and non-unit variants and confirms the variant's own synthesised tag accessor still wins.
- Pin bump 0.8.96 → 0.8.101 included.