### PR TITLE
Cover IR.Values IL emission with unit tests

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.8.110",
+      "version": "0.8.111",
       "commands": [
         "ghul-compiler"
       ],

--- a/unit-tests/src/ir/values/box_tests.ghul
+++ b/unit-tests/src/ir/values/box_tests.ghul
@@ -1,0 +1,65 @@
+namespace IR.Values.UnitTests is
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    use Source.LOCATION;
+
+    use IR.RAW;
+    use IR.Values.BOX;
+
+    use Semantic.Symbols.CLASSY_GENERIC_ARGUMENT;
+
+    class BOX_TESTS is
+        @test()
+
+        init() is si
+
+        loc() -> LOCATION => LOCATION("test.ghul", 1, 1, 1, 1);
+
+        // A RAW value typed with `T` (writes `!0 ` for IL emission).
+        raw_value() -> IR.Values.Value =>
+            RAW(CLASSY_GENERIC_ARGUMENT(loc(), null, "T", 0).type, "// value");
+
+        gen_to_string(value: IR.Values.Value) -> string is
+            let context = IR.CONTEXT(null, null);
+            context.enter_buffer(false);
+            value.gen(context);
+            return context.leave_buffer();
+        si
+
+        is_value_type__should_be_false_regardless_of_inner() is
+            @test()
+
+            // BOX produces a reference (the boxed object) — `is_value_type`
+            // must be false for any inner value. If a refactor short-circuits
+            // this to delegate to `value.is_value_type`, callers that decide
+            // whether to box or unbox based on the BOX result will produce
+            // double-boxed or under-boxed IL.
+            let value = BOX(raw_value());
+
+            Assert.is_false(value.is_value_type);
+        si
+
+        Calling__gen__should_emit_inner_then_box_il_type() is
+            @test()
+
+            // BOX lowers to `value; box {il_type}`. The `box {T}` instruction
+            // is the moral content — without it, the value-type address ends
+            // up on the stack instead of the boxed reference.
+            let value = BOX(raw_value());
+
+            Assert.are_equal(
+                "// value\nbox !0 \n",
+                gen_to_string(value)
+            );
+        si
+
+        type__should_delegate_to_inner_value_type() is
+            @test()
+
+            let inner = raw_value();
+            let value = BOX(inner);
+
+            Assert.are_same(inner.type, value.type);
+        si
+    si
+si

--- a/unit-tests/src/ir/values/cast_tests.ghul
+++ b/unit-tests/src/ir/values/cast_tests.ghul
@@ -1,0 +1,92 @@
+namespace IR.Values.UnitTests is
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    use Source.LOCATION;
+
+    use IR.Values.CAST;
+
+    use Semantic.Symbols.CLASSY_GENERIC_ARGUMENT;
+
+    // RAW always types as Semantic.Types.ERROR (a reference type), so testing
+    // CAST's value-type pre-box branch needs an inner value that reports
+    // `is_value_type => true`. This test-only fake is the smallest thing
+    // that satisfies that — Moq isn't viable per the no-generic-constraints
+    // limitation and a hand fake stays inside the proven fixture pattern.
+    class FAKE_VALUE_TYPED_VALUE: IR.Values.Value is
+        type: Semantic.Types.Type;
+
+        is_value_type: bool => true;
+
+        init(type: Semantic.Types.Type) is
+            super.init();
+            self.type = type;
+        si
+
+        gen(context: IR.CONTEXT) is
+            context.write_line("// inner-vt");
+        si
+    si
+
+    class FAKE_REFERENCE_TYPED_VALUE: IR.Values.Value is
+        type: Semantic.Types.Type;
+
+        is_value_type: bool => false;
+
+        init(type: Semantic.Types.Type) is
+            super.init();
+            self.type = type;
+        si
+
+        gen(context: IR.CONTEXT) is
+            context.write_line("// inner-ref");
+        si
+    si
+
+    class CAST_TESTS is
+        @test()
+
+        init() is si
+
+        loc() -> LOCATION => LOCATION("test.ghul", 1, 1, 1, 1);
+
+        type_named(name: string, index: int) -> Semantic.Types.Type =>
+            CLASSY_GENERIC_ARGUMENT(loc(), null, name, index).type;
+
+        gen_to_string(value: IR.Values.Value) -> string is
+            let context = IR.CONTEXT(null, null);
+            context.enter_buffer(false);
+            value.gen(context);
+            return context.leave_buffer();
+        si
+
+        Calling__gen__on_reference_inner__should_emit_isinst_only_no_box() is
+            @test()
+
+            let inner = FAKE_REFERENCE_TYPED_VALUE(type_named("R", 0));
+            let value = CAST(type_named("T", 1), inner);
+
+            // Reference inner: emit value, then `isinst T`. No pre-box —
+            // `box` on a reference produces invalid IL.
+            Assert.are_equal(
+                "// inner-ref\nisinst !1 \n",
+                gen_to_string(value)
+            );
+        si
+
+        Calling__gen__on_value_type_inner__should_emit_box_then_isinst() is
+            @test()
+
+            let inner = FAKE_VALUE_TYPED_VALUE(type_named("V", 0));
+            let value = CAST(type_named("T", 1), inner);
+
+            // Value-type inner: must box before `isinst`. The conditional
+            // pre-box is the contract worth pinning — a refactor that
+            // unconditionally emits or unconditionally skips it produces
+            // invalid IL on one side or the other.
+            Assert.are_equal(
+                "// inner-vt\nbox !0 \nisinst !1 \n",
+                gen_to_string(value)
+            );
+        si
+    si
+si

