### PR TITLE
Default DiagnosticFormatter flag accessors via trait defaults

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.8.106",
+      "version": "0.8.107",
       "commands": [
         "ghul-compiler"
       ],

--- a/src/logging/diagnostics_store.ghul
+++ b/src/logging/diagnostics_store.ghul
@@ -39,8 +39,8 @@ namespace Logging is
     si
 
     trait DiagnosticFormatter is
-        want_filter_error_cascades: bool;
-        need_clear_errors: bool;
+        want_filter_error_cascades: bool => false;
+        need_clear_errors: bool => false;
         format(diagnostic: DIAGNOSTIC_MESSAGE) -> string;
     si
 
@@ -80,9 +80,6 @@ namespace Logging is
     si
 
     class HUMAN_READABLE_DIAGNOSTIC_FORMATTER: DiagnosticFormatter is
-        want_filter_error_cascades: bool => false;
-        need_clear_errors: bool => false;
-
         init() is
         si
 
@@ -113,9 +110,6 @@ namespace Logging is
     si
 
     class MSBUILD_DIAGNOSTIC_FORMATTER: DiagnosticFormatter is
-        want_filter_error_cascades: bool => false;
-        need_clear_errors: bool => false;
-
         init() is
         si
 


### PR DESCRIPTION
Technical:

- \`DiagnosticFormatter\` declares \`want_filter_error_cascades\` and \`need_clear_errors\` with \`=> false\` defaults; \`HUMAN_READABLE_DIAGNOSTIC_FORMATTER\` and \`MSBUILD_DIAGNOSTIC_FORMATTER\` drop their boilerplate \`=> false\` overrides. \`TAB_DELIMITED_DIAGNOSTIC_FORMATTER\` keeps its \`=> true\` overrides.