### PR TITLE
Cover IR.Values composite and literal IL emission

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.8.111",
+      "version": "0.8.112",
       "commands": [
         "ghul-compiler"
       ],

--- a/unit-tests/src/ir/values/block_tests.ghul
+++ b/unit-tests/src/ir/values/block_tests.ghul
@@ -1,0 +1,84 @@
+namespace IR.Values.UnitTests is
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    use Source.LOCATION;
+
+    use IR.RAW;
+    use IR.Values.BLOCK;
+
+    use Semantic.Symbols.CLASSY_GENERIC_ARGUMENT;
+
+    class BLOCK_TESTS is
+        @test()
+
+        init() is si
+
+        loc() -> LOCATION => LOCATION("test.ghul", 1, 1, 1, 1);
+
+        type_t() -> Semantic.Types.Type =>
+            CLASSY_GENERIC_ARGUMENT(loc(), null, "T", 0).type;
+
+        gen_to_string(value: IR.Values.Value) -> string is
+            let context = IR.CONTEXT(null, null);
+            context.enter_buffer(false);
+            value.gen(context);
+            return context.leave_buffer();
+        si
+
+        is_block__should_be_true() is
+            @test()
+
+            // BLOCK is the only Value where is_block is true. Code paths
+            // that need to know whether they're inside a block before
+            // emitting (e.g. TEMP declaration sites) branch on this.
+            let block = BLOCK(type_t());
+
+            Assert.is_true(block.is_block);
+        si
+
+        Calling__gen__should_emit_each_added_value_in_order() is
+            @test()
+
+            let block = BLOCK(type_t());
+            block.add(RAW("// first"));
+            block.add(RAW("// second"));
+            block.add(RAW("// third"));
+
+            // Order matters — block content is the linearised IL stream
+            // for the surrounding scope. Reordering would silently change
+            // emitted IL.
+            Assert.are_equal(
+                "// first\n// second\n// third\n",
+                gen_to_string(block)
+            );
+        si
+
+        Calling__gen__on_empty_block__should_emit_nothing() is
+            @test()
+
+            let block = BLOCK(type_t());
+
+            Assert.are_equal("", gen_to_string(block));
+        si
+
+        Calling__gen__twice_on_same_block__should_assert_emitted_flag() is
+            @test()
+
+            // Once gen() runs, is_emitted becomes true and re-emitting
+            // would emit duplicate IL. The assert in gen() guards this:
+            // the same BLOCK appearing twice in an emission tree (e.g.
+            // shared between an if/else fallthrough and its parent) is
+            // a bug in the producer, not something to silently re-emit.
+            let block = BLOCK(type_t());
+            block.add(RAW("// once"));
+            gen_to_string(block);
+
+            try
+                gen_to_string(block);
+                Assert.fail("expected assert on second emit");
+            catch ex: System.Exception
+                Assert.is_true(ex.message.contains("already emitted"));
+            yrt
+        si
+    si
+si

