### PR TITLE
Build ghul-runtime against bootstrapped compiler in CI (re-do)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.8.116",
+      "version": "0.8.117",
       "commands": [
         "ghul-compiler"
       ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,53 @@ jobs:
         name: project-test-results
         path: project-test-results.txt
 
+  runtime_tests:
+    needs: [version, bootstrap]
+    name: Run runtime tests
+
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/dotnet/sdk:8.0-jammy
+
+    timeout-minutes: 10
+
+    # Build ghul-runtime (latest main, no version pin) against the
+    # bootstrapped compiler and run its unit tests. Same symmetry
+    # contract as examples_tests: the new compiler must build current
+    # ghul-runtime main, and current ghul-runtime main must build
+    # under the previously-published compiler. Catches source-compat
+    # regressions in the runtime before they require a runtime fix to
+    # unstick — e.g. an inference change that silently breaks the
+    # runtime test source.
+    steps:
+    - name: Checkout ghul-runtime
+      uses: actions/checkout@v3
+      with:
+        repository: degory/ghul-runtime
+        path: ghul-runtime
+
+    - name: Download ghul.compiler package
+      uses: actions/download-artifact@v4
+      with:
+        name: ghul-compiler-package
+        path: nupkg
+
+    - name: Install bootstrapped ghul.compiler in ghul-runtime
+      working-directory: ghul-runtime
+      run: dotnet tool update --local ghul.compiler --version ${{ needs.version.outputs.package }} --add-source ../nupkg
+
+    - name: Restore local .NET tools
+      working-directory: ghul-runtime
+      run: dotnet tool restore
+
+    - name: Build ghul-runtime
+      working-directory: ghul-runtime
+      run: dotnet build
+
+    - name: Run ghul-runtime unit tests
+      working-directory: ghul-runtime
+      run: dotnet test tests/tests.ghulproj
+
   examples_tests:
     needs: [version, bootstrap]
     name: Run examples tests
@@ -286,7 +333,7 @@ jobs:
       run: dotnet ghul-test --use-dotnet-build integration-tests
 
   publish_beta_package:
-    needs: [version, unit_tests, analysis_tests, integration_tests, project_tests, examples_tests]
+    needs: [version, unit_tests, analysis_tests, integration_tests, project_tests, runtime_tests, examples_tests]
     name: Publish beta package
 
     timeout-minutes: 5
@@ -428,7 +475,7 @@ jobs:
       run: docker push degory/ghul-devcontainer:dotnet
 
   publish_release_package:
-    needs: [version, unit_tests, analysis_tests, project_tests, container_tests, examples_tests]
+    needs: [version, unit_tests, analysis_tests, project_tests, container_tests, runtime_tests, examples_tests]
     name: Publish release package
 
     timeout-minutes: 5


### PR DESCRIPTION
Re-application of the changes intended for #1260 — that PR's head ref accidentally pointed at #1259's branch (`claude/fix-identity-lambda-inference`) and the squash-merge was empty, so the `runtime_tests` gate never actually landed on main. Confirmed by `grep -c "runtime_tests:" .github/workflows/ci.yml` on `main` returning 0.

Enhancements:
- New `runtime_tests` job mirrors `examples_tests`: checkout `ghul-runtime` main, install the just-bootstrapped `ghul.compiler` artefact, `dotnet build` and `dotnet test tests/tests.ghulproj`. Wired into `publish_beta_package` and `publish_release_package` gates so a runtime build break blocks publish on the same pull-request and post-merge paths examples already cover. Catches source-compat regressions in the runtime before they require a runtime fix to unstick.