### PR TITLE
Type narrowing in if branches

### DIFF
--- a/integration-tests/execution/type-narrowing-comprehensive/ghul.json
+++ b/integration-tests/execution/type-narrowing-comprehensive/ghul.json
@@ -1,0 +1,6 @@
+{
+    "compiler": "dotnet ../../../publish/ghul.dll",
+    "source": [
+        "."
+    ]
+}

--- a/integration-tests/execution/type-narrowing-comprehensive/run.expected
+++ b/integration-tests/execution/type-narrowing-comprehensive/run.expected
@@ -1,0 +1,27 @@
+01-basic-is_xxx: 42
+02-isa-class: whiskers purrs
+03-and-chain: 7 > 0
+04-or-cancels: at least one yes (True,False)
+05-not-cancels: not-no (True)
+06-deep-outer: luna purrs
+06-deep-inner: luna is fluffy
+06-deep-outer-after: luna purrs
+07-nested-diff: nala purrs | rex barks
+07-nested-diff-outer: nala purrs
+08-sibling-cat-branch: simba purrs
+09-reassign-pre: panther purrs
+09-reassign-post: animal rex
+10-scope-inside: tom purrs
+10-scope-after: animal tom
+11-independent: misty purrs | animal buster
+12-generic-args: 1000
+13-inner-reassign: buddy purrs (a now animal rocky)
+13-inner-reassign-after-inner: animal rocky
+14-cancel-renarrow-cat: luna purrs
+14-cancel-renarrow-dog: buddy barks
+15-and-across: 20 - milo purrs
+16-destructure: a=1 b=two
+17-elif-dog: rex barks
+18-else-base: animal buddy
+19-closure: misty purrs
+20-assign-in-else: animal ginger

--- a/integration-tests/execution/type-narrowing-comprehensive/test.ghul
+++ b/integration-tests/execution/type-narrowing-comprehensive/test.ghul
@@ -1,0 +1,273 @@
+use IO.Std.write_line;
+
+union Maybe[T] is
+    YES(value: T);
+    NO;
+si
+
+union Pair[A,B] is
+    BOTH(first: A, second: B);
+    NEITHER;
+si
+
+class Animal is
+    name: string public;
+    init(name: string) is self.name = name; si
+    speak() -> string => "animal {name}";
+si
+
+class Cat: Animal is
+    init(name: string) is super.init(name); si
+    purr() -> string => "{name} purrs";
+si
+
+class Dog: Animal is
+    init(name: string) is super.init(name); si
+    bark() -> string => "{name} barks";
+si
+
+class Persian: Cat is
+    init(name: string) is super.init(name); si
+    fluff() -> string => "{name} is fluffy";
+si
+
+entry() is
+    test_basic_is_xxx();
+    test_isa_class();
+    test_and_chain();
+    test_or_cancels();
+    test_not_cancels();
+    test_nested_same_var_deep();
+    test_nested_different_vars();
+    test_sibling_branches();
+    test_reassignment_cancels();
+    test_scope_unwind();
+    test_independent_vars();
+    test_generic_args_preserved();
+    test_inner_reassign_outer_independent();
+    test_cancel_then_renarrow();
+    test_and_across_vars();
+    test_destructure_under_narrow();
+    test_elif_branch();
+    test_else_no_narrow();
+    test_closure_captures_narrow();
+    test_assignment_inside_else();
+si
+
+test_basic_is_xxx() is
+    let m: Maybe[int] = Maybe.YES[int](42);
+    if m.is_yes then
+        write_line("01-basic-is_xxx: {m.value}");
+    fi
+si
+
+test_isa_class() is
+    let a: Animal = Cat("whiskers");
+    if isa Cat(a) then
+        write_line("02-isa-class: {a.purr()}");
+    fi
+si
+
+test_and_chain() is
+    let m: Maybe[int] = Maybe.YES[int](7);
+    if m.is_yes /\ m.value > 0 then
+        write_line("03-and-chain: {m.value} > 0");
+    fi
+si
+
+test_or_cancels() is
+    // After `\/` neither side's narrowings export. m is still
+    // Maybe[int] inside the body. We exercise the wide-type API
+    // (the union has .has_value implicitly via `?`).
+    let m: Maybe[int] = Maybe.YES[int](5);
+    let n: Maybe[int] = Maybe.NO[int]();
+    if m.is_yes \/ n.is_yes then
+        write_line("04-or-cancels: at least one yes ({m?},{n?})");
+    fi
+si
+
+test_not_cancels() is
+    // V1 doesn't push the negation so `!m.is_no` body can't read
+    // m.value as int — only as the union shortcut. Print via the
+    // declared-type access (compiles either way).
+    let m: Maybe[int] = Maybe.YES[int](99);
+    if !m.is_no then
+        write_line("05-not-cancels: not-no ({m?})");
+    fi
+si
+
+test_nested_same_var_deep() is
+    // Outer narrows Animal -> Cat, inner narrows Cat -> Persian.
+    // Inside inner: Persian methods. After inner exit: Cat methods.
+    // After outer exit: Animal methods (via test_scope_unwind).
+    let a: Animal = Persian("luna");
+    if isa Cat(a) then
+        write_line("06-deep-outer: {a.purr()}");
+        if isa Persian(a) then
+            write_line("06-deep-inner: {a.fluff()}");
+        fi
+        write_line("06-deep-outer-after: {a.purr()}");
+    fi
+si
+
+test_nested_different_vars() is
+    let a: Animal = Cat("nala");
+    let b: Animal = Dog("rex");
+    if isa Cat(a) then
+        if isa Dog(b) then
+            write_line("07-nested-diff: {a.purr()} | {b.bark()}");
+        fi
+        write_line("07-nested-diff-outer: {a.purr()}");
+    fi
+si
+
+test_sibling_branches() is
+    // Two unrelated `if isa X(a)` siblings. Each narrowing is
+    // contained — second branch sees declared type at entry.
+    let a: Animal = Cat("simba");
+    if isa Dog(a) then
+        write_line("08-sibling-dog-branch: {a.bark()}");
+    fi
+    if isa Cat(a) then
+        write_line("08-sibling-cat-branch: {a.purr()}");
+    fi
+si
+
+test_reassignment_cancels() is
+    // Inside narrow, reassign with a value of the declared type.
+    // After the assignment the narrow is gone — read via Animal API.
+    let a: Animal = Cat("panther");
+    if isa Cat(a) then
+        write_line("09-reassign-pre: {a.purr()}");
+        a = Dog("rex");
+        write_line("09-reassign-post: {a.speak()}");
+    fi
+si
+
+test_scope_unwind() is
+    let a: Animal = Cat("tom");
+    if isa Cat(a) then
+        write_line("10-scope-inside: {a.purr()}");
+    fi
+    write_line("10-scope-after: {a.speak()}");
+si
+
+test_independent_vars() is
+    let a: Animal = Cat("misty");
+    let b: Animal = Dog("buster");
+    if isa Cat(a) then
+        write_line("11-independent: {a.purr()} | {b.speak()}");
+    fi
+si
+
+test_generic_args_preserved() is
+    // Narrowing a Maybe[int] should give YES[int], not raw YES.
+    // m.value's type must be int — using it as int parameter
+    // confirms the generic args carry through narrowing.
+    let m: Maybe[int] = Maybe.YES[int](500);
+    if m.is_yes then
+        let doubled: int = m.value * 2;
+        write_line("12-generic-args: {doubled}");
+    fi
+si
+
+test_inner_reassign_outer_independent() is
+    // Reassigning a's narrowed type cancels narrow for a only;
+    // b's narrow (deeper in the stack) remains.
+    let a: Animal = Cat("oreo");
+    let b: Animal = Cat("buddy");
+    if isa Cat(a) then
+        if isa Cat(b) then
+            a = Dog("rocky");
+            write_line("13-inner-reassign: {b.purr()} (a now {a.speak()})");
+        fi
+        write_line("13-inner-reassign-after-inner: {a.speak()}");
+    fi
+si
+
+test_cancel_then_renarrow() is
+    // Cancel narrow via reassignment, then re-narrow with a
+    // different isa.
+    let a: Animal = Cat("luna");
+    if isa Cat(a) then
+        write_line("14-cancel-renarrow-cat: {a.purr()}");
+        a = Dog("buddy");
+        if isa Dog(a) then
+            write_line("14-cancel-renarrow-dog: {a.bark()}");
+        fi
+    fi
+si
+
+test_and_across_vars() is
+    // AND-chain with predicates against different variables.
+    // Both narrowings export.
+    let m: Maybe[int] = Maybe.YES[int](20);
+    let a: Animal = Cat("milo");
+    if m.is_yes /\ isa Cat(a) then
+        write_line("15-and-across: {m.value} - {a.purr()}");
+    fi
+si
+
+test_destructure_under_narrow() is
+    let p: Pair[int, string] = Pair.BOTH[int, string](1, "two");
+    if p.is_both then
+        write_line(
+            let (a, b) = p in
+            "16-destructure: a={a} b={b}"
+        );
+    fi
+si
+
+test_elif_branch() is
+    // Each branch in an if-elif chain is its own narrowing scope.
+    // Reaching the elif body means the if condition was false —
+    // V1 doesn't push that as a narrowing on the elif (would need
+    // V2 negation). The elif's own predicate narrows independently.
+    let a: Animal = Dog("rex");
+    if isa Cat(a) then
+        write_line("17-elif-cat: {a.purr()}");
+    elif isa Dog(a) then
+        write_line("17-elif-dog: {a.bark()}");
+    fi
+si
+
+test_else_no_narrow() is
+    // V1 doesn't push narrowing into an `else` body; the variable
+    // shows declared type. (V2 would propagate the negated form.)
+    let a: Animal = Dog("buddy");
+    if isa Cat(a) then
+        write_line("18-else-cat: {a.purr()}");
+    else
+        write_line("18-else-base: {a.speak()}");
+    fi
+si
+
+test_closure_captures_narrow() is
+    // A lambda body walked while narrowing is in effect should
+    // capture the narrowed view — `a.purr()` typechecks because
+    // a is Cat at lambda-construction time, even though by the
+    // time the closure is invoked the narrowing scope is gone.
+    let a: Animal = Cat("misty");
+    let purrer: () -> string;
+    if isa Cat(a) then
+        purrer = () -> string => a.purr();
+    fi
+
+    if purrer? then
+        write_line("19-closure: {purrer()}");
+    fi
+si
+
+test_assignment_inside_else() is
+    // Assignment inside a branch where the variable wasn't
+    // narrowed (the else branch) is a normal assignment — no
+    // narrowing to cancel, no spurious widening. Verifies the
+    // cancel path is robust against "no save for this symbol".
+    let a: Animal = Dog("rocky");
+    if isa Cat(a) then
+        write_line("20-else-no-narrow-not-reached");
+    else
+        a = Cat("ginger");
+        write_line("20-assign-in-else: {a.speak()}");
+    fi
+si

