### PR TITLE
Narrow else branch of two-variant union if/else

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.8.117",
+      "version": "0.8.120",
       "commands": [
         "ghul-compiler"
       ],

--- a/integration-tests/execution/type-narrowing-comprehensive/run.expected
+++ b/integration-tests/execution/type-narrowing-comprehensive/run.expected
@@ -25,3 +25,9 @@
 18-else-base: animal buddy
 19-closure: misty purrs
 20-assign-in-else: animal ginger
+21-then-ok: 42
+22-else-err: oops
+23-else-typed-error: len 4 (5)
+24-else-then-b: 7
+25-else-then-no
+26-then-ok: 1

--- a/integration-tests/execution/type-narrowing-comprehensive/test.ghul
+++ b/integration-tests/execution/type-narrowing-comprehensive/test.ghul
@@ -10,6 +10,17 @@ union Pair[A,B] is
     NEITHER;
 si
 
+union Result[T,E] is
+    OK(value: T);
+    ERR(error: E);
+si
+
+union Trio[T] is
+    A(a: T);
+    B(b: T);
+    C(c: T);
+si
+
 class Animal is
     name: string public;
     init(name: string) is self.name = name; si
@@ -52,6 +63,12 @@ entry() is
     test_else_no_narrow();
     test_closure_captures_narrow();
     test_assignment_inside_else();
+    test_else_narrows_two_variant_then_taken();
+    test_else_narrows_two_variant_else_taken();
+    test_else_narrows_two_variant_generic_args();
+    test_else_no_narrow_three_variant();
+    test_else_no_narrow_through_elif();
+    test_assignment_inside_complement_else();
 si
 
 test_basic_is_xxx() is
@@ -232,8 +249,11 @@ test_elif_branch() is
 si
 
 test_else_no_narrow() is
-    // V1 doesn't push narrowing into an `else` body; the variable
-    // shows declared type. (V2 would propagate the negated form.)
+    // `isa Class` else doesn't narrow — the negation of `isa Cat`
+    // on Animal is the open set of non-Cat Animal subtypes, with
+    // no representable single-type bound. Issue #1265 covers
+    // generalising to a sum-type representation; v1 leaves this
+    // case as-is.
     let a: Animal = Dog("buddy");
     if isa Cat(a) then
         write_line("18-else-cat: {a.purr()}");
@@ -269,5 +289,92 @@ test_assignment_inside_else() is
     else
         a = Cat("ginger");
         write_line("20-assign-in-else: {a.speak()}");
+    fi
+si
+
+test_else_narrows_two_variant_then_taken() is
+    // Else-complement narrowing on a 2-variant union: the else
+    // body sees `r` narrowed to ERR. The then path runs in this
+    // case, but both branches have to typecheck.
+    let r: Result[int, string] = Result.OK[int, string](42);
+    if r.is_ok then
+        write_line("21-then-ok: {r.value}");
+    else
+        write_line("21-else-err-not-reached: {r.error}");
+    fi
+si
+
+test_else_narrows_two_variant_else_taken() is
+    // Same shape, else path runs — exercises the narrowed access
+    // at runtime: `r.error` requires r to be ERR.
+    let r: Result[int, string] = Result.ERR[int, string]("oops");
+    if r.is_ok then
+        write_line("22-then-ok-not-reached: {r.value}");
+    else
+        write_line("22-else-err: {r.error}");
+    fi
+si
+
+test_else_narrows_two_variant_generic_args() is
+    // Generic args from the receiver propagate to the complement
+    // variant type — the narrowed view is `Result.ERR[int,string]`,
+    // not `Result.ERR[?,?]`.
+    let r: Result[int, string] = Result.ERR[int, string]("len 4");
+    if r.is_ok then
+        write_line("23-then-not-reached");
+    else
+        let e: string = r.error;
+        write_line("23-else-typed-error: {e} ({e.length})");
+    fi
+si
+
+test_else_no_narrow_three_variant() is
+    // 3-variant union: the complement of `is_a` is `B | C`, which
+    // has no single-variant bound. The else body sees `t` at the
+    // wide union type — accessing `t.b` or `t.c` directly would
+    // not typecheck. Exercise the wide-type path via `is_b`
+    // inside the else, confirming no spurious narrowing.
+    let t: Trio[int] = Trio.B[int](7);
+    if t.is_a then
+        write_line("24-then-not-reached");
+    else
+        if t.is_b then
+            write_line("24-else-then-b: {t.b}");
+        fi
+    fi
+si
+
+test_else_no_narrow_through_elif() is
+    // Only the strict `if/else` shape narrows the else. An IF with
+    // an `elif` falls outside scope — the else is not narrowed
+    // even when the elif's condition is itself a 2-variant is_X.
+    // (Issue #1265 covers the generalisation.) Exercise via the
+    // wide-type path with another `is_yes` check.
+    let m: Maybe[int] = Maybe.NO[int]();
+    if m.is_yes then
+        write_line("25-then-not-reached");
+    elif false then
+        write_line("25-elif-not-reached");
+    else
+        if m.is_no then
+            write_line("25-else-then-no");
+        fi
+    fi
+si
+
+test_assignment_inside_complement_else() is
+    // Assignment inside a complement-narrowed else: cancel_for
+    // restores the declared union type before the new value is
+    // typechecked, so assigning a wider value (the parent union)
+    // is still legal. Mirrors test_assignment_inside_else but
+    // for the union-variant complement path.
+    let r: Result[int, string] = Result.OK[int, string](1);
+    if r.is_ok then
+        write_line("26-then-ok: {r.value}");
+    else
+        r = Result.OK[int, string](99);
+        if r.is_ok then
+            write_line("26-else-renarrow-ok: {r.value}");
+        fi
     fi
 si