--- a/unit-tests/src/ir/values/call/closure_tests.ghul
+++ b/unit-tests/src/ir/values/call/closure_tests.ghul
@@ -1,0 +1,99 @@
+namespace IR.Values.Call.UnitTests is
+    use Collections.LIST;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    use Source.LOCATION;
+
+    use IR.RAW;
+    use IR.Values.Call.CLOSURE;
+
+    use Semantic.Symbols.CLASSY_GENERIC_ARGUMENT;
+
+    // CLOSURE wraps a delegate-style invocation: emit the receiver, emit
+    // each argument, then `callvirt instance {ret} {func_type}::Invoke({args})`.
+    // The tested contracts are the action-vs-func return-shape switch and
+    // the indexed-argument list — both regression-prone because the IL is
+    // synthesised with a StringBuilder and any reordering or count error
+    // produces malformed IL the runtime rejects at JIT time.
+    class CLOSURE_TESTS is
+        @test()
+
+        init() is si
+
+        loc() -> LOCATION => LOCATION("test.ghul", 1, 1, 1, 1);
+
+        type_named(name: string, index: int) -> Semantic.Types.Type =>
+            CLASSY_GENERIC_ARGUMENT(loc(), null, name, index).type;
+
+        gen_to_string(value: IR.Values.Value) -> string is
+            let context = IR.CONTEXT(null, null);
+            context.enter_buffer(false);
+            value.gen(context);
+            return context.leave_buffer();
+        si
+
+        Calling__gen__on_zero_arg_action__should_emit_void_invoke_with_no_args() is
+            @test()
+
+            let from = RAW("// receiver");
+            let func_type = type_named("Action", 0);
+            let closure = CLOSURE(from, type_named("void", 1), true, func_type, LIST[IR.Values.Value]());
+
+            // is_action=true → return type is `void`; arg list is empty.
+            Assert.are_equal(
+                "// receiver\ncallvirt instance void !0 ::Invoke()\n",
+                gen_to_string(closure)
+            );
+        si
+
+        Calling__gen__on_zero_arg_func__should_emit_index_zero_return_with_no_args() is
+            @test()
+
+            // is_action=false with N=0 args → return is `!0`. The index is
+            // the *count of args*, not 0 — for a Func<T> that's 0, for a
+            // Func<T,U> it's 1 (the position of the return type slot).
+            let closure = CLOSURE(RAW("// receiver"), type_named("R", 0), false, type_named("Func", 1), LIST[IR.Values.Value]());
+
+            Assert.are_equal(
+                "// receiver\ncallvirt instance !0 !1 ::Invoke()\n",
+                gen_to_string(closure)
+            );
+        si
+
+        Calling__gen__on_two_arg_func__should_emit_index_two_return_with_indexed_args() is
+            @test()
+
+            let args = LIST[IR.Values.Value]();
+            args.add(RAW("// arg0"));
+            args.add(RAW("// arg1"));
+
+            let closure = CLOSURE(RAW("// receiver"), type_named("R", 0), false, type_named("Func", 1), args);
+
+            // 2 args → return slot is `!2`, args are `!0,!1`. The
+            // comma-separated list is the easy bug class: an off-by-one
+            // in the loop produces a leading or trailing comma.
+            Assert.are_equal(
+                "// receiver\n// arg0\n// arg1\ncallvirt instance !2 !1 ::Invoke(!0,!1)\n",
+                gen_to_string(closure)
+            );
+        si
+
+        Calling__gen__on_two_arg_action__should_emit_void_with_indexed_args() is
+            @test()
+
+            let args = LIST[IR.Values.Value]();
+            args.add(RAW("// arg0"));
+            args.add(RAW("// arg1"));
+
+            let closure = CLOSURE(RAW("// receiver"), type_named("void", 0), true, type_named("Action", 1), args);
+
+            // is_action=true even with N>0 keeps the void return — only
+            // the return shape switches, not the argument indexing.
+            Assert.are_equal(
+                "// receiver\n// arg0\n// arg1\ncallvirt instance void !1 ::Invoke(!0,!1)\n",
+                gen_to_string(closure)
+            );
+        si
+    si
+si

--- a/unit-tests/src/ir/values/literal/number_tests.ghul
+++ b/unit-tests/src/ir/values/literal/number_tests.ghul
@@ -1,0 +1,67 @@
+namespace IR.Values.Literal.UnitTests is
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    use Source.LOCATION;
+
+    use IR.Values.Literal.NUMBER;
+
+    use Semantic.Symbols.CLASSY_GENERIC_ARGUMENT;
+
+    class NUMBER_TESTS is
+        @test()
+
+        init() is si
+
+        loc() -> LOCATION => LOCATION("test.ghul", 1, 1, 1, 1);
+
+        type_int() -> Semantic.Types.Type =>
+            CLASSY_GENERIC_ARGUMENT(loc(), null, "int", 0).type;
+
+        gen_to_string(value: IR.Values.Value) -> string is
+            let context = IR.CONTEXT(null, null);
+            context.enter_buffer(false);
+            value.gen(context);
+            return context.leave_buffer();
+        si
+
+        Calling__gen__without_conv__should_emit_only_ldc_suffix_value() is
+            @test()
+
+            let value = NUMBER("42", type_int(), "i4");
+
+            // `ldc.{suffix} {value}`. The suffix interpolates verbatim,
+            // so `i4`, `i8`, `r4`, `r8` etc. all work the same way.
+            Assert.are_equal(
+                "ldc.i4 42\n",
+                gen_to_string(value)
+            );
+        si
+
+        Calling__gen__with_conv__should_emit_ldc_then_conv_instruction() is
+            @test()
+
+            let value = NUMBER("42", type_int(), "i4", "conv.i8");
+
+            // The conv is for cases where the literal can't be represented
+            // directly in the destination width — e.g. encoding a long as
+            // ldc.i4 + conv.i8 when it fits. Without conv, the JIT type-
+            // checks and rejects.
+            Assert.are_equal(
+                "ldc.i4 42\nconv.i8\n",
+                gen_to_string(value)
+            );
+        si
+
+        is_lightweight_pure__should_be_true() is
+            @test()
+
+            // Number literals are pure — no side effects, no shared state.
+            // Value.get_temp_copier uses this to avoid materialising a TEMP
+            // for the same literal, returning the literal directly instead.
+            // A regression to false would emit redundant locals.
+            let value = NUMBER("42", type_int(), "i4");
+
+            Assert.is_true(value.is_lightweight_pure);
+        si
+    si
+si