--- a/integration-tests/execution/type-narrowing-comprehensive/test.ghulproj
+++ b/integration-tests/execution/type-narrowing-comprehensive/test.ghulproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+
+    <GhulCompiler>dotnet ghul-compiler</GhulCompiler>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <GhulSources Include="**/*.ghul" />
+    <PackageReference Include="ghul.runtime" />
+    <PackageReference Include="ghul.pipes" />
+    <PackageReference Include="ghul.targets" />
+  </ItemGroup>
+</Project>

--- a/integration-tests/execution/union-option-operators/test.ghul
+++ b/integration-tests/execution/union-option-operators/test.ghul
@@ -34,7 +34,7 @@ test_result() is
     let r_err = error("bad");
 
     if r_ok.is_ok then
-        write_line(r_ok.ok);
+        write_line(r_ok.value);
     fi;
 
     if r_err.is_error then

--- a/integration-tests/execution/unions/test.ghul
+++ b/integration-tests/execution/unions/test.ghul
@@ -27,7 +27,7 @@ test_option() is
 
     let stringify_option = (o: Option[int]) -> string rec =>
         if o.is_some then
-            let value = o.some;
+            let value = o.value;
             value.to_string()
         else
             "none"
@@ -46,7 +46,7 @@ test_list() is
 
     let stringify_list = (l: List[int]) -> string rec =>
         if l.is_cons then
-            let (head, tail) = l.cons in
+            let (head, tail) = l in
             "{head}, {rec(tail)}"
         else
             "nil"
@@ -69,7 +69,7 @@ test_tree() is
 
     let stringify_tree = (t: Tree[int]) -> string rec =>
         if t.is_node then
-            let (left, right) = t.node in
+            let (left, right) = t in
             "({rec(left)}, {rec(right)})"
         else
             "{t.leaf}"

--- a/src/ir/values/load/symbol.ghul
+++ b/src/ir/values/load/symbol.ghul
@@ -10,7 +10,24 @@ namespace IR.Values.Load is
         has_symbol: bool => symbol?;
         has_address: bool => true;
         is_consumable: bool => false;
-        type: Type => symbol_as_typed.type;
+
+        // Concrete type at construction time. Snapshotted so later
+        // mutation of `symbol.type` (e.g. type-narrowing release
+        // restoring a Variable's declared type) doesn't change the
+        // type observed by IR consumers — the load *was* of a value
+        // of `_snapshot_type`, regardless of where the symbol's
+        // type ends up later. Null when the symbol's type was an
+        // inference placeholder at load time; that case stays lazy
+        // so iterative-inference resolution still flows through.
+        _snapshot_type: Type;
+
+        type: Type =>
+            if _snapshot_type? then
+                _snapshot_type
+            else
+                symbol_as_typed.type
+            fi;
+
         from: Value;
 
         init(from: Value, symbol: SymbolBase) is
@@ -20,6 +37,12 @@ namespace IR.Values.Load is
 
             self.from = from;
             self.symbol = symbol;
+
+            let typed = cast TypeTyped(symbol);
+
+            if typed? /\ typed.type? /\ !typed.type.is_inferred /\ !typed.type.is_error then
+                _snapshot_type = typed.type;
+            fi
         si
 
         gen(context: IR.CONTEXT) is

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -15,19 +15,6 @@ namespace Syntax.Process is
 
     use Syntax.Trees.Definitions.PRAGMA;
 
-    // One save record per `push_narrowing` call. The symbol's
-    // declared type is saved here so the matching
-    // `release_narrowing_scope` can restore it.
-    class NARROWING_SAVE is
-        symbol: Semantic.Symbols.Variable public;
-        saved_type: Type public;
-
-        init(symbol: Semantic.Symbols.Variable, saved_type: Type) is
-            self.symbol = symbol;
-            self.saved_type = saved_type;
-        si
-    si
-
     class COMPILE_EXPRESSIONS: ScopedVisitor is
         _logger: Logger;
         _symbol_table: Semantic.SYMBOL_TABLE;
@@ -56,14 +43,12 @@ namespace Syntax.Process is
         // iterations (constraint accumulation needs that stability).
         _type_arg_placeholder_origins: Collections.MAP[Trees.Node, Collections.LIST[Semantic.Symbols.Variable]];
 
-        // Type narrowing — `(symbol, saved_type)` saves pushed at the
-        // point a narrowing predicate is observed during AST walk. The
-        // owning AST (IF_BRANCH body, CASE arm, WHILE body, etc.)
-        // marks the stack on entry and releases (pops + restores) on
-        // exit. Top-of-stack wins for symbol type lookups, so chained
-        // narrowings and reassignments compose naturally.
-        _narrowing_saves: Collections.LIST[NARROWING_SAVE];
-        _narrowing_marks: Collections.LIST[int];
+        // Type-narrowing stack — owns scope marks and per-symbol
+        // saves. Visit hooks (IF_BRANCH for marking, BINARY/UNARY
+        // for `\/`/`!` cancellation, ISA/MEMBER for predicate
+        // pushes, SIMPLE_LEFT_EXPRESSION for assignment cancel)
+        // delegate here. See `narrowing.ghul` for the mechanism.
+        _narrowing: NARROWING;
 
         current_statement_list: Trees.Statements.LIST;
 
