### PR TITLE
Prefer downstream `next` over `main` in cross-repo CI checkouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,11 +256,34 @@ jobs:
     # unstick — e.g. an inference change that silently breaks the
     # runtime test source.
     steps:
+    # Pick `next` over `main` when it exists and is strictly ahead.
+    # See docs/claude/breaking-change-coordination.md.
+    - name: Resolve ghul-runtime ref
+      id: ref
+      shell: bash
+      run: |
+        set -euo pipefail
+        repo=degory/ghul-runtime
+        main_sha=$(git ls-remote "https://github.com/${repo}" refs/heads/main | cut -f1)
+        next_sha=$(git ls-remote "https://github.com/${repo}" refs/heads/next | cut -f1 || true)
+        ref=main
+        if [ -n "${next_sha}" ] && [ "${next_sha}" != "${main_sha}" ]; then
+          tmp=$(mktemp -d) && trap "rm -rf '${tmp}'" EXIT
+          git clone --quiet --filter=blob:none --no-checkout --branch=next --depth=200 "https://github.com/${repo}" "${tmp}"
+          git -C "${tmp}" fetch --quiet --depth=200 origin main:refs/remotes/origin/main
+          if git -C "${tmp}" merge-base --is-ancestor origin/main next; then
+            ref=next
+            echo "using ${repo}/next"
+          fi
+        fi
+        echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+
     - name: Checkout ghul-runtime
       uses: actions/checkout@v3
       with:
         repository: degory/ghul-runtime
         path: ghul-runtime
+        ref: ${{ steps.ref.outputs.ref }}
 
     - name: Download ghul.compiler package
       uses: actions/download-artifact@v4
@@ -304,11 +327,34 @@ jobs:
     # publish_release_package, so a skipped run would silently block
     # publish on the post-merge run.
     steps:
+    # Pick `next` over `main` when it exists and is strictly ahead.
+    # See docs/claude/breaking-change-coordination.md.
+    - name: Resolve ghul-examples ref
+      id: ref
+      shell: bash
+      run: |
+        set -euo pipefail
+        repo=degory/ghul-examples
+        main_sha=$(git ls-remote "https://github.com/${repo}" refs/heads/main | cut -f1)
+        next_sha=$(git ls-remote "https://github.com/${repo}" refs/heads/next | cut -f1 || true)
+        ref=main
+        if [ -n "${next_sha}" ] && [ "${next_sha}" != "${main_sha}" ]; then
+          tmp=$(mktemp -d) && trap "rm -rf '${tmp}'" EXIT
+          git clone --quiet --filter=blob:none --no-checkout --branch=next --depth=200 "https://github.com/${repo}" "${tmp}"
+          git -C "${tmp}" fetch --quiet --depth=200 origin main:refs/remotes/origin/main
+          if git -C "${tmp}" merge-base --is-ancestor origin/main next; then
+            ref=next
+            echo "using ${repo}/next"
+          fi
+        fi
+        echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+
     - name: Checkout ghul-examples
       uses: actions/checkout@v3
       with:
         repository: degory/ghul-examples
         path: ghul-examples
+        ref: ${{ steps.ref.outputs.ref }}
 
     - name: Download ghul.compiler package
       uses: actions/download-artifact@v4


### PR DESCRIPTION
Technical:
- `runtime_tests` and `examples_tests` each gain a `Resolve <repo> ref` step that picks `next` over `main` when `next` exists on origin and is strictly ahead of `main`. Selection uses `git ls-remote` to compare SHAs and a shallow clone with `git merge-base --is-ancestor` to verify the ancestor condition. Selected ref is exported as a step output and passed to `actions/checkout`. Fall-through is `main`; behaviour is unchanged when no `next` exists. Stages breaking compiler changes that need synchronous runtime/examples source updates.