--- a/unit-tests/src/ir/values/compare_order_to_zero_tests.ghul
+++ b/unit-tests/src/ir/values/compare_order_to_zero_tests.ghul
@@ -1,0 +1,110 @@
+namespace IR.Values.UnitTests is
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    use Source.LOCATION;
+
+    use IR.RAW;
+    use IR.Values.COMPARE_ORDER_TO_ZERO;
+
+    use Semantic.Symbols.CLASSY_GENERIC_ARGUMENT;
+
+    // Tests for the IL lowering produced by COMPARE_ORDER_TO_ZERO, the value
+    // that wraps a non-innate `<>` (compare-order) call so its int result is
+    // mapped back to a bool. Issue #283 / PR #1235 — without this wrapper,
+    // user-defined `<>(other) -> int` returned the raw int and every `>`,
+    // `>=`, `<`, `<=` against the type evaluated as True. Each operator's
+    // mapping below is the contract: regression here would re-open #283
+    // without any high-level test failing immediately (the bug surfaces as
+    // wrong booleans, not crashes).
+    class COMPARE_ORDER_TO_ZERO_TESTS is
+        @test()
+
+        init() is si
+
+        loc() -> LOCATION => LOCATION("test.ghul", 1, 1, 1, 1);
+
+        type_bool() -> Semantic.Types.Type =>
+            CLASSY_GENERIC_ARGUMENT(loc(), null, "bool", 0).type;
+
+        gen_to_string(value: IR.Values.Value) -> string is
+            let context = IR.CONTEXT(null, null);
+            context.enter_buffer(false);
+            value.gen(context);
+            return context.leave_buffer();
+        si
+
+        Calling__gen__for_greater_than__should_emit_cgt() is
+            @test()
+
+            let value = COMPARE_ORDER_TO_ZERO(RAW("// cmp"), ">", type_bool());
+
+            // x > 0  →  cmp; ldc.i4 0; cgt
+            Assert.are_equal(
+                "// cmp\nldc.i4 0\ncgt\n",
+                gen_to_string(value)
+            );
+        si
+
+        Calling__gen__for_less_than__should_emit_clt() is
+            @test()
+
+            let value = COMPARE_ORDER_TO_ZERO(RAW("// cmp"), "<", type_bool());
+
+            // x < 0  →  cmp; ldc.i4 0; clt
+            Assert.are_equal(
+                "// cmp\nldc.i4 0\nclt\n",
+                gen_to_string(value)
+            );
+        si
+
+        Calling__gen__for_greater_or_equal__should_emit_clt_then_negate() is
+            @test()
+
+            let value = COMPARE_ORDER_TO_ZERO(RAW("// cmp"), ">=", type_bool());
+
+            // x >= 0  →  !(x < 0)  →  cmp; ldc.i4 0; clt; ldc.i4 0; ceq
+            Assert.are_equal(
+                "// cmp\nldc.i4 0\nclt\nldc.i4 0\nceq\n",
+                gen_to_string(value)
+            );
+        si
+
+        Calling__gen__for_less_or_equal__should_emit_cgt_then_negate() is
+            @test()
+
+            let value = COMPARE_ORDER_TO_ZERO(RAW("// cmp"), "<=", type_bool());
+
+            // x <= 0  →  !(x > 0)  →  cmp; ldc.i4 0; cgt; ldc.i4 0; ceq
+            Assert.are_equal(
+                "// cmp\nldc.i4 0\ncgt\nldc.i4 0\nceq\n",
+                gen_to_string(value)
+            );
+        si
+
+        Calling__gen__with_unrecognised_operation__should_throw() is
+            @test()
+
+            let value = COMPARE_ORDER_TO_ZERO(RAW("// cmp"), "?!", type_bool());
+
+            try
+                gen_to_string(value);
+                Assert.fail("expected exception for unrecognised operation");
+            catch ex: System.Exception
+                Assert.is_true(ex.message.contains("?!"));
+            yrt
+        si
+
+        is_value_type__should_be_true() is
+            @test()
+
+            // The value the wrapper produces is an int->bool comparison
+            // result, always a value type. (The is_value_type override is
+            // load-bearing because the wrapper would otherwise inherit
+            // Value's default, which derives from the inner value's type
+            // and could mis-classify when the source `<>` is on a class.)
+            let value = COMPARE_ORDER_TO_ZERO(RAW("// cmp"), ">", type_bool());
+
+            Assert.is_true(value.is_value_type);
+        si
+    si
+si