--- a/integration-tests/execution/unions/test.ghul
+++ b/integration-tests/execution/unions/test.ghul
@@ -72,7 +72,7 @@ test_tree() is
             let (left, right) = t in
             "({rec(left)}, {rec(right)})"
         else
-            "{t.leaf}"
+            "{t.value}"
         fi;
 
     write_line(stringify_tree(tree));

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -15,6 +15,28 @@ namespace Syntax.Process is
 
     use Syntax.Trees.Definitions.PRAGMA;
 
+    // Per-IF bookkeeping for else-branch complement narrowing on
+    // 2-variant unions. An IF "qualifies" when it has exactly
+    // 2 branches with the second being an `else` — in
+    // `if cond then ... else ... fi`, a 2-variant union narrowed
+    // by `cond` of the form `<simple-id>.is_<variant>` lets the
+    // else body see the variable narrowed to the other variant.
+    // Multi-variant complements need an internal sum type — see
+    // issue #1265.
+    //
+    // pre(IF) pushes a frame; visit(IF) pops it. visit(IF_BRANCH)
+    // for the if-branch fills in (target, complement_type) when
+    // the qualifying cond shape matches; pre(IF_BRANCH) for the
+    // else-branch reads them and pushes the narrowing.
+    class ELSE_COMPLEMENT_FRAME is
+        is_two_branch_if_else: bool public;
+        target: Semantic.Symbols.Variable public;
+        complement_type: Type public;
+
+        init() is
+        si
+    si
+
     class COMPILE_EXPRESSIONS: ScopedVisitor is
         _logger: Logger;
         _symbol_table: Semantic.SYMBOL_TABLE;
@@ -50,6 +72,12 @@ namespace Syntax.Process is
         // delegate here. See `narrowing.ghul` for the mechanism.
         _narrowing: NARROWING;
 
+        // Stack of frames, one per IF currently being walked.
+        // pre/visit(IF) push and pop; visit(IF_BRANCH) for the
+        // if-branch of a qualifying frame stashes the complement
+        // narrowing for pre(IF_BRANCH) of the else-branch to push.
+        _else_complement_stack: Collections.LIST[ELSE_COMPLEMENT_FRAME];
+
         current_statement_list: Trees.Statements.LIST;
 
         init(
@@ -84,6 +112,8 @@ namespace Syntax.Process is
             _type_arg_placeholder_origins = Collections.MAP[Trees.Node, Collections.LIST[Semantic.Symbols.Variable]]();
 
             _narrowing = NARROWING();
+
+            _else_complement_stack = Collections.LIST[ELSE_COMPLEMENT_FRAME]();
         si
 
         // True if `name` looks like a synthesized variant accessor
@@ -179,6 +209,68 @@ namespace Syntax.Process is
             return null;
         si
 
+        // For an `is_<variant>` access on a 2-variant union, return
+        // the type of the OTHER variant carrying the receiver's
+        // generic args. Null if the receiver isn't a union, has more
+        // or fewer than 2 variants, or no variant matches the suffix.
+        // Multi-variant complements need a sum-type representation
+        // — see issue #1265.
+        try_get_two_variant_complement(
+            receiver_type: Type,
+            member_name: string
+        ) -> Type is
+            if !is_variant_accessor_name(member_name) then
+                return null;
+            fi
+
+            let classy = get_classy_for_narrowing(receiver_type);
+
+            if !classy? \/ !classy.is_union then
+                return null;
+            fi
+
+            let suffix = member_name.substring(3);
+
+            let variants = Collections.LIST[Semantic.Symbols.Classy]();
+
+            for s in classy.symbols do
+                if s? /\ s.is_variant then
+                    variants.add(cast Semantic.Symbols.Classy(s));
+                fi
+            od
+
+            if variants.count != 2 then
+                return null;
+            fi
+
+            let other: Semantic.Symbols.Classy;
+            let saw_match = false;
+
+            for v in variants do
+                if v.name? /\ v.name.to_lower_invariant() =~ suffix then
+                    saw_match = true;
+                else
+                    other = v;
+                fi
+            od
+
+            if !saw_match \/ !other? then
+                return null;
+            fi
+
+            if isa Semantic.Types.GENERIC(receiver_type) then
+                let generic_receiver = cast Semantic.Types.GENERIC(receiver_type);
+
+                return Semantic.Types.GENERIC(
+                    other.location,
+                    other,
+                    generic_receiver.arguments
+                );
+            else
+                return Semantic.Types.NAMED(other);
+            fi
+        si
+
         apply(root: Trees.Node) is
             assert _keep_depth == 0;
             assert _stub_depth == 0;
@@ -212,6 +304,12 @@ namespace Syntax.Process is
             // it goes, not just clears the stacks.
             _narrowing.unwind_all();
 
+            // Defensive — same rationale as _narrowing.unwind_all above.
+            // Frames are pushed in pre(IF) and popped in visit(IF); a
+            // leak from an aborted earlier walk would let stale frames
+            // misroute else-complement narrowings on later compiles.
+            _else_complement_stack.clear();
+
             root.walk(self);
 
             assert _keep_depth == 0;
@@ -220,6 +318,8 @@ namespace Syntax.Process is
                 else "narrowing saves stack leaked: {_narrowing.saves_count} unreleased";
             assert _narrowing.marks_count == 0
                 else "narrowing marks stack leaked: {_narrowing.marks_count} unreleased";
+            assert _else_complement_stack.count == 0
+                else "else-complement frame stack leaked: {_else_complement_stack.count} unreleased";
         si
 
         should_skip(node: Trees.Node) -> bool => _stub_depth > 0 \/ is_stable(node);
@@ -1113,10 +1213,52 @@ namespace Syntax.Process is
             // saves into this branch's frame; the matching release
             // in visit() pops them once the body has been walked.
             _narrowing.mark_scope();
+
+            // Else-complement narrowing: if this is the else
+            // branch of a qualifying IF and the if-branch's visit
+            // already stashed a (target, complement_type) pair on
+            // the frame, push it onto the just-marked scope so
+            // the body sees the variable narrowed to the other
+            // variant.
+            if !`if.condition? /\ _else_complement_stack.count > 0 then
+                let frame = _else_complement_stack[_else_complement_stack.count - 1];
+
+                if frame.is_two_branch_if_else /\ frame.target? /\ frame.complement_type? then
+                    _narrowing.try_push(frame.target, frame.complement_type);
+                fi
+            fi
         si
 
         visit(`if: Trees.Statements.IF_BRANCH) is
             _narrowing.release_scope();
