### PR TITLE
Pin container_tests runtime to dev container's installed compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,6 +419,18 @@ jobs:
     - name: Remove tool manifest
       run: rm -rf .config
 
+    # Pin the runtime DLL the compiled test binaries link against to
+    # the compiler that's actually installed in this container — not
+    # whatever runtime version the globally-installed `ghul.test` was
+    # packaged with. Same fix as the integration_tests job, with a
+    # different discovery: the dev container's dockerfile installs
+    # `ghul.compiler` into `/usr/local/bin/.store/ghul.compiler/`,
+    # and the runtime DLL sits next to ghul.dll inside that store.
+    # `find` resolves it without needing to know the version.
+    # GHUL_RUNTIME_DLL was added in ghul-test 1.3.7 (degory/ghul-test#108).
+    - name: Locate compiler runtime DLL
+      run: echo "GHUL_RUNTIME_DLL=$(find /usr/local/bin/.store/ghul.compiler -type f -name ghul-runtime.dll | head -1)" >> $GITHUB_ENV
+
     - name: Run integration tests
       run: bash -c "set -o pipefail ; ghul-test integration-tests | tee test-results.txt"
 


### PR DESCRIPTION
Same shape of fix as #1262, applied to the `container_tests` job (which only runs on push, in the dev container). `ghul-test` in the container picks up the runtime sitting next to its globally-installed binary — i.e. whatever `ghul.runtime` version `ghul.test` was packaged with — and any test binary linked against a newer runtime fails to load.

This is what caused the 33 integration test failures on the #1261 release build (`Could not load file or assembly 'ghul-runtime, Version=1.3.6.0'`): the bootstrap-built compiler bundles 1.3.6, but `ghul.test` 1.3.7 was the latest published at that time and it had bundled 1.3.5.

Sets `GHUL_RUNTIME_DLL` to the runtime DLL shipped inside the dev container's installed `ghul.compiler` — located via `find`, since the version-pinned path inside `/usr/local/bin/.store/ghul.compiler/` would otherwise need to match the bootstrap-built `\${{ needs.version.outputs.package }}`. `GHUL_RUNTIME_DLL` was added in `ghul-test` 1.3.7 (degory/ghul-test#108).