--- a/unit-tests/src/ir/values/has_value_tests.ghul
+++ b/unit-tests/src/ir/values/has_value_tests.ghul
@@ -1,0 +1,54 @@
+namespace IR.Values.UnitTests is
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    use Source.LOCATION;
+
+    use IR.RAW;
+    use IR.Values.HAS_VALUE;
+
+    use Semantic.Symbols.CLASSY_GENERIC_ARGUMENT;
+
+    class HAS_VALUE_TESTS is
+        @test()
+
+        init() is si
+
+        loc() -> LOCATION => LOCATION("test.ghul", 1, 1, 1, 1);
+
+        type_t() -> Semantic.Types.Type =>
+            CLASSY_GENERIC_ARGUMENT(loc(), null, "T", 0).type;
+
+        gen_to_string(value: IR.Values.Value) -> string is
+            let context = IR.CONTEXT(null, null);
+            context.enter_buffer(false);
+            value.gen(context);
+            return context.leave_buffer();
+        si
+
+        Calling__gen__should_emit_inner_then_ldnull_then_cgt_un() is
+            @test()
+
+            // `x?` lowers to `x; ldnull; cgt.un` — pushes 1 if the reference
+            // on the stack is non-null, 0 otherwise. The unsigned compare
+            // (cgt.un) is load-bearing: a signed cgt would treat one of
+            // null/non-null as negative depending on pointer representation
+            // and produce wrong results on 64-bit. Pinning the unsigned
+            // form catches a regression to plain `cgt`.
+            let inner = RAW("// inner-ref");
+            let value = HAS_VALUE(inner, type_t());
+
+            Assert.are_equal(
+                "// inner-ref\nldnull\ncgt.un\n",
+                gen_to_string(value)
+            );
+        si
+
+        has_type__should_be_true_when_type_is_set() is
+            @test()
+
+            let value = HAS_VALUE(RAW("// inner"), type_t());
+
+            Assert.is_true(value.has_type);
+        si
+    si
+si

--- a/unit-tests/src/ir/values/not_tests.ghul
+++ b/unit-tests/src/ir/values/not_tests.ghul
@@ -1,0 +1,35 @@
+namespace IR.Values.UnitTests is
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    use IR.RAW;
+    use IR.Values.NOT;
+
+    class NOT_TESTS is
+        @test()
+
+        init() is si
+
+        gen_to_string(value: IR.Values.Value) -> string is
+            let context = IR.CONTEXT(null, null);
+            context.enter_buffer(false);
+            value.gen(context);
+            return context.leave_buffer();
+        si
+
+        Calling__gen__should_emit_inner_then_ldc_i4_0_then_ceq() is
+            @test()
+
+            // NOT lowers `!x` to `x; ldc.i4 0; ceq` — equivalent to `x == 0`
+            // when x is a bool. Any future change that drops the comparison
+            // (e.g. assuming the inner is already a 1-bit boolean) breaks
+            // negation of typed-as-bool int values that happen to be > 1.
+            let inner = RAW("// inner-bool");
+            let value = NOT(inner);
+
+            Assert.are_equal(
+                "// inner-bool\nldc.i4 0\nceq\n",
+                gen_to_string(value)
+            );
+        si
+    si
+si

--- a/unit-tests/src/ir/values/null_tests.ghul
+++ b/unit-tests/src/ir/values/null_tests.ghul
@@ -1,0 +1,43 @@
+namespace IR.Values.UnitTests is
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    use Source.LOCATION;
+
+    use IR.Values.NULL;
+
+    use Semantic.Symbols.CLASSY_GENERIC_ARGUMENT;
+
+    class NULL_TESTS is
+        @test()
+
+        init() is si
+
+        loc() -> LOCATION => LOCATION("test.ghul", 1, 1, 1, 1);
+
+        type_t() -> Semantic.Types.Type =>
+            CLASSY_GENERIC_ARGUMENT(loc(), null, "T", 0).type;
+
+        gen_to_string(value: IR.Values.Value) -> string is
+            let context = IR.CONTEXT(null, null);
+            context.enter_buffer(false);
+            value.gen(context);
+            return context.leave_buffer();
+        si
+
+        Calling__gen__should_emit_ldnull() is
+            @test()
+
+            let value = NULL(type_t());
+
+            Assert.are_equal("ldnull\n", gen_to_string(value));
+        si
+
+        has_type__should_be_true_when_type_is_set() is
+            @test()
+
+            let value = NULL(type_t());
+
+            Assert.is_true(value.has_type);
+        si
+    si
+si