+
+            // Else-complement narrowing: if the just-finished
+            // branch is the if-branch of a qualifying IF and its
+            // condition is `<simple-id>.is_<variant>` on a 2-variant
+            // union, stash the complement variant type on the frame
+            // for pre(IF_BRANCH) of the else-branch to consume.
+            if
+                _else_complement_stack.count > 0 /\
+                `if? /\
+                `if.condition? /\
+                isa Trees.Expressions.MEMBER(`if.condition)
+            then
+                let frame = _else_complement_stack[_else_complement_stack.count - 1];
+
+                if frame.is_two_branch_if_else /\ !frame.target? then
+                    let member = cast Trees.Expressions.MEMBER(`if.condition);
+
+                    if member.left? /\ member.left.value? /\ member.left.value.type? /\ member.identifier? then
+                        let target = try_get_narrowing_target(member.left);
+                        let complement = try_get_two_variant_complement(member.left.value.type, member.identifier.name);
+
+                        if target? /\ complement? then
+                            frame.target = target;
+                            frame.complement_type = complement;
+                        fi
+                    fi
+                fi
+            fi
 
             if
                 `if? /\
@@ -4386,10 +4528,37 @@ namespace Syntax.Process is
                 od
             fi
 
+            // Push an else-complement frame for this IF. Structural
+            // qualification check: exactly 2 branches, branch 0 has a
+            // condition, branch 1 is `else` (null condition). The
+            // type-dependent variant-count check is deferred until
+            // visit(IF_BRANCH) for branch 0 — we only know the
+            // receiver's resolved type after the cond walk.
+            let frame = ELSE_COMPLEMENT_FRAME();
+
+            let count = 0;
+            let first_has_condition = false;
+            let second_is_else = false;
+
+            for b in `if.branches do
+                count = count + 1;
+                if count == 1 then
+                    first_has_condition = b? /\ b.condition?;
+                elif count == 2 then
+                    second_is_else = b? /\ !b.condition?;
+                fi
+            od
+
+            frame.is_two_branch_if_else = count == 2 /\ first_has_condition /\ second_is_else;
+
+            _else_complement_stack.add(frame);
+
             return false;
         si
 
         visit(`if: Trees.Statements.IF) is
+            _else_complement_stack.remove_at(_else_complement_stack.count - 1);
+
             for i in `if.branches do
                 if i.condition? then
                     IR.Values.Value.check_is_consumable(_logger, i.condition.location, i.condition.value);


### PR DESCRIPTION
Enhancements:
- In `if t.is_X then ... else ... fi` over a union with exactly two variants, the else body now sees `t` narrowed to the other variant. Multi-variant unions and elif chains stay un-narrowed (#1265).

Technical:
- `integration-tests/execution/unions` stringify_tree else now reads `t.value` (LEAF's field) instead of `t.leaf` (the union's variant accessor) — variant scope's `find_member` suppresses union-owned accessors under narrowing, the same shadow that applies to `t.node` in already-narrowed then branches.