### PR TITLE
Import default methods from external trait assemblies

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.8.101",
+      "version": "0.8.103",
       "commands": [
         "ghul-compiler"
       ],

--- a/project-tests/import-default-trait-method/import-default-trait-method.ghulproj
+++ b/project-tests/import-default-trait-method/import-default-trait-method.ghulproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <GhulCompiler>dotnet ghul-compiler</GhulCompiler>
+    <AssemblyName>binary</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <GhulSources Include="*.ghul" />
+    <ProjectReference Include="lib/lib.csproj" />
+  </ItemGroup>
+</Project>

--- a/project-tests/import-default-trait-method/lib/lib.cs
+++ b/project-tests/import-default-trait-method/lib/lib.cs
@@ -1,0 +1,9 @@
+namespace ImportedDefaultTrait;
+
+public interface IGreeter
+{
+    void Greet()
+    {
+        System.Console.WriteLine("default greeting from imported trait");
+    }
+}

--- a/project-tests/import-default-trait-method/lib/lib.csproj
+++ b/project-tests/import-default-trait-method/lib/lib.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>import-default-trait-method-lib</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Remove="ghul.runtime" />
+  </ItemGroup>
+</Project>

--- a/project-tests/import-default-trait-method/run.expected
+++ b/project-tests/import-default-trait-method/run.expected
@@ -1,0 +1,1 @@
+default greeting from imported trait

--- a/project-tests/import-default-trait-method/test.ghul
+++ b/project-tests/import-default-trait-method/test.ghul
@@ -1,0 +1,14 @@
+namespace Test is
+    use ImportedDefaultTrait;
+
+    class Greeting: IGreeter is
+        init() is si
+    si
+
+    class Main is
+        entry() static is
+            let g = Greeting();
+            g.greet();
+        si
+    si
+si

--- a/src/semantic/dotnet/symbol_factory.ghul
+++ b/src/semantic/dotnet/symbol_factory.ghul
@@ -531,8 +531,8 @@ namespace Semantic.DotNet is
                 result = Symbols.STRUCT_METHOD(location, location, declaring_symbol, name, owner);
             elif method.is_abstract then
                 result = Symbols.ABSTRACT_METHOD(location, location, declaring_symbol, name, owner);
-            elif method.is_virtual then
-                result = Symbols.INSTANCE_METHOD(location, location, declaring_symbol, name, owner);
+            elif method.declaring_type.is_interface then
+                result = Symbols.DEFAULT_TRAIT_METHOD(location, location, declaring_symbol, name, owner);
             else
                 result = Symbols.INSTANCE_METHOD(location, location, declaring_symbol, name, owner);
             fi


### PR DESCRIPTION
Bugs fixed:

- Default trait methods on interfaces imported from other assemblies were imported as `INSTANCE_METHOD`, so calls dispatched as if they were class virtuals; switch to `DEFAULT_TRAIT_METHOD` when the declaring type is an interface.

Closes #1244