--- a/unit-tests/src/ir/values/literal/string_tests.ghul
+++ b/unit-tests/src/ir/values/literal/string_tests.ghul
@@ -1,0 +1,73 @@
+namespace IR.Values.Literal.UnitTests is
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    use Source.LOCATION;
+
+    use IR.Values.Literal.STRING;
+
+    use Semantic.Symbols.CLASSY_GENERIC_ARGUMENT;
+
+    // STRING.gen emits `ldstr bytearray (<hex>)` where each character is
+    // encoded as two little-endian bytes (UTF-16). The hex form is what
+    // ilasm consumes — quoted-string `ldstr "..."` doesn't work for
+    // arbitrary content (escaping rules differ), so the bytearray form
+    // is the universal fallback ghūl uses.
+    class STRING_TESTS is
+        @test()
+
+        init() is si
+
+        loc() -> LOCATION => LOCATION("test.ghul", 1, 1, 1, 1);
+
+        type_string() -> Semantic.Types.Type =>
+            CLASSY_GENERIC_ARGUMENT(loc(), null, "string", 0).type;
+
+        gen_to_string(value: IR.Values.Value) -> string is
+            let context = IR.CONTEXT(null, null);
+            context.enter_buffer(false);
+            value.gen(context);
+            return context.leave_buffer();
+        si
+
+        Calling__gen__on_empty_string__should_emit_ldstr_with_no_bytes() is
+            @test()
+
+            let value = STRING("", type_string());
+
+            Assert.are_equal(
+                "ldstr bytearray ()\n",
+                gen_to_string(value)
+            );
+        si
+
+        Calling__gen__on_ascii_string__should_emit_low_byte_then_zero_for_each_char() is
+            @test()
+
+            // ASCII chars have high byte 0; UTF-16-LE is `low high `.
+            // 'H' = 0x48, 'i' = 0x69 → "48 00 69 00 ". The trailing space
+            // after each pair is part of the format — ilasm tolerates it
+            // and the encoder always appends it.
+            let value = STRING("Hi", type_string());
+
+            Assert.are_equal(
+                "ldstr bytearray (48 00 69 00 )\n",
+                gen_to_string(value)
+            );
+        si
+
+        Calling__gen__on_non_ascii_char__should_split_codepoint_low_first_then_high() is
+            @test()
+
+            // U+03BB GREEK SMALL LETTER LAMDA → low=0xBB, high=0x03 →
+            // "BB 03 ". A regression that swapped these would silently
+            // produce the wrong character at runtime — UTF-16 BE would
+            // decode this as U+BB03, an unrelated CJK ideograph.
+            let value = STRING("λ", type_string());
+
+            Assert.are_equal(
+                "ldstr bytearray (BB 03 )\n",
+                gen_to_string(value)
+            );
+        si
+    si
+si

--- a/unit-tests/src/ir/values/sequence_tests.ghul
+++ b/unit-tests/src/ir/values/sequence_tests.ghul
@@ -1,0 +1,67 @@
+namespace IR.Values.UnitTests is
+    use Collections.LIST;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    use Source.LOCATION;
+
+    use IR.RAW;
+    use IR.Values.SEQUENCE;
+
+    use Semantic.Symbols.CLASSY_GENERIC_ARGUMENT;
+
+    // SEQUENCE.gen calls IoC.CONTAINER.instance.value_boxer.box_if_needed,
+    // which would need IoC bootstrap to test. These tests pin the structure
+    // SEQUENCE preserves — type, element type, and the value list — without
+    // touching gen.
+    class SEQUENCE_TESTS is
+        @test()
+
+        init() is si
+
+        loc() -> LOCATION => LOCATION("test.ghul", 1, 1, 1, 1);
+
+        type_named(name: string, index: int) -> Semantic.Types.Type =>
+            CLASSY_GENERIC_ARGUMENT(loc(), null, name, index).type;
+
+        Type_and_element_type__should_be_distinct_fields() is
+            @test()
+
+            // SEQUENCE represents a List[T]: `type` is the List, `element_type`
+            // is T. They must not collapse — gen emits `newarr {element_type}`,
+            // not `newarr {type}`, and confusing them produces malformed IL.
+            let list_type = type_named("List", 0);
+            let element_type = type_named("T", 1);
+            let values = LIST[IR.Values.Value]();
+
+            let sequence = SEQUENCE(list_type, element_type, values);
+
+            Assert.are_same(list_type, sequence.type);
+            Assert.are_same(element_type, sequence.element_type);
+        si
+
+        Values_list__should_preserve_input_list_identity() is
+            @test()
+
+            // SEQUENCE holds the exact list passed in (no copy) — callers
+            // can append to it before gen runs, and tests / dump output
+            // see the same list.
+            let values = LIST[IR.Values.Value]();
+            values.add(RAW("// a"));
+            values.add(RAW("// b"));
+
+            let sequence = SEQUENCE(type_named("List", 0), type_named("T", 1), values);
+
+            Assert.are_same(values, sequence.values);
+            Assert.are_equal(2, sequence.values.count);
+        si
+
+        has_type__should_be_true_when_type_is_set() is
+            @test()
+
+            let sequence = SEQUENCE(type_named("List", 0), type_named("T", 1), LIST[IR.Values.Value]());
+
+            Assert.is_true(sequence.has_type);
+        si
+    si
+si