@@ -98,61 +83,7 @@ namespace Syntax.Process is
 
             _type_arg_placeholder_origins = Collections.MAP[Trees.Node, Collections.LIST[Semantic.Symbols.Variable]]();
 
-            _narrowing_saves = Collections.LIST[NARROWING_SAVE]();
-            _narrowing_marks = Collections.LIST[int]();
-        si
-
-        // Mark the current narrowing stack depth — paired with
-        // `release_narrowing_scope` on the same owning AST.
-        mark_narrowing_scope() is
-            _narrowing_marks.add(_narrowing_saves.count);
-        si
-
-        // Pop the most recent mark, restoring every save pushed since.
-        // Restoration walks the stack top-down so reassignments
-        // (which push a new save over an existing one) unwind to the
-        // declared type, not an intermediate narrowed type.
-        release_narrowing_scope() is
-            assert _narrowing_marks.count > 0 else "release_narrowing_scope without matching mark";
-
-            let mark = _narrowing_marks[_narrowing_marks.count - 1];
-            _narrowing_marks.remove_at(_narrowing_marks.count - 1);
-
-            while _narrowing_saves.count > mark do
-                let last = _narrowing_saves.count - 1;
-                let save = _narrowing_saves[last];
-
-                save.symbol.set_type(save.saved_type);
-                _narrowing_saves.remove_at(last);
-            od
-        si
-
-        // Push a single narrowing — saves the symbol's current type,
-        // then mutates `symbol.type` to the narrowed type. The save
-        // is popped (and the original type restored) by the next
-        // matching `release_narrowing_scope`.
-        push_narrowing(symbol: Semantic.Symbols.Variable, narrowed_type: Type) is
-            _narrowing_saves.add(NARROWING_SAVE(symbol, symbol.type));
-            symbol.set_type(narrowed_type);
-        si
-
-        // Defensive recovery — restore every outstanding save and
-        // empty both stacks. Called at apply() boundaries so a
-        // leaked narrowing from a previous walk (e.g. one that
-        // exception'd through a missing release) doesn't poison the
-        // next compile. Walk top-down so the most recent save (which
-        // may itself overwrite an earlier save's symbol) restores to
-        // the value beneath it correctly.
-        unwind_all_narrowings() is
-            while _narrowing_saves.count > 0 do
-                let last = _narrowing_saves.count - 1;
-                let save = _narrowing_saves[last];
-
-                save.symbol.set_type(save.saved_type);
-                _narrowing_saves.remove_at(last);
-            od
-
-            _narrowing_marks.clear();
+            _narrowing = NARROWING();
         si
 
         // True if `name` looks like a synthesized variant accessor
@@ -248,103 +179,6 @@ namespace Syntax.Process is
             return null;
         si
 
-        // Push only when `narrowed` is strictly assignable-narrower
-        // than the target's current type. Skips no-ops and refuses
-        // accidental widening. Also gated on an enclosing
-        // narrowing scope being open — predicates outside any
-        // owning AST (e.g. a top-level `assert isa T(x)`) have no
-        // body that would consume the narrowing, and an unmarked
-        // push would leak past apply()'s leak asserts.
-        try_push_narrowing(target: Semantic.Symbols.Variable, narrowed: Type) is
-            if _narrowing_marks.count == 0 then
-                return;
-            fi
-
-            if !target? \/ !narrowed? \/ !target.type? then
-                return;
-            fi
-
-            if narrowed.is_error \/ narrowed.is_inferred then
-                return;
-            fi
-
-            if target.type =~ narrowed then
-                return;
-            fi
-
-            if !target.type.is_assignable_from(narrowed) then
-                return;
-            fi
-
-            push_narrowing(target, narrowed);
-        si
-
-        // Bottommost narrowing save for `target` carries its type
-        // before any narrowing pushed — i.e. its declared type.
-        // Returns the declared type for an actively narrowed
-        // variable; falls back to `target.type` when no save exists.
-        // Used to bypass narrowing for assignment LHS checks: a
-        // user reassignment inside a narrowing branch must
-        // typecheck against the variable's declared type, not the
-        // narrowed view, or `if isa T(x) then x = wider_value`
-        // patterns (idiomatic across the codebase) would fail.
-        get_declared_type_of(target: Semantic.Symbols.Variable) -> Type is
-            if !target? then
-                return null;
-            fi
-
-            for save in _narrowing_saves do
-                if save.symbol == target then
-                    return save.saved_type;
-                fi
-            od
-
-            return target.type;
-        si
-
-        // Drop every narrowing save covering `target` and restore
-        // its type to the declared type. Called after a successful
-        // reassignment to a narrowed variable: the narrow may no
-        // longer hold, so subsequent reads in the same scope must
-        // observe the declared type. Saves higher up the stack for
-        // *other* symbols are preserved; only `target`'s saves are
-        // collapsed — release_narrowing_scope's mark/depth book-
-        // keeping copes with a sparser saves list.
-        cancel_narrowing_for(target: Semantic.Symbols.Variable) is
-            if !target? then
-                return;
-            fi
-
-            let declared = get_declared_type_of(target);
-
-            // Walk top-down: removing index-i shifts later indices,
-            // and we want to keep the marks list stable. Decrement
-            // each mark by the number of saves removed below it.
-            let i = _narrowing_saves.count - 1;
-
-            while i >= 0 do
-                let save = _narrowing_saves[i];
-
-                if save.symbol == target then
-                    _narrowing_saves.remove_at(i);
-
-                    let m = 0;
-                    while m < _narrowing_marks.count do
-                        if _narrowing_marks[m] > i then
-                            _narrowing_marks[m] = _narrowing_marks[m] - 1;
-                        fi
-                        m = m + 1;
-                    od
-                fi
-
-                i = i - 1;
-            od
-
-            if declared? then
-                target.set_type(declared);
-            fi
-        si
-
         apply(root: Trees.Node) is
             assert _keep_depth == 0;
             assert _stub_depth == 0;
@@ -376,16 +210,16 @@ namespace Syntax.Process is
             // so a leaked narrowing doesn't poison subsequent runs of
             // the same compiler instance — restores symbol types as
             // it goes, not just clears the stacks.
-            unwind_all_narrowings();
+            _narrowing.unwind_all();
 
             root.walk(self);
 
             assert _keep_depth == 0;
             assert _stub_depth == 0;
-            assert _narrowing_saves.count == 0
-                else "narrowing saves stack leaked: {_narrowing_saves.count} unreleased";
-            assert _narrowing_marks.count == 0
-                else "narrowing marks stack leaked: {_narrowing_marks.count} unreleased";
+            assert _narrowing.saves_count == 0
+                else "narrowing saves stack leaked: {_narrowing.saves_count} unreleased";
+            assert _narrowing.marks_count == 0
+                else "narrowing marks stack leaked: {_narrowing.marks_count} unreleased";
         si
 
         should_skip(node: Trees.Node) -> bool => _stub_depth > 0 \/ is_stable(node);
@@ -772,7 +606,7 @@ namespace Syntax.Process is
             let target_variable = try_get_narrowing_target(left.expression);
             let lhs_type =
                 if target_variable? then
-                    get_declared_type_of(target_variable)
+                    _narrowing.declared_type_of(target_variable)
                 else
                     left.expression.value.type
                 fi;
@@ -789,7 +623,7 @@ namespace Syntax.Process is
             // reads in the same scope should observe the declared
             // type. Saves for *other* symbols stay in place.
             if target_variable? then
-                cancel_narrowing_for(target_variable);
+                _narrowing.cancel_for(target_variable);
             fi
         si
         
@@ -1017,7 +851,7 @@ namespace Syntax.Process is
 
                     type =
                         if target_variable? then
