### PR TITLE
Bump ghul.runtime 1.3.6 → 2.0.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.8.120",
+      "version": "0.8.122",
       "commands": [
         "ghul-compiler"
       ],

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <ItemGroup>
     <!-- ghūl runtime -->
-    <PackageVersion Include="ghul.runtime" Version="1.3.6" />
+    <PackageVersion Include="ghul.runtime" Version="2.0.0" />
 
     <!-- ghūl compiler dependencies -->
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />

--- a/project-tests/runtime-pipes/adaptor-pipe-tests.ghul
+++ b/project-tests/runtime-pipes/adaptor-pipe-tests.ghul
@@ -15,7 +15,7 @@ namespace Tests is
         Pipe_FromArray_ReturnsInstanceOfADAPTOR_PIPE() is
             @test()
 
-            let pipe = Ghul.Pipes.Pipe`[int].from([1, 2, 3, 4, 5]);
+            let pipe = Ghul.Pipes.Factory.from`[int]([1, 2, 3, 4, 5]);
 
             expect_equal(pipe.get_type(), typeof ADAPTOR_PIPE[int]);
             Assert.is_instance_of_type(pipe, typeof ADAPTOR_PIPE[int]);

--- a/project-tests/runtime-pipes/cat-pipe-tests.ghul
+++ b/project-tests/runtime-pipes/cat-pipe-tests.ghul
@@ -18,8 +18,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from(empty`[int]())
+                Ghul.Pipes.Factory.from`[int](empty`[int]())
                     .cat(empty`[int]());
 
             expect_equal(empty`[int]() |, pipe);
@@ -31,8 +30,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from(empty`[int]())
+                Ghul.Pipes.Factory.from`[int](empty`[int]())
                     .cat([1, 2, 3, 4, 5]);
 
             expect_equal([1, 2, 3, 4, 5] |, pipe);
@@ -43,8 +41,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from([1, 2, 3, 4, 5])
+                Ghul.Pipes.Factory.from`[int]([1, 2, 3, 4, 5])
                     .cat(empty`[int]());
 
             expect_equal([1, 2, 3, 4, 5] |, pipe);
@@ -55,8 +52,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from([1, 2, 3, 4, 5])
+                Ghul.Pipes.Factory.from`[int]([1, 2, 3, 4, 5])
                     .cat([6, 7, 8, 9, 10]);
 
             expect_equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 10] |, pipe);
@@ -67,8 +63,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from([3, 4, 5])
+                Ghul.Pipes.Factory.from`[int]([3, 4, 5])
                     .cat([1, 2, 1])
                     .cat(empty`[int]())
                     .cat([2, 3, 4])
@@ -84,8 +79,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from([3, 4, 5])
+                Ghul.Pipes.Factory.from`[int]([3, 4, 5])
                     .cat([1, 2, 1])
                     .cat(empty`[int]())
                     .cat([2, 3, 4])

--- a/project-tests/runtime-pipes/filter-pipe-tests.ghul
+++ b/project-tests/runtime-pipes/filter-pipe-tests.ghul
@@ -16,8 +16,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from([3, 4, 5, 1, 2, 1, 2, 3, 4, 5]);
+                Ghul.Pipes.Factory.from`[int]([3, 4, 5, 1, 2, 1, 2, 3, 4, 5]);
 
 
             let result = 
@@ -32,8 +31,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from([3, 4, 1, 5, 2, 3, 1, 4, 5]);
+                Ghul.Pipes.Factory.from`[int]([3, 4, 1, 5, 2, 3, 1, 4, 5]);
 
             let result =
                 pipe
@@ -47,8 +45,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from([1, 2, 1, 3, 4, 5, 6, 7]);
+                Ghul.Pipes.Factory.from`[int]([1, 2, 1, 3, 4, 5, 6, 7]);
 
             let result =
                 pipe
@@ -62,8 +59,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from([7, 6, 5, 4, 3, 2, 1]);
+                Ghul.Pipes.Factory.from`[int]([7, 6, 5, 4, 3, 2, 1]);
 
             let result =
                 pipe
@@ -77,8 +73,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+                Ghul.Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result =
                 pipe

--- a/project-tests/runtime-pipes/index-pipe-tests.ghul
+++ b/project-tests/runtime-pipes/index-pipe-tests.ghul
@@ -16,8 +16,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from(empty`[int]());
+                Ghul.Pipes.Factory.from`[int](empty`[int]());
 
             let result = 
                 pipe