--- a/unit-tests/src/ir/values/tuple_tests.ghul
+++ b/unit-tests/src/ir/values/tuple_tests.ghul
@@ -1,0 +1,64 @@
+namespace IR.Values.UnitTests is
+    use Collections.LIST;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    use Source.LOCATION;
+
+    use IR.RAW;
+    use IR.Values.TUPLE;
+
+    use Semantic.Symbols.CLASSY_GENERIC_ARGUMENT;
+
+    class TUPLE_TESTS is
+        @test()
+
+        init() is si
+
+        loc() -> LOCATION => LOCATION("test.ghul", 1, 1, 1, 1);
+
+        type_named(name: string, index: int) -> Semantic.Types.Type =>
+            CLASSY_GENERIC_ARGUMENT(loc(), null, name, index).type;
+
+        gen_to_string(value: IR.Values.Value) -> string is
+            let context = IR.CONTEXT(null, null);
+            context.enter_buffer(false);
+            value.gen(context);
+            return context.leave_buffer();
+        si
+
+        Calling__gen__on_empty_tuple__should_emit_newobj_with_empty_args() is
+            @test()
+
+            // A 0-tuple still produces a `newobj` against the tuple type's
+            // ctor with an empty argument list. The trailing parentheses
+            // are load-bearing — `newobj instance void T ::'.ctor'` without
+            // them is invalid IL.
+            let tuple = TUPLE(type_named("T", 0), LIST[IR.Values.Value]());
+
+            Assert.are_equal(
+                "newobj instance void !0  ::'.ctor'()\n",
+                gen_to_string(tuple)
+            );
+        si
+
+        Calling__gen__on_two_element_tuple__should_emit_inners_then_newobj_with_indexed_args() is
+            @test()
+
+            // The signature uses `!0,!1` indexed references — the open form
+            // required by the methodref shape contract (see il-emission.md).
+            // A regression that emits resolved type names here would cause
+            // the runtime MissingMethodException class.
+            let values = LIST[IR.Values.Value]();
+            values.add(RAW("// a0"));
+            values.add(RAW("// a1"));
+
+            let tuple = TUPLE(type_named("T", 0), values);
+
+            Assert.are_equal(
+                "// a0\n// a1\nnewobj instance void !0  ::'.ctor'(!0,!1)\n",
+                gen_to_string(tuple)
+            );
+        si
+    si
+si


### PR DESCRIPTION
Stacked on #1255.

Technical:
- 19 new tests covering `BLOCK`, `SEQUENCE`, `TUPLE`, `CLOSURE`, and `literal/{NUMBER,STRING}`.
- `TUPLE` and `CLOSURE` pin the constructor-style methodref shapes (open-form indexed args). `STRING` pins the UTF-16-LE bytearray encoding — mutation-checked, swapping byte order trips both ASCII and non-ASCII cases.
- `BLOCK` pins emit ordering, empty-block behaviour, and the assert on double-`gen()`.
- `SEQUENCE` is structural-only; `gen()` calls `IoC.CONTAINER.instance.value_boxer` and would need IoC bootstrap to test.
- The remaining `call/*` (`global`, `static`, `instance`, `struct`, `innate`) are deferred — their `gen()` routes through `Function.get_il_reference()`, which trips on the `null`-owner fixture shortcut. Follow-up.