### PR TITLE
Pin CI integration_tests runtime to bootstrap artefact

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,14 +10,14 @@
       "rollForward": false
     },
     "ghul.test": {
-      "version": "1.3.5",
+      "version": "1.3.7",
       "commands": [
         "ghul-test"
       ],
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.8.113",
+      "version": "0.8.116",
       "commands": [
         "ghul-compiler"
       ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,21 +136,36 @@ jobs:
       with:
         name: ghul-compiler-package
         path: nupkg
-        
+
+    - name: Download bootstrap compiler tool tree
+      uses: actions/download-artifact@v4
+      with:
+        name: ghul-compiler-tool
+        path: bootstrap-tool
+
     - name: Uninstall ghul.compiler
       if: ${{ github.actor == 'dependabot[bot]' }}
-      run: dotnet tool uninstall ghul.compiler      
+      run: dotnet tool uninstall ghul.compiler
 
     - name: Add GHCR package source
-      run: dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/degory/index.json"    
-      
+      run: dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/degory/index.json"
+
     - name: Install ghul.compiler
       run: dotnet tool update --local ghul.compiler --version ${{ needs.version.outputs.package }} --add-source nupkg
 
     - name: Restore local .NET tools
       run: dotnet tool restore
 
+    # Pin the runtime DLL the compiled test binaries link against to the
+    # one the bootstrapped compiler ships with, not whatever runtime
+    # ghul.test was packaged with. Without this, an integration test
+    # that uses a runtime feature added since the ghul.test publish
+    # would fail to resolve the symbol — because ghul-test in CI mode
+    # otherwise picks the runtime DLL sitting next to its own binary.
+    # GHUL_RUNTIME_DLL was added in ghul-test 1.3.7 (degory/ghul-test#108).
     - name: Run integration tests
+      env:
+        GHUL_RUNTIME_DLL: ${{ github.workspace }}/bootstrap-tool/ghul-runtime.dll
       run: bash -c "set -o pipefail ; dotnet ghul-test integration-tests | tee test-results.txt"
 
     - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Enhancements:
- `integration_tests` job now downloads the `ghul-compiler-tool` artefact (the fully-extracted bootstrap tool tree, already produced for `analysis_tests`) and sets `GHUL_RUNTIME_DLL` to its `ghul-runtime.dll`. ghul-test in CI mode otherwise picks the runtime DLL sitting next to its own binary — pinning that to whatever runtime version `ghul.test` was packaged with and silently breaking any integration test that relies on a runtime feature added since. `GHUL_RUNTIME_DLL` was added in `ghul-test` 1.3.7 (degory/ghul-test#108).

Technical:
- Bump pinned `ghul.test` 1.3.5 → 1.3.7.