@@ -31,8 +30,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[string]
-                    .from(["3", "4", "1", "5", "2", "3", "1", "4", "5"]);
+                Ghul.Pipes.Factory.from`[string](["3", "4", "1", "5", "2", "3", "1", "4", "5"]);
 
             let result = 
                 pipe
@@ -46,8 +44,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[string]
-                    .from(["3", "4", "1", "5", "2", "3", "1", "4", "5"]);
+                Ghul.Pipes.Factory.from`[string](["3", "4", "1", "5", "2", "3", "1", "4", "5"]);
 
             let result = 
                 pipe
@@ -61,8 +58,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[string]
-                    .from(["3", "4", "1", "5", "2", "3", "1", "4", "5"]);
+                Ghul.Pipes.Factory.from`[string](["3", "4", "1", "5", "2", "3", "1", "4", "5"]);
 
             let result = 
                 pipe

--- a/project-tests/runtime-pipes/map-pipe-tests.ghul
+++ b/project-tests/runtime-pipes/map-pipe-tests.ghul
@@ -16,8 +16,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from(empty`[int]());
+                Ghul.Pipes.Factory.from`[int](empty`[int]());
 
             let result = 
                 pipe
@@ -31,8 +30,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from([3, 4, 1, 5, 2, 3, 1, 4, 5]);
+                Ghul.Pipes.Factory.from`[int]([3, 4, 1, 5, 2, 3, 1, 4, 5]);
 
             let result = 
                 pipe
@@ -46,8 +44,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from([1, 2, 3, 4, 5, 6]);
+                Ghul.Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6]);
 
             let result = 
                 pipe

--- a/project-tests/runtime-pipes/pipe-tests.ghul
+++ b/project-tests/runtime-pipes/pipe-tests.ghul
@@ -17,7 +17,7 @@ namespace Tests is
         Pipe_SkipThenFirst_ReturnsCorrectElement() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             Assert.are_equal(MAYBE[int](6), pipe.skip(5).first());
         si
@@ -25,7 +25,7 @@ namespace Tests is
         Pipe_TakeThenFirst_ReturnsFirstElement() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             Assert.are_equal(MAYBE[int](1), pipe.take(5).first());
         si
@@ -33,7 +33,7 @@ namespace Tests is
         Pipe_FirstEmptySequence_ReturnsMaybeNot() is
             @test()
 
-            let pipe = Pipe`[int].from(empty`[int]());
+            let pipe = Pipes.Factory.from`[int](empty`[int]());
 
             let first = pipe.first();
             let expected = MAYBE[int]();
@@ -44,7 +44,7 @@ namespace Tests is
         Pipe_FindEmptySequence_ReturnsMaybeNot() is
             @test()
 
-            let pipe = Pipe`[int].from(empty`[int]());
+            let pipe = Pipes.Factory.from`[int](empty`[int]());
 
             let found = pipe.find(i => i > 10);
             let expected = MAYBE[int]();
@@ -55,7 +55,7 @@ namespace Tests is
         Pipe_FindNonEmptySequenceButNoMatch_ReturnsMaybeNot() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
             let found = pipe.find(i => i == 10);
             let expected = MAYBE[int]();
@@ -66,7 +66,7 @@ namespace Tests is
         Pipe_FindSingleMatchingElement_ReturnsThatElement() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
             let found = pipe.find(i => i == 4);
             let expected = MAYBE[int](4);
@@ -79,7 +79,7 @@ namespace Tests is
 
             let array = [THING(1), THING(2), THING(3), THING(4), THING(3), THING(2), THING(3), THING(8), THING(9)];
 
-            let pipe = Pipe`[THING].from(array);
+            let pipe = Pipes.Factory.from`[THING](array);
 
             let found = pipe.find(t => t.key == 3);
             let expected = MAYBE[THING](array[2]);
@@ -90,7 +90,7 @@ namespace Tests is
         Pipe_HasNoElements_ReturnsFalse() is
             @test()
 
-            let pipe = Pipe`[int].from(empty`[int]());
+            let pipe = Pipes.Factory.from`[int](empty`[int]());
 
             Assert.is_false(pipe.has(i => i == 4));
         si
@@ -98,7 +98,7 @@ namespace Tests is
         Pipe_HasSomeElementsButNoneMatch_ReturnsFalse() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
             Assert.is_false(pipe.has(i => i == 99));
         si
@@ -106,7 +106,7 @@ namespace Tests is
         Pipe_HasSomeElementsOneMatches_ReturnsTrue() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
             Assert.is_true(pipe.has(i => i == 4));
         si
@@ -114,7 +114,7 @@ namespace Tests is
         Pipe_HasSomeElementsMultipleMatches_ReturnsTrue() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
             Assert.is_true(pipe.has(i => i > 4));
         si
@@ -122,7 +122,7 @@ namespace Tests is
         Pipe_SkipThenFilter_ReturnsFilteredTailSequence() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.skip(5).filter(i => (i ∩ 1) == 0);
 
@@ -132,7 +132,7 @@ namespace Tests is
         Pipe_FilterThenSkip_ReturnsFilteredTailSequence() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.filter(i => (i ∩ 1) == 0).skip(1);
 
@@ -142,7 +142,7 @@ namespace Tests is
         Pipe_SkipThenIndex_StartsIndexingFromZero() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.skip(4).index();
 
@@ -152,7 +152,7 @@ namespace Tests is
         Pipe_IndexThenSkip_StartsIndexingFromCorrectOffset() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.index().skip(6);
 
@@ -162,7 +162,7 @@ namespace Tests is
         Pipe_TakeThenFilter_ReturnsFilteredHeadSequence() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.take(5).filter(i => (i ∩ 1) == 0);
 
@@ -172,7 +172,7 @@ namespace Tests is
         Pipe_FilterThenTake_ReturnsFilteredHeadSequence() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.filter(i => (i ∩ 1) == 0).take(3);
 
@@ -182,7 +182,7 @@ namespace Tests is
         Pipe_IndexThenFilter_RetainsOriginalIndexes() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.index().filter(i => (i.value ∩ 1) == 1);
 
@@ -192,7 +192,7 @@ namespace Tests is
         Pipe_FilterThenIndex_AppliesNewIndexes() is
             @test()
 
-            let pipe = Pipe`[int].from([3, 4, 1, 5, 2, 3, 1, 4, 5]);
+            let pipe = Pipes.Factory.from`[int]([3, 4, 1, 5, 2, 3, 1, 4, 5]);
 
             let result = pipe.filter(i => i > 2).index();
 
@@ -202,7 +202,7 @@ namespace Tests is
         Pipe_SkipThenMap_ReturnsMappedTailSequence() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.skip(5).map(i => "X" + i);
 
@@ -212,7 +212,7 @@ namespace Tests is
         Pipe_MapThenSkip_ReturnsMappedTailSequence() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.map(i => "X" + i).skip(5);
 
@@ -222,7 +222,7 @@ namespace Tests is
         Pipe_TakeThenMap_ReturnsMappedHeadSequence() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.take(4).map(i => "X" + i);
 
@@ -232,7 +232,7 @@ namespace Tests is
         Pipe_MapThenTake_ReturnsMappedHeadSequence() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.map(i => "X" + i).take(6);
 
@@ -242,7 +242,7 @@ namespace Tests is
         Pipe_TakeThenIndex_StartsIndexingFromZero() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.take(4).index();
 
@@ -252,7 +252,7 @@ namespace Tests is
         Pipe_IndexThenTake_StartsIndexingFromZero() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.index().take(6);
 
@@ -262,7 +262,7 @@ namespace Tests is
         Pipe_FilterThenFilter_ReturnsOnlyElementsThatMatchBothPredicates() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.filter(i => i > 3 /\ i < 9).filter(i => (i ∩ 1) == 0);
 
@@ -272,7 +272,7 @@ namespace Tests is
         Pipe_MapThenMap_AppliesBothFunctionsToEveryElementInCorrectOrder() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6]);
 
             let result = pipe.map(i => "" + i + "-first").map(i => i + "-second");
 
@@ -282,7 +282,7 @@ namespace Tests is
         Pipe_Running() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6]);
 
             let result = pipe.reduce(0, (running, element) => running + element);
 
@@ -292,7 +292,7 @@ namespace Tests is
         Pipe_Mapped_Running() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6]);
 
             let result = pipe.reduce(0, (running, element) => running + element, total => "total: " + total);
 
@@ -302,7 +302,7 @@ namespace Tests is
         Sort_NoComparer_SortsInDefaultOrder() is
             @test()
 
-            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+            let pipe = Pipes.Factory.from`[int]([2, 1, 4, 3, 6, 5]);
 
             let result = pipe.sort();
 
@@ -312,7 +312,7 @@ namespace Tests is
         Sort_GivenComparer_SortsInComparerOrder() is
             @test()
 
-            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+            let pipe = Pipes.Factory.from`[int]([2, 1, 4, 3, 6, 5]);
 
             let result = pipe.sort(ReverseIntComparer());
 
@@ -322,7 +322,7 @@ namespace Tests is
         Sort_GivenCompareFunction_SortsInCompareFunctionOrder() is
             @test()
 
-            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+            let pipe = Pipes.Factory.from`[int]([2, 1, 4, 3, 6, 5]);
 
             let result = pipe.sort((x, y) => y - x);
 
@@ -332,7 +332,7 @@ namespace Tests is
         Sort_CalledTwice_SortsInLastComparerOrder() is
             @test()
 
-            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+            let pipe = Pipes.Factory.from`[int]([2, 1, 4, 3, 6, 5]);
 
             let result = pipe.sort().sort(ReverseIntComparer());
 
@@ -342,7 +342,7 @@ namespace Tests is
         Sort_EnumeratedTwice_ReturnsSameResultBothTimes() is
             @test()
 
-            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+            let pipe = Pipes.Factory.from`[int]([2, 1, 4, 3, 6, 5]);
 
             let sorted = pipe.sort(ReverseIntComparer());
 
@@ -354,7 +354,7 @@ namespace Tests is
         ToString_WithNoSeparatorArgument_ReturnsStringRepresentationOfAllElementsSeparatedWithACommaAndSpace() is
             @test()
 
-            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+            let pipe = Pipes.Factory.from`[int]([2, 1, 4, 3, 6, 5]);
 
             let result = pipe.to_string();
 
@@ -364,7 +364,7 @@ namespace Tests is
         ToString_WithSeparatorArgument_ReturnsStringRepresentationOfAllElementsSeparatedWithThatSeparator() is
             @test()
 
-            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+            let pipe = Pipes.Factory.from`[int]([2, 1, 4, 3, 6, 5]);
 
             let result = pipe.to_string("///");
 
@@ -374,7 +374,7 @@ namespace Tests is
         ToString_CalledTwice_ReturnsStringRepresentationOfAllElements() is
             @test()
 
-            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+            let pipe = Pipes.Factory.from`[int]([2, 1, 4, 3, 6, 5]);
 
             pipe.to_string();
 
@@ -386,7 +386,7 @@ namespace Tests is
         AppendTo_WithNoSeparatorArgument_AppendsStringRepresentationOfAllElementsSeparatedWithACommaAndSpace() is
             @test()
 
-            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+            let pipe = Pipes.Factory.from`[int]([2, 1, 4, 3, 6, 5]);
 
             let result = StringBuilder("XX");
 
@@ -398,7 +398,7 @@ namespace Tests is
         AppendTo_WithSeparatorArgument_AppendsStringRepresentationOfAllElementsSeparatedWithThatSeparator() is
             @test()
 
-            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+            let pipe = Pipes.Factory.from`[int]([2, 1, 4, 3, 6, 5]);
 
             let result = StringBuilder("XX");
 
@@ -410,7 +410,7 @@ namespace Tests is
         AppendTo_CalledTwice_AppendsStringRepresentationOfAllElementsTwice() is
             @test()
 
-            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+            let pipe = Pipes.Factory.from`[int]([2, 1, 4, 3, 6, 5]);
 
             let result = StringBuilder("XX");
 

--- a/project-tests/runtime-ranges/int-range-inclusive.ghul
+++ b/project-tests/runtime-ranges/int-range-inclusive.ghul
@@ -13,7 +13,7 @@ namespace Tests is
 
             expect_equal(range | .count(), 11);
 
-            Assert.are_equal(Pipes.Pipe`[int].from(range) .count(), 11);
+            Assert.are_equal(Pipes.Factory.from`[int](range) .count(), 11);
         si        
 
         INT_RANGE_INCLUSIVE__init__given_0_to_10__constructs_range_with_11_elements_consecutive_elements_0_through_10() is
@@ -31,7 +31,7 @@ namespace Tests is
             let range = Ghul.INT_RANGE_INCLUSIVE(10, 0);
 
             expect_equal(range | .count(), 0);
-            Assert.are_equal(Pipes.Pipe`[int].from(range) .count(), 0);
+            Assert.are_equal(Pipes.Factory.from`[int](range) .count(), 0);
         si
 
         INT_RANGE_INCLUSIVE__init__given_50_to_50__constructs_range_with_1_elements() is
@@ -40,7 +40,7 @@ namespace Tests is
             let range = Ghul.INT_RANGE_INCLUSIVE(50, 50);
 
             expect_equal(range | .count(), 1);
-            Assert.are_equal(Pipes.Pipe`[int].from(range) .count(), 1);
+            Assert.are_equal(Pipes.Factory.from`[int](range) .count(), 1);
         si
 
         INT_RANGE_INCLUSIVE__colon_colon__given_0_to_10__constructs_range_with_consecutive_elements_0_through_10() is
@@ -66,7 +66,7 @@ namespace Tests is
 
             let range = 0::10;
             
-            Pipes.Pipe`[int].from(range) .take(5);
+            Pipes.Factory.from`[int](range) .take(5);
 
             expect_equal(range |, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] |);
             assert_equal(range, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);

--- a/project-tests/runtime-ranges/int-range.ghul
+++ b/project-tests/runtime-ranges/int-range.ghul
@@ -12,7 +12,7 @@ namespace Tests is
             let range = Ghul.INT_RANGE(0, 10);
 
             expect_equal(range | .count(), 10);
-            Assert.are_equal(Pipes.Pipe`[int].from(range) .count(), 10);
+            Assert.are_equal(Pipes.Factory.from`[int](range) .count(), 10);
         si        
 
         INT_RANGE__init__given_0_to_10__constructs_range_with_10_elements_consecutive_elements_0_through_9() is
@@ -30,7 +30,7 @@ namespace Tests is
             let range = Ghul.INT_RANGE(10, 0);
 
             expect_equal(range | .count(), 0);
-            Assert.are_equal(Pipes.Pipe`[int].from(range) .count(), 0);
+            Assert.are_equal(Pipes.Factory.from`[int](range) .count(), 0);
         si
 
         INT_RANGE__init__given_50_to_50__constructs_range_with_0_elements() is
@@ -39,7 +39,7 @@ namespace Tests is
             let range = Ghul.INT_RANGE(50, 50);
 
             expect_equal(range | .count(), 0);
-            Assert.are_equal(Pipes.Pipe`[int].from(range) .count(), 0);
+            Assert.are_equal(Pipes.Factory.from`[int](range) .count(), 0);
         si
 
         INT_RANGE__dot_dot__given_0_to_10__constructs_range_with_consecutive_elements_0_through_9() is
@@ -65,7 +65,7 @@ namespace Tests is
 
             let range = 0..10;
             
-            Pipes.Pipe`[int].from(range) .take(5);
+            Pipes.Factory.from`[int](range) .take(5);
 
             expect_equal(range |, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] |);
             assert_equal(range, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);


### PR DESCRIPTION
Technical:

- ghul-runtime 2.0.0 (degory/ghul-runtime#74, released 2026-05-10) converted `Ghul.Pipes.Pipe[T]` from class to trait. Source-compat preserved for callers that use the `|` operator (parser desugar already routes through `Ghul.Pipes.pipe` since #1261); the one removed entry point is `Pipe.from` static, replaced by `Pipes.Factory.from`.
- `project-tests/runtime-pipes/` and `project-tests/runtime-ranges/` called `Pipe.from(...)` directly; rewritten to `Pipes.Factory.from(...)`.
- Pins `ghul.compiler` 0.8.120 → 0.8.122.