-                            get_declared_type_of(target_variable)
+                            _narrowing.declared_type_of(target_variable)
                         else
                             simple.expression.value.type
                         fi;
@@ -1278,11 +1112,11 @@ namespace Syntax.Process is
             // condition so any predicates the cond observes push
             // saves into this branch's frame; the matching release
             // in visit() pops them once the body has been walked.
-            mark_narrowing_scope();
+            _narrowing.mark_scope();
         si
 
         visit(`if: Trees.Statements.IF_BRANCH) is
-            release_narrowing_scope();
+            _narrowing.release_scope();
 
             if
                 `if? /\
@@ -2073,7 +1907,7 @@ namespace Syntax.Process is
                     `isa.right.value
                 );
 
-            try_push_narrowing(
+            _narrowing.try_push(
                 try_get_narrowing_target(`isa.right),
                 isa_type
             );
@@ -2611,12 +2445,12 @@ namespace Syntax.Process is
             // smart-merge LUB machinery deferred to v2.
             if unary.operation? /\ unary.operation.name =~ "!" then
                 if unary.right? then
-                    mark_narrowing_scope();
+                    _narrowing.mark_scope();
 
                     try
                         unary.right.walk(self);
                     finally
-                        release_narrowing_scope();
+                        _narrowing.release_scope();
                     yrt
                 fi
 
@@ -2682,22 +2516,22 @@ namespace Syntax.Process is
             // and generic-args axes.
             if binary.operation? /\ binary.operation.name =~ "\\/" then
                 if binary.left? then
-                    mark_narrowing_scope();
+                    _narrowing.mark_scope();
 
                     try
                         binary.left.walk(self);
                     finally
-                        release_narrowing_scope();
+                        _narrowing.release_scope();
                     yrt
                 fi
 
                 if binary.right? then
-                    mark_narrowing_scope();
+                    _narrowing.mark_scope();
 
                     try
                         binary.right.walk(self);
                     finally
-                        release_narrowing_scope();
+                        _narrowing.release_scope();
                     yrt
                 fi
 
@@ -3091,7 +2925,7 @@ namespace Syntax.Process is
                 member.value = value;
 
                 if !need_store /\ is_variant_accessor_name(member.identifier.name) then
-                    try_push_narrowing(
+                    _narrowing.try_push(
                         try_get_narrowing_target(member.left),
                         try_get_variant_type_for_is_accessor(named_type, member.identifier.name)
                     );

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -155,6 +155,196 @@ namespace Syntax.Process is
             _narrowing_marks.clear();
         si
 
+        // True if `name` looks like a synthesized variant accessor
+        // (`is_<lowercased_variant_name>`) — i.e. starts with `is_`
+        // and has at least one suffix character.
+        is_variant_accessor_name(name: string) -> bool =>
+            name? /\ name.length > 3 /\ name.starts_with("is_");
+
+        // If `expr` is an unqualified identifier resolving (in the
+        // current scope) to a Variable, return that Variable; null
+        // otherwise. Caller-bounded to predicates whose narrowing
+        // target must be a simple-identifier — qualified or
+        // member-access targets are v1-deferred.
+        try_get_narrowing_target(expr: Trees.Expressions.Expression) -> Semantic.Symbols.Variable is
+            if !expr? \/ !isa Trees.Expressions.IDENTIFIER(expr) then
+                return null;
+            fi
+
+            let identifier_expr = cast Trees.Expressions.IDENTIFIER(expr);
+
+            if !identifier_expr.identifier? \/ identifier_expr.identifier.is_qualified then
+                return null;
+            fi
+
+            let symbol = find(identifier_expr.identifier);
+
+            if !symbol? \/ !isa Semantic.Symbols.Variable(symbol) then
+                return null;
+            fi
+
+            return cast Semantic.Symbols.Variable(symbol);
+        si
+
+        // Drill `type` to the underlying Classy (peeling Symbols.GENERIC
+        // wrapping for specialized generics). Null if `type` isn't a
+        // NAMED of a Classy.
+        get_classy_for_narrowing(type: Type) -> Semantic.Symbols.Classy is
+            if !type? \/ !isa Semantic.Types.NAMED(type) then
+                return null;
+            fi
+
+            let symbol = (cast Semantic.Types.NAMED(type)).symbol;
+
+            if isa Semantic.Symbols.GENERIC(symbol) then
+                symbol = (cast Semantic.Symbols.GENERIC(symbol)).symbol;
+            fi
+
+            if !isa Semantic.Symbols.Classy(symbol) then
+                return null;
+            fi
+
+            return cast Semantic.Symbols.Classy(symbol);
+        si
+
+        // For an `is_<variant>` access on a value of union type,
+        // return the variant type with the same generic args as the
+        // receiver. Null if the receiver isn't a union, or no variant
+        // matches the suffix.
+        try_get_variant_type_for_is_accessor(
+            receiver_type: Type,
+            member_name: string
+        ) -> Type is
+            if !is_variant_accessor_name(member_name) then
+                return null;
+            fi
+
+            let classy = get_classy_for_narrowing(receiver_type);
+
+            if !classy? \/ !classy.is_union then
+                return null;
+            fi
+
+            let suffix = member_name.substring(3);
+
+            for s in classy.symbols do
+                if s? /\ s.is_variant /\ s.name? /\ s.name.to_lower_invariant() =~ suffix then
+                    let variant = cast Semantic.Symbols.Classy(s);
+
+                    if isa Semantic.Types.GENERIC(receiver_type) then
+                        let generic_receiver = cast Semantic.Types.GENERIC(receiver_type);
+
+                        return Semantic.Types.GENERIC(
+                            variant.location,
+                            variant,
+                            generic_receiver.arguments
+                        );
+                    else
+                        return Semantic.Types.NAMED(variant);
+                    fi
+                fi
+            od
+
+            return null;
+        si
+
+        // Push only when `narrowed` is strictly assignable-narrower
+        // than the target's current type. Skips no-ops and refuses
+        // accidental widening. Also gated on an enclosing
+        // narrowing scope being open — predicates outside any
+        // owning AST (e.g. a top-level `assert isa T(x)`) have no
+        // body that would consume the narrowing, and an unmarked
+        // push would leak past apply()'s leak asserts.
+        try_push_narrowing(target: Semantic.Symbols.Variable, narrowed: Type) is
+            if _narrowing_marks.count == 0 then
+                return;
+            fi
+
+            if !target? \/ !narrowed? \/ !target.type? then
+                return;
+            fi
+
+            if narrowed.is_error \/ narrowed.is_inferred then
+                return;
+            fi
+
+            if target.type =~ narrowed then
+                return;
+            fi
+
+            if !target.type.is_assignable_from(narrowed) then
+                return;
+            fi
+
+            push_narrowing(target, narrowed);
+        si
+
+        // Bottommost narrowing save for `target` carries its type
+        // before any narrowing pushed — i.e. its declared type.
+        // Returns the declared type for an actively narrowed
+        // variable; falls back to `target.type` when no save exists.
+        // Used to bypass narrowing for assignment LHS checks: a
+        // user reassignment inside a narrowing branch must
+        // typecheck against the variable's declared type, not the
+        // narrowed view, or `if isa T(x) then x = wider_value`
+        // patterns (idiomatic across the codebase) would fail.
+        get_declared_type_of(target: Semantic.Symbols.Variable) -> Type is
+            if !target? then
+                return null;
+            fi
+
+            for save in _narrowing_saves do
+                if save.symbol == target then
+                    return save.saved_type;
+                fi
+            od
+
+            return target.type;
+        si
+
+        // Drop every narrowing save covering `target` and restore
+        // its type to the declared type. Called after a successful
+        // reassignment to a narrowed variable: the narrow may no
+        // longer hold, so subsequent reads in the same scope must
+        // observe the declared type. Saves higher up the stack for
+        // *other* symbols are preserved; only `target`'s saves are
+        // collapsed — release_narrowing_scope's mark/depth book-
+        // keeping copes with a sparser saves list.
+        cancel_narrowing_for(target: Semantic.Symbols.Variable) is
+            if !target? then
+                return;
+            fi
+
+            let declared = get_declared_type_of(target);
+
+            // Walk top-down: removing index-i shifts later indices,
+            // and we want to keep the marks list stable. Decrement
+            // each mark by the number of saves removed below it.
+            let i = _narrowing_saves.count - 1;
+
+            while i >= 0 do
+                let save = _narrowing_saves[i];
+
+                if save.symbol == target then
+                    _narrowing_saves.remove_at(i);
+
+                    let m = 0;
+                    while m < _narrowing_marks.count do
+                        if _narrowing_marks[m] > i then
+                            _narrowing_marks[m] = _narrowing_marks[m] - 1;
+                        fi
+                        m = m + 1;
+                    od
+                fi
+
+                i = i - 1;
+            od
+
+            if declared? then
+                target.set_type(declared);
+            fi
+        si
+
         apply(root: Trees.Node) is
             assert _keep_depth == 0;
             assert _stub_depth == 0;
@@ -574,12 +764,33 @@ namespace Syntax.Process is
                 return;
             fi
 
-            if !left.expression.value.type.is_assignable_from(left.value.type) then
-                _logger.error(left.assign_location, "{left.value.type} is not assignable to {left.expression.value.type}");
+            // Bypass narrowing for assignability — the LHS value's
+            // type may be a narrowed view, but assignment must
+            // typecheck against the variable's declared type, or
+            // `if isa T(x) then x = wider_value` (idiomatic across
+            // the codebase) would fail at the narrow.
+            let target_variable = try_get_narrowing_target(left.expression);
+            let lhs_type =
+                if target_variable? then
+                    get_declared_type_of(target_variable)
+                else
+                    left.expression.value.type
+                fi;
+
+            if !lhs_type.is_assignable_from(left.value.type) then
+                _logger.error(left.assign_location, "{left.value.type} is not assignable to {lhs_type}");
                 return;
             fi
 
             left.value = left.expression.value;
+
+            // Reassignment cancels narrowing for the target — the
+            // new value may not satisfy the narrow, so subsequent
+            // reads in the same scope should observe the declared
+            // type. Saves for *other* symbols stay in place.
+            if target_variable? then
+                cancel_narrowing_for(target_variable);
+            fi
         si
         
         get_conventionally_named_destructure_member_types(type: Type) -> Collections.List[Type] is
@@ -802,7 +1013,14 @@ namespace Syntax.Process is
                 simple.expression.walk(self);
 
                 if simple.expression.value? /\ simple.expression.value.type? /\ !simple.expression.value.type.is_error then
-                    type = simple.expression.value.type;
+                    let target_variable = try_get_narrowing_target(simple.expression);
+
+                    type =
+                        if target_variable? then
+                            get_declared_type_of(target_variable)
+                        else
+                            simple.expression.value.type
+                        fi;
                 fi
 
                 _logger.roll_back();
@@ -1053,7 +1271,19 @@ namespace Syntax.Process is
             super.visit(`do);
         si
 
+        pre(`if: Trees.Statements.IF_BRANCH) -> bool is
+            super.pre(`if);
+
+            // Mark the narrowing scope before walking the
+            // condition so any predicates the cond observes push
+            // saves into this branch's frame; the matching release
+            // in visit() pops them once the body has been walked.
+            mark_narrowing_scope();
+        si
+
         visit(`if: Trees.Statements.IF_BRANCH) is
+            release_narrowing_scope();
+
             if
                 `if? /\
                 `if.condition? /\
@@ -1839,9 +2069,14 @@ namespace Syntax.Process is
             `isa.value =
                 ISA(
                     bool_type,
-                    isa_type,                     
+                    isa_type,
                     `isa.right.value
                 );
