### PR TITLE
Default Scope.is_xxx markers via trait defaults

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.8.103",
+      "version": "0.8.105",
       "commands": [
         "ghul-compiler"
       ],

--- a/integration-tests/execution/trait-default-class-chain/ghul.json
+++ b/integration-tests/execution/trait-default-class-chain/ghul.json
@@ -1,0 +1,6 @@
+{
+    "compiler": "dotnet ../../../publish/ghul.dll",
+    "source": [
+        "."
+    ]
+}

--- a/integration-tests/execution/trait-default-class-chain/run.expected
+++ b/integration-tests/execution/trait-default-class-chain/run.expected
@@ -1,0 +1,2 @@
+Mid.flag = False
+Leaf.flag = True

--- a/integration-tests/execution/trait-default-class-chain/test.ghul
+++ b/integration-tests/execution/trait-default-class-chain/test.ghul
@@ -1,0 +1,25 @@
+namespace Test is
+    use Std = IO.Std;
+
+    trait Marker is
+        flag: bool => false;
+    si
+
+    class Mid: Marker is
+        init() is si
+    si
+
+    class Leaf: Mid is
+        flag: bool => true;
+        init() is si
+    si
+
+    class Main is
+        entry() static is
+            let m = Mid();
+            let l = Leaf();
+            Std.write_line("Mid.flag = {m.flag}");
+            Std.write_line("Leaf.flag = {l.flag}");
+        si
+    si
+si

--- a/src/semantic/scope/block_scope.ghul
+++ b/src/semantic/scope/block_scope.ghul
@@ -21,15 +21,6 @@ namespace Semantic is
 
         unspecialized_symbol: Symbols.Symbol => null;
 
-        is_trait: bool => false;
-        is_capture_context: bool => false;
-        is_instance_context: bool => false;
-        is_closure: bool => false;
-        is_namespace: bool => false;
-        is_classy: bool => false;
-        is_union: bool => false;
-        is_variant: bool => false;
-
         init() is
             init(null);
         si

--- a/src/semantic/scope/empty_scope.ghul
+++ b/src/semantic/scope/empty_scope.ghul
@@ -16,14 +16,6 @@ namespace Semantic is
         symbols: Iterable[Symbol] => LIST[Symbol]();
         type: Type => null;
         unspecialized_symbol: Symbol => null;
-        is_trait: bool => false;
-        is_capture_context: bool => false;
-        is_instance_context: bool => false;
-        is_closure: bool => false;
-        is_namespace: bool => false;
-        is_classy: bool => false;
-        is_union: bool => false;
-        is_variant: bool => false;
 
         init(name: string) is
             self.name = name;

--- a/src/semantic/scope/namespace_scope.ghul
+++ b/src/semantic/scope/namespace_scope.ghul
@@ -36,14 +36,8 @@ namespace Semantic is
         qualified_name: string => _namespace.qualified_name;
         symbols: Collections.Iterable[Symbol] => _namespace.symbols;
 
-        is_trait: bool => false;
         is_capture_context: bool => true;
-        is_instance_context: bool => false;
-        is_closure: bool => false;
         is_namespace: bool => true;
-        is_classy: bool => false;
-        is_union: bool => false;
-        is_variant: bool => false;
 
         init(`namespace: Symbols.NAMESPACE) is
             _namespace = `namespace;

--- a/src/semantic/scope/scope.ghul
+++ b/src/semantic/scope/scope.ghul
@@ -20,14 +20,14 @@ namespace Semantic is
 
         unspecialized_symbol: Symbols.Symbol;
 
-        is_trait: bool;
-        is_classy: bool;
-        is_closure: bool;
-        is_union: bool;
-        is_variant: bool;
-        is_capture_context: bool;
-        is_instance_context: bool;
-        is_namespace: bool;
+        is_trait: bool => false;
+        is_classy: bool => false;
+        is_closure: bool => false;
+        is_union: bool => false;
+        is_variant: bool => false;
+        is_capture_context: bool => false;
+        is_instance_context: bool => false;
+        is_namespace: bool => false;
         
         qualify(name: string) -> string;
         find_direct(name: string) -> Symbols.Symbol;

--- a/src/semantic/symbols/generic.ghul
+++ b/src/semantic/symbols/generic.ghul
@@ -16,7 +16,7 @@ namespace Semantic.Symbols is
     // A GENERIC represents a particular specialization of a generic class, trait or struct - i.e. a version of that symbol
     // with actual type arguments specified for its formal type parameters, and all its member symbols' signatures rewritten 
     // with all instances of each formal type parameter replaced with the corresponding actual type argument  
-    class GENERIC: Symbol, Scope, Types.Typed is
+    class GENERIC: Symbol, Types.Typed is
         _symbol: Classy;
         _type_map: Collections.Map[string,Type];
 

--- a/src/semantic/symbols/symbol.ghul
+++ b/src/semantic/symbols/symbol.ghul
@@ -472,7 +472,7 @@ namespace Semantic.Symbols is
         to_string() -> string => short_description;
     si
 
-    class Scoped: Symbol, Scope, DeclarationContext is
+    class Scoped: Symbol, DeclarationContext is
         _symbols: SYMBOL_STORE;
 
         symbols: Collections.Iterable[Symbol] => _symbols.values;
@@ -646,7 +646,7 @@ namespace Semantic.Symbols is
         si
     si
 
-    class NONE: Symbol, Scope is
+    class NONE: Symbol is
         _instance: NONE static;
 
         instance: NONE static is
@@ -662,7 +662,7 @@ namespace Semantic.Symbols is
         si
     si
     
-    class UNDEFINED: Symbol, Scope, DeclarationContext, Types.Typed is
+    class UNDEFINED: Symbol, DeclarationContext, Types.Typed is
         type: Type => Types.ERROR();
 
         description: string => "undefined";


### PR DESCRIPTION
Technical:

- \`Scope\` trait declares \`is_trait\`, \`is_classy\`, \`is_closure\`, \`is_union\`, \`is_variant\`, \`is_capture_context\`, \`is_instance_context\` and \`is_namespace\` with \`=> false\` defaults; standalone implementers (\`BLOCK_SCOPE\`, \`EMPTY_SCOPE\`, \`NAMESPACE_SCOPE\`) drop their boilerplate \`=> false\` overrides and keep only the markers they flip to \`true\`. Symbol-rooted hierarchies keep their explicit \`=> false\` overrides because subclasses depend on class-inheritance dispatch for their own \`=> true\` overrides.
- Drop redundant \`, Scope\` from \`class GENERIC: Symbol, Scope, Types.Typed\`, \`class Scoped: Symbol, Scope, DeclarationContext\`, \`class NONE: Symbol, Scope\` and \`class UNDEFINED: Symbol, Scope, DeclarationContext, Types.Typed\` — \`Symbol\` already implements \`Scope\`, and the duplicate listing now collides with the trait's defaults.
- Adds \`integration-tests/execution/trait-default-class-chain\` exercising trait default → direct implementer → subclass override propagation, the case the dogfood relies on.