--- a/unit-tests/src/ir/values/pop_tests.ghul
+++ b/unit-tests/src/ir/values/pop_tests.ghul
@@ -1,0 +1,43 @@
+namespace IR.Values.UnitTests is
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    use Source.LOCATION;
+
+    use IR.Values.POP;
+
+    use Semantic.Symbols.CLASSY_GENERIC_ARGUMENT;
+
+    class POP_TESTS is
+        @test()
+
+        init() is si
+
+        loc() -> LOCATION => LOCATION("test.ghul", 1, 1, 1, 1);
+
+        type_t() -> Semantic.Types.Type =>
+            CLASSY_GENERIC_ARGUMENT(loc(), null, "T", 0).type;
+
+        gen_to_string(value: IR.Values.Value) -> string is
+            let context = IR.CONTEXT(null, null);
+            context.enter_buffer(false);
+            value.gen(context);
+            return context.leave_buffer();
+        si
+
+        Calling__gen__should_emit_consume_comment_naming_the_type() is
+            @test()
+
+            // POP is a sentinel — it doesn't emit `pop` itself; the actual
+            // stack consumption is handled by surrounding emission. The IL
+            // it emits is purely a comment naming the type that *would* be
+            // consumed, useful for reading generated IL but invisible at
+            // runtime. If a future refactor swaps in real `pop`, every
+            // user of POP that relies on no stack effect (e.g. discard
+            // expressions whose value the consumer has already consumed)
+            // would break silently.
+            let value = POP(type_t());
+
+            Assert.are_equal("// consume T from the stack top\n", gen_to_string(value));
+        si
+    si
+si

--- a/unit-tests/src/ir/values/unbox_tests.ghul
+++ b/unit-tests/src/ir/values/unbox_tests.ghul
@@ -1,0 +1,55 @@
+namespace IR.Values.UnitTests is
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    use Source.LOCATION;
+
+    use IR.RAW;
+    use IR.Values.UNBOX;
+
+    use Semantic.Symbols.CLASSY_GENERIC_ARGUMENT;
+
+    class UNBOX_TESTS is
+        @test()
+
+        init() is si
+
+        loc() -> LOCATION => LOCATION("test.ghul", 1, 1, 1, 1);
+
+        raw_value() -> IR.Values.Value =>
+            RAW(CLASSY_GENERIC_ARGUMENT(loc(), null, "T", 0).type, "// value");
+
+        gen_to_string(value: IR.Values.Value) -> string is
+            let context = IR.CONTEXT(null, null);
+            context.enter_buffer(false);
+            value.gen(context);
+            return context.leave_buffer();
+        si
+
+        is_value_type__should_be_true_regardless_of_inner() is
+            @test()
+
+            // UNBOX produces a value type — the dual of BOX. Always true,
+            // never delegated to the inner; the inner is always a reference
+            // by definition (you only unbox what was boxed).
+            let value = UNBOX(raw_value());
+
+            Assert.is_true(value.is_value_type);
+        si
+
+        Calling__gen__should_emit_inner_then_unbox_any_il_type() is
+            @test()
+
+            // UNBOX lowers to `value; unbox.any {il_type}`. The `.any`
+            // suffix matters: bare `unbox` returns a managed pointer to
+            // the inside of the boxed value, which is rarely what callers
+            // want. `unbox.any` does the deref and gives a value-type
+            // copy on the stack.
+            let value = UNBOX(raw_value());
+
+            Assert.are_equal(
+                "// value\nunbox.any !0 \n",
+                gen_to_string(value)
+            );
+        si
+    si
+si


### PR DESCRIPTION
Technical:
- Add unit tests under `unit-tests/src/ir/values/` for `NULL`, `POP`, `NOT`, `HAS_VALUE`, `COMPARE_ORDER_TO_ZERO`, `BOX`, `UNBOX`, `CAST`. Each pins the IL string the value emits (and, where the contract matters, the static `is_value_type` answer that downstream emission branches on). 19 new tests.
- The `COMPARE_ORDER_TO_ZERO` cases pin the four operator → IL mappings (`>`/`<`/`>=`/`<=`) the wrapper exists for; a regression on any one re-opens issue #283 silently (wrong booleans, no crash).
- Fixture pattern matches the existing symbol/type tests — direct `LOCATION` construction, `null` owner, `IR.CONTEXT(null, null)` plus `enter_buffer`/`leave_buffer` to capture IL, hand-rolled `Value` fakes for `CAST`'s value-type-inner branch.
- Pin bump 0.8.110 → 0.8.111. 124/124 unit + 648/648 integration + 6/6 project + bootstrap byte-identical (72s).