+
+            try_push_narrowing(
+                try_get_narrowing_target(`isa.right),
+                isa_type
+            );
         si
 
         visit(`typeof: Trees.Expressions.TYPEOF) is
@@ -2369,6 +2604,28 @@ namespace Syntax.Process is
             return (cast Value(Load.SYMBOL(null, function_group)), cast Value(NEW(type, function, arguments)));
         si
 
+        pre(unary: Trees.Expressions.UNARY) -> bool is
+            // `!` cancels narrowings observed in its operand —
+            // a v1 conservative choice, since the negation form
+            // (e.g. `!x.is_some` ⇒ `x` is `NONE`) would need the
+            // smart-merge LUB machinery deferred to v2.
+            if unary.operation? /\ unary.operation.name =~ "!" then
+                if unary.right? then
+                    mark_narrowing_scope();
+
+                    try
+                        unary.right.walk(self);
+                    finally
+                        release_narrowing_scope();
+                    yrt
+                fi
+
+                return true;
+            fi
+
+            return false;
+        si
+
         visit(unary: Trees.Expressions.UNARY) is
             unary.value = null;
 
@@ -2416,12 +2673,46 @@ namespace Syntax.Process is
             fi
         si        
 
+        pre(binary: Trees.Expressions.BINARY) -> bool is
+            // `\/` (OR) — cancel each side's narrowings during
+            // walk so the right operand evaluates as if the left
+            // was false, and so neither side leaks predicates into
+            // the surrounding (post-OR) context. v2 will replace
+            // this with a smart-merge along the variant-identity
+            // and generic-args axes.
+            if binary.operation? /\ binary.operation.name =~ "\\/" then
+                if binary.left? then
+                    mark_narrowing_scope();
+
+                    try
+                        binary.left.walk(self);
+                    finally
+                        release_narrowing_scope();
+                    yrt
+                fi
+
+                if binary.right? then
+                    mark_narrowing_scope();
+
+                    try
+                        binary.right.walk(self);
+                    finally
+                        release_narrowing_scope();
+                    yrt
+                fi
+
+                return true;
+            fi
+
+            return false;
+        si
+
         visit(binary: Trees.Expressions.BINARY) is
             try
                 _visit(binary);
             catch ex: Exception
                 _logger.exception(binary.location, ex, "exception compiling binary operator (called from {System.Diagnostics.StackTrace().to_string().replace_line_endings(" ")})");
-            yrt            
+            yrt
         si
 
         _visit(binary: Trees.Expressions.BINARY) is
@@ -2798,6 +3089,13 @@ namespace Syntax.Process is
                 fi
 
                 member.value = value;
+
+                if !need_store /\ is_variant_accessor_name(member.identifier.name) then
+                    try_push_narrowing(
+                        try_get_narrowing_target(member.left),
+                        try_get_variant_type_for_is_accessor(named_type, member.identifier.name)
+                    );
+                fi
             fi
         si
 

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -15,6 +15,19 @@ namespace Syntax.Process is
 
     use Syntax.Trees.Definitions.PRAGMA;
 
+    // One save record per `push_narrowing` call. The symbol's
+    // declared type is saved here so the matching
+    // `release_narrowing_scope` can restore it.
+    class NARROWING_SAVE is
+        symbol: Semantic.Symbols.Variable public;
+        saved_type: Type public;
+
+        init(symbol: Semantic.Symbols.Variable, saved_type: Type) is
+            self.symbol = symbol;
+            self.saved_type = saved_type;
+        si
+    si
+
     class COMPILE_EXPRESSIONS: ScopedVisitor is
         _logger: Logger;
         _symbol_table: Semantic.SYMBOL_TABLE;
@@ -42,6 +55,15 @@ namespace Syntax.Process is
         // is the body retry loop's lifecycle, so origins persist across
         // iterations (constraint accumulation needs that stability).
         _type_arg_placeholder_origins: Collections.MAP[Trees.Node, Collections.LIST[Semantic.Symbols.Variable]];
+
+        // Type narrowing — `(symbol, saved_type)` saves pushed at the
+        // point a narrowing predicate is observed during AST walk. The
+        // owning AST (IF_BRANCH body, CASE arm, WHILE body, etc.)
+        // marks the stack on entry and releases (pops + restores) on
+        // exit. Top-of-stack wins for symbol type lookups, so chained
+        // narrowings and reassignments compose naturally.
+        _narrowing_saves: Collections.LIST[NARROWING_SAVE];
+        _narrowing_marks: Collections.LIST[int];
 
         current_statement_list: Trees.Statements.LIST;
 
@@ -75,6 +97,62 @@ namespace Syntax.Process is
             _value_boxer = value_boxer;
 
             _type_arg_placeholder_origins = Collections.MAP[Trees.Node, Collections.LIST[Semantic.Symbols.Variable]]();
+
+            _narrowing_saves = Collections.LIST[NARROWING_SAVE]();
+            _narrowing_marks = Collections.LIST[int]();
+        si
+
+        // Mark the current narrowing stack depth — paired with
+        // `release_narrowing_scope` on the same owning AST.
+        mark_narrowing_scope() is
+            _narrowing_marks.add(_narrowing_saves.count);
+        si
+
+        // Pop the most recent mark, restoring every save pushed since.
+        // Restoration walks the stack top-down so reassignments
+        // (which push a new save over an existing one) unwind to the
+        // declared type, not an intermediate narrowed type.
+        release_narrowing_scope() is
+            assert _narrowing_marks.count > 0 else "release_narrowing_scope without matching mark";
+
+            let mark = _narrowing_marks[_narrowing_marks.count - 1];
+            _narrowing_marks.remove_at(_narrowing_marks.count - 1);
+
+            while _narrowing_saves.count > mark do
+                let last = _narrowing_saves.count - 1;
+                let save = _narrowing_saves[last];
+
+                save.symbol.set_type(save.saved_type);
+                _narrowing_saves.remove_at(last);
+            od
+        si
+
+        // Push a single narrowing — saves the symbol's current type,
+        // then mutates `symbol.type` to the narrowed type. The save
+        // is popped (and the original type restored) by the next
+        // matching `release_narrowing_scope`.
+        push_narrowing(symbol: Semantic.Symbols.Variable, narrowed_type: Type) is
+            _narrowing_saves.add(NARROWING_SAVE(symbol, symbol.type));
+            symbol.set_type(narrowed_type);
+        si
+
+        // Defensive recovery — restore every outstanding save and
+        // empty both stacks. Called at apply() boundaries so a
+        // leaked narrowing from a previous walk (e.g. one that
+        // exception'd through a missing release) doesn't poison the
+        // next compile. Walk top-down so the most recent save (which
+        // may itself overwrite an earlier save's symbol) restores to
+        // the value beneath it correctly.
+        unwind_all_narrowings() is
+            while _narrowing_saves.count > 0 do
+                let last = _narrowing_saves.count - 1;
+                let save = _narrowing_saves[last];
+
+                save.symbol.set_type(save.saved_type);
+                _narrowing_saves.remove_at(last);
+            od
+
+            _narrowing_marks.clear();
         si
 
         apply(root: Trees.Node) is
@@ -99,10 +177,25 @@ namespace Syntax.Process is
             // the start of apply is safe.
             _type_arg_placeholder_origins.clear();
 
+            // Narrowing stack must be empty at apply() boundaries —
+            // every push has to be balanced by a release before its
+            // owning AST exits. A leak here means a `pre`/`visit` pair
+            // got out of step (likely an early return / exception that
+            // skipped a release) and would surface as confusing
+            // type-mismatch errors on later walks. Unwind defensively
+            // so a leaked narrowing doesn't poison subsequent runs of
+            // the same compiler instance — restores symbol types as
+            // it goes, not just clears the stacks.
+            unwind_all_narrowings();
+
             root.walk(self);
 
             assert _keep_depth == 0;
             assert _stub_depth == 0;
+            assert _narrowing_saves.count == 0
+                else "narrowing saves stack leaked: {_narrowing_saves.count} unreleased";
+            assert _narrowing_marks.count == 0
+                else "narrowing marks stack leaked: {_narrowing_marks.count} unreleased";
         si
 
         should_skip(node: Trees.Node) -> bool => _stub_depth > 0 \/ is_stable(node);

--- a/src/syntax/process/narrowing.ghul
+++ b/src/syntax/process/narrowing.ghul
@@ -1,0 +1,191 @@
+namespace Syntax.Process is
+    use Semantic.Types.Type;
+
+    // One save record per `NARROWING.push` call. Captures the
+    // symbol's type before narrowing so the matching scope
+    // release can restore it.
+    class NARROWING_SAVE is
+        symbol: Semantic.Symbols.Variable public;
+        saved_type: Type public;
+
+        init(symbol: Semantic.Symbols.Variable, saved_type: Type) is
+            self.symbol = symbol;
+            self.saved_type = saved_type;
+        si
+    si
+
+    // Type-narrowing stack: a list of save records and a parallel
+    // list of marks. An owning AST (IF_BRANCH body, BINARY's `\/`
+    // operands, UNARY's `!` operand) calls `mark_scope` on entry
+    // and `release_scope` on exit — release pops every save above
+    // the most recent mark, restoring the affected symbols' types
+    // top-down so reassignments unwind through any narrowed
+    // shadows correctly.
+    //
+    // Predicates (HAS_VALUE, ISA, MEMBER for `is_xxx`) call
+    // `try_push` at observation. AND chains compose because each
+    // leaf push lands on the same scope; OR/NOT shape what
+    // survives by bracketing each operand walk in its own scope.
+    //
+    // Direct symbol-type mutation is the lookup mechanism — the
+    // narrowed type is what the variable's `Variable.type` reads
+    // until release. `Load.SYMBOL` snapshots that type at
+    // construction so reads compiled inside a narrowing scope
+    // carry through to IL gen unchanged after release.
+    class NARROWING is
+        _saves: Collections.LIST[NARROWING_SAVE];
+        _marks: Collections.LIST[int];
+
+        has_open_scope: bool => _marks.count > 0;
+        is_empty: bool => _saves.count == 0 /\ _marks.count == 0;
+        saves_count: int => _saves.count;
+        marks_count: int => _marks.count;
+
+        init() is
+            _saves = Collections.LIST[NARROWING_SAVE]();
+            _marks = Collections.LIST[int]();
+        si
+
+        // Mark the current stack depth — paired with `release_scope`
+        // on the same owning AST.
+        mark_scope() is
+            _marks.add(_saves.count);
+        si
+
+        // Pop the most recent mark, restoring every save pushed since.
+        // Walks top-down so reassignments (which push fresh saves
+        // over an existing one) unwind to the declared type, not
+        // an intermediate narrowed type.
+        release_scope() is
+            assert _marks.count > 0 else "NARROWING.release_scope without matching mark";
+
+            let mark = _marks[_marks.count - 1];
+            _marks.remove_at(_marks.count - 1);
+
+            while _saves.count > mark do
+                let last = _saves.count - 1;
+                let save = _saves[last];
+
+                save.symbol.set_type(save.saved_type);
+                _saves.remove_at(last);
+            od
+        si
+
+        // Push a fresh save and mutate the target's type. The save
+        // is popped — and the original type restored — by the next
+        // `release_scope` whose mark sits below this push.
+        push(target: Semantic.Symbols.Variable, narrowed_type: Type) is
+            _saves.add(NARROWING_SAVE(target, target.type));
+            target.set_type(narrowed_type);
+        si
+
+        // Push only when `narrowed_type` is strictly assignable-
+        // narrower than the target's current type, and an enclosing
+        // narrowing scope is open. The scope gate prevents leaks
+        // past the visitor's apply()-level invariant — predicates
+        // observed outside any owning AST have no body that would
+        // consume the narrow.
+        try_push(target: Semantic.Symbols.Variable, narrowed_type: Type) is
+            if _marks.count == 0 then
+                return;
+            fi
+
+            if !target? \/ !narrowed_type? \/ !target.type? then
+                return;
+            fi
+
+            if narrowed_type.is_error \/ narrowed_type.is_inferred then
+                return;
+            fi
+
+            if target.type =~ narrowed_type then
+                return;
+            fi
+
+            if !target.type.is_assignable_from(narrowed_type) then
+                return;
+            fi
+
+            push(target, narrowed_type);
+        si
+
+        // Defensive recovery — restore every outstanding save and
+        // empty both stacks. Walks top-down so the most recent save
+        // (which may itself overwrite an earlier save's symbol)
+        // restores to the value beneath it correctly. Called at
+        // visitor apply() boundaries so a leak from a previous walk
+        // doesn't poison the next compile.
+        unwind_all() is
+            while _saves.count > 0 do
+                let last = _saves.count - 1;
+                let save = _saves[last];
+
+                save.symbol.set_type(save.saved_type);
+                _saves.remove_at(last);
+            od
+
+            _marks.clear();
+        si
+
+        // Bottommost save for `target` carries the type before any
+        // narrowing pushed for that variable — i.e. its declared
+        // type at the point narrowing first kicked in. Falls back
+        // to `target.type` when no save exists. Used to bypass
+        // narrowing for assignment LHS checks: a user reassignment
+        // inside a narrowing branch must typecheck against the
+        // variable's declared type, not the narrowed view, or
+        // `if isa T(x) then x = wider_value` (idiomatic across the
+        // codebase) would fail.
+        declared_type_of(target: Semantic.Symbols.Variable) -> Type is
+            if !target? then
+                return null;
+            fi
+
+            for save in _saves do
+                if save.symbol == target then
+                    return save.saved_type;
+                fi
+            od
+
+            return target.type;
+        si
+
+        // Drop every save covering `target` and restore its type to
+        // the declared type. Called after a successful reassignment
+        // to a narrowed variable: the narrow may no longer hold, so
+        // subsequent reads in the same scope must observe the
+        // declared type. Saves for *other* symbols stay in place;
+        // mark depths shift down to match the sparser saves list.
+        cancel_for(target: Semantic.Symbols.Variable) is
+            if !target? then
+                return;
+            fi
+
+            let declared = declared_type_of(target);
+
+            let i = _saves.count - 1;
+
+            while i >= 0 do
+                let save = _saves[i];
+
+                if save.symbol == target then
+                    _saves.remove_at(i);
+
+                    let m = 0;
+                    while m < _marks.count do
+                        if _marks[m] > i then
+                            _marks[m] = _marks[m] - 1;
+                        fi
+                        m = m + 1;
+                    od
+                fi
+
+                i = i - 1;
+            od
+
+            if declared? then
+                target.set_type(declared);
+            fi
+        si
+    si
+si

--- a/unit-tests/src/syntax/process/narrowing_tests.ghul
+++ b/unit-tests/src/syntax/process/narrowing_tests.ghul
@@ -1,0 +1,356 @@
+namespace Syntax.Process.UnitTests is
+    use Collections.LIST;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    use Source.LOCATION;
+
+    use Semantic.Symbols.CLASS;
+    use Semantic.Symbols.CLASSY_GENERIC_ARGUMENT;
+    use Semantic.Symbols.Variable;
+    use Semantic.Types.Type;
+
+    // Tests for the NARROWING helper — mark/release scoping, push
+    // saves, declared-type lookup, per-symbol cancellation. The
+    // helper is decoupled from the visitor's scope lookup and AST
+    // walk, so these tests construct Variable instances directly
+    // and exercise the stack mechanics in isolation.
+    class NARROWING_TESTS is
+        @test()
+
+        init() is si
+
+        loc() -> LOCATION => LOCATION("test.ghul", 1, 1, 1, 1);
+
+        empty_names() -> LIST[string] => LIST[string]();
+
+        // Owner for free variables in tests. A non-generic CLASS
+        // suffices — the saves stack only keys by Variable identity,
+        // not by lexical structure.
+        make_owner() -> CLASS => CLASS(loc(), loc(), null, "TestOwner", empty_names(), false, null);
+
+        // A distinct Type for each call. CLASSY_GENERIC_ARGUMENT.type
+        // gives a NAMED, but identity is what we care about: each
+        // call returns a fresh symbol whose `=~` and `is_assignable_from`
+        // produce DIFFERENT against any other symbol's type.
+        make_type(name: string) -> Type =>
+            CLASSY_GENERIC_ARGUMENT(loc(), null, name, 0).type;
+
+        // A free Variable preloaded with `t` as its type. The owner
+        // is shared across vars in a single test — irrelevant to
+        // anything NARROWING does.
+        make_var(owner: CLASS, name: string, t: Type) -> Variable is
+            let v = Variable(loc(), owner, name);
+            v.set_type(t);
+            return v;
+        si
+
+        Empty_NARROWING_should_report_empty() is
+            @test()
+
+            let n = NARROWING();
+
+            Assert.is_true(n.is_empty);
+            Assert.is_false(n.has_open_scope);
+            Assert.are_equal(0, n.saves_count);
+            Assert.are_equal(0, n.marks_count);
+        si
+
+        Mark_then_release_with_no_pushes_should_leave_state_empty() is
+            @test()
+
+            let n = NARROWING();
+
+            n.mark_scope();
+            Assert.is_true(n.has_open_scope);
+            Assert.are_equal(1, n.marks_count);
+
+            n.release_scope();
+
+            Assert.is_true(n.is_empty);
+        si
+
+        Push_inside_scope_then_release_should_restore_type() is
+            @test()
+
+            let owner = make_owner();
+            let t_declared = make_type("Declared");
+            let t_narrowed = make_type("Narrowed");
+
+            let v = make_var(owner, "x", t_declared);
+            let n = NARROWING();
+
+            n.mark_scope();
+            n.push(v, t_narrowed);
+
+            Assert.are_same(t_narrowed, v.type);
+
+            n.release_scope();
+
+            Assert.are_same(t_declared, v.type);
+            Assert.is_true(n.is_empty);
+        si
+
+        Multiple_pushes_in_one_scope_should_all_restore() is
+            @test()
+
+            let owner = make_owner();
+            let t_a = make_type("A");
+            let t_b = make_type("B");
+            let t_a_narrow = make_type("ANarrow");
+            let t_b_narrow = make_type("BNarrow");
+
+            let a = make_var(owner, "a", t_a);
+            let b = make_var(owner, "b", t_b);
+            let n = NARROWING();
+
+            n.mark_scope();
+            n.push(a, t_a_narrow);
+            n.push(b, t_b_narrow);
+
+            Assert.are_same(t_a_narrow, a.type);
+            Assert.are_same(t_b_narrow, b.type);
+
+            n.release_scope();
+
+            Assert.are_same(t_a, a.type);
+            Assert.are_same(t_b, b.type);
+        si
+
+        Nested_scopes_should_unwind_independently() is
+            @test()
+
+            let owner = make_owner();
+            let t_outer = make_type("Outer");
+            let t_inner = make_type("Inner");
+            let t_deeper = make_type("Deeper");
+
+            let v = make_var(owner, "v", t_outer);
+            let n = NARROWING();
+
+            n.mark_scope();
+            n.push(v, t_inner);
+            Assert.are_same(t_inner, v.type);
+
+            n.mark_scope();
+            n.push(v, t_deeper);
+            Assert.are_same(t_deeper, v.type);
+
+            n.release_scope();
+            Assert.are_same(t_inner, v.type);
+
+            n.release_scope();
+            Assert.are_same(t_outer, v.type);
+        si
+
+        Same_symbol_pushed_twice_then_released_should_restore_to_outer() is
+            @test()
+
+            // Two saves for the same variable in one scope (e.g.
+            // narrow then reassignment-shaped second push). Release
+            // walks top-down so the bottom save's saved_type wins —
+            // i.e. the original declared type.
+            let owner = make_owner();
+            let t_declared = make_type("Declared");
+            let t_first = make_type("First");
+            let t_second = make_type("Second");
+
+            let v = make_var(owner, "v", t_declared);
+            let n = NARROWING();
+
+            n.mark_scope();
+            n.push(v, t_first);
+            n.push(v, t_second);
+
+            Assert.are_same(t_second, v.type);
+
+            n.release_scope();
+
+            Assert.are_same(t_declared, v.type);
+        si
+
+        declared_type_of_should_return_bottommost_save_for_target() is
+            @test()
+
+            // Bottommost save's saved_type is what the target had
+            // before any narrowing pushed for it — the "declared"
+            // type used to bypass narrowing on assignment LHS.
+            let owner = make_owner();
+            let t_declared = make_type("Declared");
+            let t_a = make_type("NarrowA");
+            let t_b = make_type("NarrowB");
+
+            let v = make_var(owner, "v", t_declared);
+            let n = NARROWING();
+
+            n.mark_scope();
+            n.push(v, t_a);
+            n.mark_scope();
+            n.push(v, t_b);
+
+            Assert.are_same(t_b, v.type);
+            Assert.are_same(t_declared, n.declared_type_of(v));
+
+            n.release_scope();
+            n.release_scope();
+        si
+
+        declared_type_of_should_fall_back_to_target_type_when_no_save() is
+            @test()
+
+            let owner = make_owner();
+            let t = make_type("Plain");
+            let v = make_var(owner, "v", t);
+            let n = NARROWING();
+
+            Assert.are_same(t, n.declared_type_of(v));
+        si
+
+        cancel_for_should_drop_saves_and_restore_declared() is
+            @test()
+
+            let owner = make_owner();
+            let t_declared = make_type("Declared");
+            let t_narrow = make_type("Narrow");
+
+            let v = make_var(owner, "v", t_declared);
+            let n = NARROWING();
+
+            n.mark_scope();
+            n.push(v, t_narrow);
+
+            n.cancel_for(v);
+
+            Assert.are_same(t_declared, v.type);
+            Assert.are_equal(0, n.saves_count);
+
+            // Mark is still open — release must still match.
+            Assert.are_equal(1, n.marks_count);
+
+            n.release_scope();
+            Assert.is_true(n.is_empty);
+        si
+
+        cancel_for_should_leave_other_symbols_saves_intact() is
+            @test()
+
+            let owner = make_owner();
+            let t_a = make_type("A");
+            let t_b = make_type("B");
+            let t_a_narrow = make_type("ANarrow");
+            let t_b_narrow = make_type("BNarrow");
+
+            let a = make_var(owner, "a", t_a);
+            let b = make_var(owner, "b", t_b);
+            let n = NARROWING();
+
+            n.mark_scope();
+            n.push(a, t_a_narrow);
+            n.push(b, t_b_narrow);
+
+            n.cancel_for(a);
+
+            Assert.are_same(t_a, a.type);
+            Assert.are_same(t_b_narrow, b.type);
+            Assert.are_equal(1, n.saves_count);
+
+            n.release_scope();
+            Assert.are_same(t_b, b.type);
+        si
+
+        cancel_for_should_shift_marks_down_when_save_below_mark_is_removed() is
+            @test()
+
+            // Layout: outer push for v in scope 1, inner push for v
+            // in scope 2. Inside scope 2, cancel_for(v) drops both
+            // v saves. Mark for scope 2 sat above one save we just
+            // removed; it must shift down so subsequent release
+            // doesn't pop more than it should.
+            let owner = make_owner();
+            let t_declared = make_type("Declared");
+            let t_outer = make_type("Outer");
+            let t_inner = make_type("Inner");
+            let t_other = make_type("Other");
+
+            let v = make_var(owner, "v", t_declared);
+            let other = make_var(owner, "other", t_other);
+            let n = NARROWING();
+
+            n.mark_scope();
+            n.push(v, t_outer);
+
+            n.mark_scope();
+            n.push(other, t_other);
+            n.push(v, t_inner);
+
+            n.cancel_for(v);
+
+            Assert.are_same(t_declared, v.type);
+            Assert.are_same(t_other, other.type);
+            Assert.are_equal(1, n.saves_count);
+
+            n.release_scope();
+            n.release_scope();
+
+            Assert.is_true(n.is_empty);
+        si
+
+        unwind_all_should_restore_every_save_and_clear() is
+            @test()
+
+            let owner = make_owner();
+            let t_a = make_type("A");
+            let t_b = make_type("B");
+            let t_a_narrow = make_type("ANarrow");
+            let t_b_narrow = make_type("BNarrow");
+
+            let a = make_var(owner, "a", t_a);
+            let b = make_var(owner, "b", t_b);
+            let n = NARROWING();
+
+            n.mark_scope();
+            n.push(a, t_a_narrow);
+            n.mark_scope();
+            n.push(b, t_b_narrow);
+
+            n.unwind_all();
+
+            Assert.are_same(t_a, a.type);
+            Assert.are_same(t_b, b.type);
+            Assert.is_true(n.is_empty);
+        si
+
+        try_push_should_be_no_op_outside_open_scope() is
+            @test()
+
+            let owner = make_owner();
+            let t_declared = make_type("Declared");
+            let t_narrow = make_type("Narrow");
+
+            let v = make_var(owner, "v", t_declared);
+            let n = NARROWING();
+
+            n.try_push(v, t_narrow);
+
+            Assert.are_same(t_declared, v.type);
+            Assert.is_true(n.is_empty);
+        si
+
+        try_push_should_skip_when_narrowed_equals_current() is
+            @test()
+
+            let owner = make_owner();
+            let t = make_type("Same");
+
+            let v = make_var(owner, "v", t);
+            let n = NARROWING();
+
+            n.mark_scope();
+            n.try_push(v, t);
+
+            Assert.are_equal(0, n.saves_count);
+
+            n.release_scope();
+        si
+    si
+si


### PR DESCRIPTION
Enhancements:
- Compile-time type narrowing inside `if` branches: predicates `x.is_<variant>` (on a union value), `isa T(x)`, and `/\` chains thereof refine `x`'s static type for the duration of the branch body. Inside `if isa Cat(a) then a.purr() fi` no explicit cast is needed; inside `if o.is_some then o.value` the variant's per-field accessor is reachable directly. `\/` and `!` cancel each operand's narrowings (V1 conservative — V2 will smart-merge OR along the variant-identity and generic-args axes). Reassigning a narrowed variable typechecks against its declared type and drops the narrow so subsequent reads see the post-assignment value. Closures capture the narrowed view.

Technical:
- New `Syntax.Process.NARROWING` helper owns a saves/marks stack: `mark_scope` / `release_scope` paired by the visit hooks (IF_BRANCH for marking; BINARY for `\/`; UNARY for `!`); `try_push` gated on an enclosing scope and on the narrowed type being strictly assignable-narrower than the current; `declared_type_of` / `cancel_for` for the assignment LHS path. Defensive `unwind_all` + leak asserts at `COMPILE_EXPRESSIONS.apply()` boundaries catch any push/release imbalance at the bug source.
- `IR.Values.Load.SYMBOL` snapshots its type at construction when concrete, so a load compiled inside a narrowing scope carries the narrowed type through to IL gen even after the scope releases. Inference placeholders (`is_inferred`) fall back to the existing lazy `symbol.type` lookup so iterative-inference resolution keeps flowing.
- Comprehensive integration test `execution/type-narrowing-comprehensive` covers 20 scenarios (basic predicates, AND chains, OR/NOT cancellation, deep nested narrowing on the same variable, sibling branches, reassignment cancel, scope unwind, generic-arg preservation, ELIF/ELSE behaviour, closure capture, destructure of a narrowed variant, …). 14 unit tests in `unit-tests/src/syntax/process/narrowing_tests.ghul` pin the stack mechanics directly.
- The `unions` and `union-option-operators` integration tests update to the post-narrowing idiom (`o.value` and per-field variant accessors instead of the union's `.<lowercase-variant>` shortcut, which is correctly hidden once `o` narrows to the variant). Pin bump 0.8.108 → 0.8.111.