### PR TITLE
Migrate ghul/src to trailing `mut` for reassigned local bindings

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.9.1",
+      "version": "0.9.5",
       "commands": [
         "ghul-compiler"
       ],

--- a/src/analysis/command_despatcher.ghul
+++ b/src/analysis/command_despatcher.ghul
@@ -103,10 +103,10 @@ namespace Analysis is
         si
 
         read_command() -> string is
-            let desynchronized = false;
+            let desynchronized mut = false;
 
             do
-                let command = _reader.read_line();
+                let command mut = _reader.read_line();
 
                 if !command? then
                     break;
@@ -129,7 +129,7 @@ namespace Analysis is
                 fi
 
                 if !desynchronized then
-                    let length = command.length;
+                    let length mut = command.length;
 
                     if length > 20 then
                         length = 20;

--- a/src/analysis/command_handlers.ghul
+++ b/src/analysis/command_handlers.ghul
@@ -36,11 +36,11 @@ namespace Analysis is
             let line = System.Convert.to_int32(reader.read_line());
             let column = System.Convert.to_int32(reader.read_line());
 
-            let written_header = false;
+            let written_header mut = false;
             
             try
                 if !_watchdog.want_restart then
-                    let symbol = _symbol_use_locations.find_hover_use(path, line, column);
+                    let symbol mut = _symbol_use_locations.find_hover_use(path, line, column);
 
                     if !symbol? then
                         _full_compiler.compile_all(writer);
@@ -95,11 +95,11 @@ namespace Analysis is
             let line = System.Convert.to_int32(reader.read_line());
             let column = System.Convert.to_int32(reader.read_line());
 
-            let written_header = false;
+            let written_header mut = false;
 
             try
                 if !_watchdog.want_restart then
-                    let symbol = _symbol_use_locations.find_definition_from_use(path, line, column);
+                    let symbol mut = _symbol_use_locations.find_definition_from_use(path, line, column);
 
                     if !symbol? then
                         _full_compiler.compile_all(writer);
@@ -147,7 +147,7 @@ namespace Analysis is
         handle(reader: IO.TextReader, writer: IO.TextWriter) is
             IoC.CONTAINER.instance.want_tab_delimited_logger(writer);
 
-            let written_header = false;
+            let written_header mut = false;
 
             try
                 let path = reader.read_line();
@@ -155,7 +155,7 @@ namespace Analysis is
                 let column = System.Convert.to_int32(reader.read_line());
 
                 if !_watchdog.want_restart then
-                    let symbol = _symbol_use_locations.find_definition_from_use(path, line, column);
+                    let symbol mut = _symbol_use_locations.find_definition_from_use(path, line, column);
 
                     if !symbol? then
                         _full_compiler.compile_all(writer);
@@ -504,7 +504,7 @@ namespace Analysis is
         si
 
         handle(reader: IO.TextReader, writer: IO.TextWriter) is
-            let written_header = false;
+            let written_header mut = false;
 
             // TODO if we're completing a member expression, this is not required:
             _full_compiler.compile_all(writer);
@@ -566,7 +566,7 @@ namespace Analysis is
         si
 
         handle(reader: IO.TextReader, writer: IO.TextWriter) is
-            let written_header = false;
+            let written_header mut = false;
 
             try
                 let path = reader.read_line();
@@ -652,7 +652,7 @@ namespace Analysis is
         si
 
         handle(reader: IO.TextReader, writer: IO.TextWriter) is
-            let written_header = false;
+            let written_header mut = false;
 
             try
                 let path = reader.read_line();
@@ -791,7 +791,7 @@ namespace Analysis is
         handle(reader: IO.TextReader, writer: IO.TextWriter) is
             IoC.CONTAINER.instance.want_tab_delimited_logger(writer);
 
-            let written_header = false;
+            let written_header mut = false;
 
             try
                 let path = reader.read_line();
@@ -799,7 +799,7 @@ namespace Analysis is
                 let column = System.Convert.to_int32(reader.read_line());
 
                 if !_watchdog.want_restart then
-                    let symbol = _symbol_use_locations.find_definition_from_use(path, line, column);
+                    let symbol mut = _symbol_use_locations.find_definition_from_use(path, line, column);
 
                     if !symbol? then
                         _full_compiler.compile_all(writer);
@@ -853,7 +853,7 @@ namespace Analysis is
 
             _full_compiler.compile_all(writer);
 
-            let written_header = false;
+            let written_header mut = false;
 
             try
                 let path = reader.read_line();
@@ -911,7 +911,7 @@ namespace Analysis is
             // i.e. if it's a local variable - then this is not required:
             _full_compiler.compile_all(writer);
 
-            let written_header = false;
+            let written_header mut = false;
 
             try
                 let path = reader.read_line();

--- a/src/driver/arguments_parser.ghul
+++ b/src/driver/arguments_parser.ghul
@@ -11,7 +11,7 @@ namespace Driver is
 
             let input = arguments.iterator;
 
-            let more = input.move_next();
+            let more mut = input.move_next();
 
             while more do
                 more = _skip_whitespace(input);
@@ -20,7 +20,7 @@ namespace Driver is
                     return results;
                 fi
                 
-                let argument: string;
+                let argument: string mut;
 
                 (argument, more) =
                     if input.current == '"' \/ input.current == '\'' then
@@ -36,7 +36,7 @@ namespace Driver is
         si
 
         _skip_whitespace(input: Iterator[char]) -> bool is
-            let more = true;
+            let more mut = true;
 
             while more /\ char.is_white_space(input.current) do
                 more = input.move_next();
@@ -49,7 +49,7 @@ namespace Driver is
             // FIXME: doesn't support nested/escaped quotes, but neither do the MSBuild targets
             let result = System.Text.StringBuilder();
 
-            let more = input.move_next(); // skip opening quote
+            let more mut = input.move_next(); // skip opening quote
 
             while more /\ input.current != quote do
                 result.append(input.current);
@@ -62,7 +62,7 @@ namespace Driver is
 
         _parse_unquoted_argument(input: Iterator[char]) -> (argument: string, more: bool) is
             let result = System.Text.StringBuilder();
-            let more = true;
+            let more mut = true;
 
             while more /\ !char.is_white_space(input.current) do
                 result.append(input.current);

--- a/src/driver/main.ghul
+++ b/src/driver/main.ghul
@@ -97,7 +97,7 @@ namespace Driver is
         si
 
         init(arguments: LIST[string]) is
-            let result = 1;
+            let result mut = 1;
 
             try
                 Std.input_encoding = System.Text.UTF8Encoding(false);
@@ -176,7 +176,7 @@ namespace Driver is
             si;
 
             let conditional_defines = Collections.LIST[string]();
-            let emit_boilerplate_il_path: string;
+            let emit_boilerplate_il_path: string mut;
 
             for s in args_iterator do
                 if s =~ "-A" \/ s =~ "--analyse" then
@@ -243,7 +243,7 @@ namespace Driver is
                             fi
 
                             let b = System.Text.StringBuilder();
-                            let seen_any = false;
+                            let seen_any mut = false;
 
                             for p in version_parts do
                                 if seen_any then
@@ -357,7 +357,7 @@ namespace Driver is
 
         finish_build_dotnet() -> int is
             let ir_context = container.ir_context;
-            let output_file = output_file_name_generator.result;
+            let output_file mut = output_file_name_generator.result;
 
             if emit_boilerplate_il? then
                 container.ir_context.write(emit_boilerplate_il);
@@ -380,7 +380,7 @@ namespace Driver is
                 return 0;
             fi
 
-            let ilasm_args = 
+            let ilasm_args mut = 
                 "-quiet out.il -output={output_file}";
 
             if flags.want_debug then
@@ -391,7 +391,7 @@ namespace Driver is
 
             ilasm.wait_for_exit();
 
-            let result = ilasm.exit_code;
+            let result mut = ilasm.exit_code;
 
             if result != 0 then
                 Std.error.write_line("error: ilasm failed");
@@ -449,7 +449,7 @@ namespace Driver is
             od
         si
 
-        queue_library_location(directory: string) is
+        queue_library_location(directory: string mut) is
             if !directory.ends_with('/') then
                 directory = "{directory}/";
             fi

--- a/src/driver/output_file_name_generator.ghul
+++ b/src/driver/output_file_name_generator.ghul
@@ -20,7 +20,7 @@ namespace Driver is
             _current = path;
         si
 
-        seen_file(path: string) is
+        seen_file(path: string mut) is
             if _current? then
                 return;
             fi

--- a/src/driver/path_config.ghul
+++ b/src/driver/path_config.ghul
@@ -37,8 +37,8 @@ namespace Driver is
                 return _ilasm_path;
             fi
             
-            let os: string;
-            let file_extension: string = "";
+            let os: string mut;
+            let file_extension: string mut = "";
             if RuntimeInformation.is_o_s_platform(OSPlatform.linux) then
                 os = "linux";
             elif RuntimeInformation.is_o_s_platform(OSPlatform.osx) then
@@ -115,7 +115,7 @@ namespace Driver is
             return result;            
         si
 
-        get_library_location(directory: string) -> string is
+        get_library_location(directory: string mut) -> string is
             if !directory.starts_with('/') then
                 directory = "{library_prefix}{directory}";
             fi

--- a/src/ir/boilerplate_generator.ghul
+++ b/src/ir/boilerplate_generator.ghul
@@ -19,7 +19,7 @@ namespace IR is
         si
 
         gen(name: string, args: Collections.Iterable[string]) is
-            let snippet: string;
+            let snippet: string mut;
             
             if !_snippets.contains_key(name) then
                 // FIXME use path concatenation
@@ -31,7 +31,7 @@ namespace IR is
             fi
 
             if args? then
-                let index = 0;
+                let index mut = 0;
                 for a in args do
                     // this is e.g. replace('${0}') after the escapes and interpolation:
                     snippet = snippet.replace("${{{index}}}", a);

--- a/src/ir/context.ghul
+++ b/src/ir/context.ghul
@@ -202,7 +202,7 @@ namespace IR is
         si
 
         enter_file(path: string, want_comments: bool) is
-            let writer: IO.TextWriter;
+            let writer: IO.TextWriter mut;
 
             if _seen.contains(path) then
                 writer = File.append_text(path);

--- a/src/ir/innate_operation_generator.ghul
+++ b/src/ir/innate_operation_generator.ghul
@@ -150,8 +150,8 @@ namespace IR is
 
             let actual_operation = value.actual_operation;
 
-            let needs_not = false;
-            let instruction: string;
+            let needs_not mut = false;
+            let instruction: string mut;
 
             if actual_operation =~ ">" then
                 instruction = "cgt";
@@ -199,8 +199,8 @@ namespace IR is
         gen_compare_reference(value: INNATE, block: BLOCK) is
             assert value.arguments? /\ value.arguments.count == 2 else "compare reference missing arguments";
 
-            let left = value.arguments[0];
-            let right = value.arguments[1];
+            let left mut = value.arguments[0];
+            let right mut = value.arguments[1];
 
             if left.is_value_type != right.is_value_type then
                 left = _boxer.box_if_value(left);
@@ -236,7 +236,7 @@ namespace IR is
 
             gen_arguments(value, block);
 
-            let prefix = "['ghul-runtime']";
+            let prefix mut = "['ghul-runtime']";
 
             if _flags.want_stubs then
                 prefix = "";

--- a/src/ir/value_boxer.ghul
+++ b/src/ir/value_boxer.ghul
@@ -44,7 +44,7 @@ namespace IR is
                 return arguments;
             fi
 
-            let any_need_boxing = false;
+            let any_need_boxing mut = false;
 
             for i in 0..arguments.count do
                 if

--- a/src/ir/values/call/closure.ghul
+++ b/src/ir/values/call/closure.ghul
@@ -34,7 +34,7 @@ namespace IR.Values.Call is
         gen(context: IR.CONTEXT) is
             gen(from, context);
 
-            let count = 0;
+            let count mut = 0;
             for a in arguments do
                 gen(a, context);
 

--- a/src/ir/values/compare_order_to_zero.ghul
+++ b/src/ir/values/compare_order_to_zero.ghul
@@ -23,8 +23,8 @@ namespace IR.Values is
         si
 
         gen(context: IR.CONTEXT) is
-            let instruction: string;
-            let needs_not = false;
+            let instruction: string mut;
+            let needs_not mut = false;
 
             if actual_operation =~ ">" then
                 instruction = "cgt";

--- a/src/ir/values/tuple.ghul
+++ b/src/ir/values/tuple.ghul
@@ -29,8 +29,8 @@ namespace IR.Values is
             call
                 .append(" ::'.ctor'(");
 
-            let i = 0;
-            let seen_any = false;
+            let i mut = 0;
+            let seen_any mut = false;
 
             for v in values do
                 gen(v, context);

--- a/src/lexical/token_lookahead.ghul
+++ b/src/lexical/token_lookahead.ghul
@@ -15,7 +15,7 @@ namespace Lexical is
         si
 
         record_backtrack(from: int, to: int) is
-            let count = 0;
+            let count mut = 0;
 
 /*
             // FIXME generates invalid IL - suspect

--- a/src/lexical/token_names.ghul
+++ b/src/lexical/token_names.ghul
@@ -128,7 +128,7 @@ namespace Lexical is
             sorted_tokens.sort();
             
             let buffer = System.Text.StringBuilder();
-            let seen_any = false;
+            let seen_any mut = false;
 
             for s in sorted_tokens do
                 if seen_any then
@@ -138,7 +138,7 @@ namespace Lexical is
                 seen_any = true;
             od
 
-            let result = buffer.to_string();
+            let result mut = buffer.to_string();
 
             let i = result.last_index_of(',');
 

--- a/src/lexical/tokenizer.ghul
+++ b/src/lexical/tokenizer.ghul
@@ -197,7 +197,7 @@ namespace Lexical is
         si
 
         next_char() -> char is
-            let c: char;
+            let c: char mut;
 
             if _prev_char != cast char(0) then
                 c = _prev_char;
@@ -210,7 +210,7 @@ namespace Lexical is
                 return ' ';
             fi
             
-            let c0: int = _input.read();
+            let c0: int mut = _input.read();
 
             if c0 == 13 then
                 c0 = 32;
@@ -239,8 +239,8 @@ namespace Lexical is
         si
 
         read_escape() -> char is
-            let c: char = next_char();
-            let result: int = 0;
+            let c: char mut = next_char();
+            let result: int mut = 0;
             if c == 't' then
                 return cast char(9);
             elif c == 'n' then
@@ -263,7 +263,7 @@ namespace Lexical is
         si
 
         skip_white_space() -> char is
-            let c: char;
+            let c: char mut;
             do
                 c = next_char();
 
@@ -283,9 +283,9 @@ namespace Lexical is
         si
         
         read_token() -> TOKEN_PAIR is
-            let r: TOKEN;
+            let r: TOKEN mut;
 
-            let c = skip_white_space();
+            let c mut = skip_white_space();
 
             if _end_of_file then
                 return TOKEN_PAIR(TOKEN.END_OF_INPUT, location, null);
@@ -293,7 +293,7 @@ namespace Lexical is
 
             _cursor.start();
 
-            let _buffer: System.Text.StringBuilder = null;
+            let _buffer: System.Text.StringBuilder mut = null;
 
             if _expect_format_string then
                 _expect_format_string = false;
@@ -320,7 +320,7 @@ namespace Lexical is
                 return TOKEN_PAIR(TOKEN.FORMAT_STRING, location, _buffer.to_string());
 
             elif c >= '0' /\ c <= '9' then
-                let is_float = false;
+                let is_float mut = false;
 
                 _buffer = System.Text.StringBuilder();
                 _buffer.append(c);
@@ -338,8 +338,8 @@ namespace Lexical is
                         c = next_char();                                
                     od
                 else
-                    let seen_dot = false;
-                    let pc: char;
+                    let seen_dot mut = false;
+                    let pc: char mut;
 
                     while 
                         (c >= '0' /\ c <= '9') \/ c == '.' \/ c == '_'
@@ -439,7 +439,7 @@ namespace Lexical is
 
                 _buffer = System.Text.StringBuilder();
 
-                let prev_c: char;
+                let prev_c: char mut;
 
                 while (c>='a'/\c<='z') \/ (c>='A'/\c<='Z') \/ (c>='0'/\c<='9') \/ c=='_' \/ c == '`' do
                     _buffer.append(c);
@@ -575,7 +575,7 @@ namespace Lexical is
             return TOKEN_PAIR(TOKEN.UNKNOWN, location, "{c}");
         si
 
-        read_operator(c: char) -> TOKEN_PAIR is
+        read_operator(c: char mut) -> TOKEN_PAIR is
             let _buffer = System.Text.StringBuilder();
 
             while _operator_chars.contains(c) \/ (cast int(c) > 0x7E /\ char.is_symbol(c)) do
@@ -591,7 +591,7 @@ namespace Lexical is
 
             let s = _buffer.to_string();
 
-            let r = TOKEN.OPERATOR;
+            let r mut = TOKEN.OPERATOR;
             
             if _operator_tokens.contains_key(s) then
                 r = _operator_tokens[s];
@@ -603,7 +603,7 @@ namespace Lexical is
         read_string_fragment() -> (fragment: string, c: char) is
             let fragment = System.Text.StringBuilder();
 
-            let c = next_char();
+            let c mut = next_char();
 
             while c != '\n' /\ c != '"' do
                 if c == cast char(92) then
@@ -664,10 +664,10 @@ namespace Lexical is
         chain_adjacent_string_fragments(initial_fragment: string, initial_terminator: char) -> (fragment: string, c: char, loc: Source.LOCATION) is
             let buffer = System.Text.StringBuilder();
             buffer.append(initial_fragment);
-            let c = initial_terminator;
-            let saved_loc = location;
+            let c mut = initial_terminator;
+            let saved_loc mut = location;
 
-            let done = false;
+            let done mut = false;
             while !done /\ c == '"' do
                 let peeked = skip_white_space();
                 if peeked == '"' then
@@ -685,9 +685,9 @@ namespace Lexical is
         si
 
         string_enter() -> TOKEN_PAIR is
-            let (fragment, c) = read_string_fragment();
+            let (fragment, c) mut = read_string_fragment();
 
-            let loc: Source.LOCATION;
+            let loc: Source.LOCATION mut;
             (fragment, c, loc) = chain_adjacent_string_fragments(fragment, c);
 
             if c == '\n' then
@@ -711,20 +711,20 @@ namespace Lexical is
             _interpolation_depth = 0;
         si
 
-        interpolation_exit(c: char) -> TOKEN_PAIR is
+        interpolation_exit(c: char mut) -> TOKEN_PAIR is
             if _interpolation_depth == 0 then
                 _logger.error(character_location, "unmatched '\"'");
                 next_char();
                 return read_token();
             fi
 
-            let fragment = "";
+            let fragment mut = "";
 
             if c == '}' then
                 (fragment, c) = read_string_fragment();
             fi
 
-            let loc: Source.LOCATION;
+            let loc: Source.LOCATION mut;
             (fragment, c, loc) = chain_adjacent_string_fragments(fragment, c);
 
             if c == '\n' then

--- a/src/logging/diagnostics_store.ghul
+++ b/src/logging/diagnostics_store.ghul
@@ -204,7 +204,7 @@ namespace Logging is
         si
 
         write_all_diagnostics(writer: TextWriter, formatter: DiagnosticFormatter) is
-            let written_any = false;
+            let written_any mut = false;
 
             for diagnostic in _diagnostics do
                 let formatted = formatter.format(diagnostic);
@@ -280,7 +280,7 @@ namespace Logging is
         si
 
         get_diagnostics_list(source_path: string) -> DIAGNOSTICS_LIST is
-            let diagnostics_for_path: DIAGNOSTICS_LIST;
+            let diagnostics_for_path: DIAGNOSTICS_LIST mut;
 
             if !_diagnostics_by_source_path.try_get_value(source_path, diagnostics_for_path ref) then
                 diagnostics_for_path = DIAGNOSTICS_LIST(source_path);

--- a/src/semantic/back_feed.ghul
+++ b/src/semantic/back_feed.ghul
@@ -131,7 +131,7 @@ namespace Semantic is
                 return;
             fi
 
-            let count = formals.count;
+            let count mut = formals.count;
 
             if count > actuals.count then
                 count = actuals.count;

--- a/src/semantic/constraint.ghul
+++ b/src/semantic/constraint.ghul
@@ -213,7 +213,7 @@ namespace Semantic is
         // that matches the de-duplication policy for re-walks of
         // the same call site.
         get_hash_code() -> int is
-            let h = 17;
+            let h mut = 17;
 
             if argument_types? then
                 h = h * 31 + argument_types.count;
@@ -230,7 +230,7 @@ namespace Semantic is
             let buffer = StringBuilder();
             buffer.append("call(");
             if argument_types? then
-                let first = true;
+                let first mut = true;
                 for a in argument_types do
                     if !first then buffer.append(", "); fi
                     first = false;

--- a/src/semantic/dotnet/ambiguous_method_checker.ghul
+++ b/src/semantic/dotnet/ambiguous_method_checker.ghul
@@ -34,7 +34,7 @@ namespace Semantic.DotNet is
             let map = MAP[(name: string, number_of_arguments: int), LIST[(function: Function, method_info: MethodInfo)]]();
 
             for f_mi in functions do
-                let list: LIST[(function: Function, method_info: MethodInfo)];
+                let list: LIST[(function: Function, method_info: MethodInfo)] mut;
 
                 let name = f_mi.function.name;
                 let number_of_arguments = f_mi.function.argument_names.count;

--- a/src/semantic/dotnet/assemblies.ghul
+++ b/src/semantic/dotnet/assemblies.ghul
@@ -111,7 +111,7 @@ namespace Semantic.DotNet is
         get_type(type_name: string) -> TYPE =>
             get_type("System.Runtime", type_name);
 
-        get_type(assembly_name: string, type_name: string) -> TYPE is
+        get_type(assembly_name: string mut, type_name: string) -> TYPE is
             if assembly_name == null then
                 assembly_name = "System.Runtime";
             fi
@@ -129,7 +129,7 @@ namespace Semantic.DotNet is
         get_types(assembly_and_type_names: Iterable[(assembly_name: string, type_name: string)]) -> Collections.List[TYPE] =>
             assembly_and_type_names | .map(names => get_type(names.assembly_name, names.type_name)).collect();
         
-        import(assembly_names: Iterable[string]) is
+        import(assembly_names: Iterable[string] mut) is
             if _is_started then
                 return;
             fi
@@ -162,7 +162,7 @@ namespace Semantic.DotNet is
                     continue;
                 fi
                 
-                let assembly: System.Reflection.Assembly;
+                let assembly: System.Reflection.Assembly mut;
 
                 // FIXME: less fragile check:
                 if !path.starts_with("/usr/share/dotnet") /\ !path.starts_with("/usr/lib/dotnet") then
@@ -195,9 +195,9 @@ namespace Semantic.DotNet is
 
             let types_file = "{_paths.get_library_location(IO.Path.combine("dotnet", "refs"))}{assembly_name}.types";
         
-            let any_succeeded = false;
-            let exported_ex: System.Exception;
-            let forwarded_ex: System.Exception;
+            let any_succeeded mut = false;
+            let exported_ex: System.Exception mut;
+            let forwarded_ex: System.Exception mut;
 
             try
                 for type in assembly.get_types() do                        
@@ -228,7 +228,7 @@ namespace Semantic.DotNet is
             assert assembly_name? else "attempting to import type {type} with no assembly name supplied";
 
             try
-                let type_details = _type_name_map.get_type_details(type);
+                let type_details mut = _type_name_map.get_type_details(type);
 
                 if type_details? then
                     type_details.merge_assembly_reference(type, assembly_name, assembly_version);
@@ -238,7 +238,7 @@ namespace Semantic.DotNet is
                     return;
                 else
                     let namespace_details = _type_name_map.get_namespace_details(type);
-                    let namespace_name: string;
+                    let namespace_name: string mut;
     
                     if namespace_details? then
                         namespace_name = namespace_details.ghul_name;
@@ -246,7 +246,7 @@ namespace Semantic.DotNet is
                         namespace_name = type.`namespace;
                     fi
 
-                    let type_name = type.name;
+                    let type_name mut = type.name;
 
                     if type.is_nested then
                         let parts = type.full_name.split(['.']);

--- a/src/semantic/dotnet/ghul_namespace_creator.ghul
+++ b/src/semantic/dotnet/ghul_namespace_creator.ghul
@@ -45,7 +45,7 @@ namespace Semantic.DotNet is
                 return;
             fi
 
-            let current = LIST[string]();
+            let current mut = LIST[string]();
 
             let namespaces = LIST[string]();
 
@@ -64,7 +64,7 @@ namespace Semantic.DotNet is
                     current.remove_at(current.count - 1);
                 od
 
-                let index = 0;
+                let index mut = 0;
 
                 while index < current.count /\ current[index] =~ to_create[index] do
                     index = index + 1;

--- a/src/semantic/dotnet/property_details.ghul
+++ b/src/semantic/dotnet/property_details.ghul
@@ -15,7 +15,7 @@ namespace Semantic.DotNet is
         si
 
         to_string() -> string is
-            let result = "property details ";
+            let result mut = "property details ";
 
             if ghul_property? then
                 result = "{result}property: {ghul_property} {ghul_property.get_hash_code()}";

--- a/src/semantic/dotnet/symbol_factory.ghul
+++ b/src/semantic/dotnet/symbol_factory.ghul
@@ -111,7 +111,7 @@ namespace Semantic.DotNet is
             let dotnet_type = type_details.dotnet_type;
             let ghul_type_name = type_details.ghul_type_name;
             let assembly_name = type_details.assembly_name;
-            let il_name = type_details.il_name;
+            let il_name mut = type_details.il_name;
 
             let owner = EMPTY_SCOPE(type_details.ghul_namespace);
 
@@ -129,7 +129,7 @@ namespace Semantic.DotNet is
                 od
             fi
 
-            let result: Symbols.Classy;
+            let result: Symbols.Classy mut;
 
             if dotnet_type.is_enum then
                 result = Symbols.ENUM_STRUCT(Source.LOCATION.reflected, Source.LOCATION.reflected, owner, ghul_type_name, true, owner);
@@ -278,7 +278,7 @@ namespace Semantic.DotNet is
         si
 
         add_constructor(owner: Symbols.Scoped, method: ConstructorInfo) is
-            let result: Symbols.Function;
+            let result: Symbols.Function mut;
             let location = Source.LOCATION.reflected;
 
             if !method.is_public then
@@ -332,17 +332,17 @@ namespace Semantic.DotNet is
                 return;
             fi
             
-            let result: Symbols.Field;
+            let result: Symbols.Field mut;
             let location = Source.LOCATION.reflected;
 
             let field_name = `field.name;
 
-            let name: string;
+            let name: string mut;
 
             if field_name.length == 5 /\ `field.name.starts_with("Item") /\ type.is_generic_type then
                 let unspecialized_type = type.get_generic_type_definition();
 
-                let is_tuple = false;
+                let is_tuple mut = false;
 
                 for t in _tuple_types do
                     if unspecialized_type == t then
@@ -364,7 +364,7 @@ namespace Semantic.DotNet is
             // class, not the derived class — otherwise the IL fieldref says
             // "Foo::SubjectField" instead of "FooBase`2<...>::SubjectField" and
             // the runtime can't find the field.
-            let declaring_symbol: Symbols.Symbol = owner;
+            let declaring_symbol: Symbols.Symbol mut = owner;
             let dt = `field.declaring_type;
             if dt != type then
                 declaring_symbol = _type_mapper.get_type(dt).symbol;
@@ -388,7 +388,7 @@ namespace Semantic.DotNet is
             // and stash it as unspecialized_type; gen_reference prefers it.
             if dt != type /\ dt.is_generic_type /\ !dt.is_generic_type_definition then
                 let open_type = dt.get_generic_type_definition();
-                let open_field: FieldInfo;
+                let open_field: FieldInfo mut;
 
                 for m in open_type.get_members(cast BindingFlags(2 + 4 + 8 + 16 + 32)) do
                     if m.member_type == MemberTypes.FIELD then
@@ -435,7 +435,7 @@ namespace Semantic.DotNet is
                 fi
             fi            
 
-            let result: Symbols.Property;
+            let result: Symbols.Property mut;
             let name = _type_name_map.get_member_name(owner.qualified_name, property.name, false, property.is_special_name);
 
             let getter = property.get_method;
@@ -445,7 +445,7 @@ namespace Semantic.DotNet is
                 return;
             fi
             
-            let is_static = false;
+            let is_static mut = false;
 
             if getter? /\ getter.is_static then
                 is_static = true;
@@ -487,12 +487,12 @@ namespace Semantic.DotNet is
                 return;
             fi
 
-            let result: Symbols.Function;
+            let result: Symbols.Function mut;
             let location = Source.LOCATION.reflected;
 
-            let name: string;
+            let name: string mut;
 
-            let property_details: PROPERTY_DETAILS;
+            let property_details: PROPERTY_DETAILS mut;
 
             if properties.try_get_value(method, property_details ref) then
                 name = _type_name_map.get_member_name(owner.qualified_name, method.name, method.is_private, true);
@@ -517,7 +517,7 @@ namespace Semantic.DotNet is
                 name = _type_name_map.get_member_name(owner.qualified_name, method.name, method.is_private, method.is_special_name /\ !indexers.contains(method));
             fi
 
-            let declaring_symbol: Symbols.Symbol = owner;
+            let declaring_symbol: Symbols.Symbol mut = owner;
 
             if method.declaring_type != type then
                 let dt = _type_mapper.get_type(method.declaring_type);
@@ -581,7 +581,7 @@ namespace Semantic.DotNet is
             let dt = method.declaring_type;
             if dt != type /\ dt.is_generic_type /\ !dt.is_generic_type_definition then
                 let open_type = dt.get_generic_type_definition();
-                let open_method: MethodInfo;
+                let open_method: MethodInfo mut;
 
                 for m in open_type.get_members(cast BindingFlags(2 + 4 + 8 + 16 + 32)) do
                     if m.member_type == MemberTypes.METHOD then
@@ -621,7 +621,7 @@ namespace Semantic.DotNet is
         get_assembly_name(type: TYPE) -> string is
             let assembly = type.assembly;
 
-            let result: string;
+            let result: string mut;
 
             if _assembly_names.try_get_value(assembly, result ref) then
                 return result;
@@ -640,7 +640,7 @@ namespace Semantic.DotNet is
             assert type? else "get il name type is null";
             assert type.full_name? else "get il name type has no full name: {type}";
 
-            let seen_any = false;
+            let seen_any mut = false;
             for name in type.full_name.split(['.']) do
                 if seen_any then
                     buffer.append('.');
@@ -648,7 +648,7 @@ namespace Semantic.DotNet is
 
                 if name.contains('+') then
 
-                let inner_seen_any = false;
+                let inner_seen_any mut = false;
                 for inner_name in name.split(['+']) do
                     if inner_seen_any then
                         buffer.append('/');

--- a/src/semantic/dotnet/symbol_table.ghul
+++ b/src/semantic/dotnet/symbol_table.ghul
@@ -52,8 +52,8 @@ namespace Semantic.DotNet is
 
                 if ghul_namespace =~ namespace_name then
                     if !matches.contains_key(ghul_name) then
-                        let symbol_kind = Symbols.SYMBOL_KIND.UNDEFINED;
-                        let completion_kind = Symbols.COMPLETION_KIND.UNDEFINED;
+                        let symbol_kind mut = Symbols.SYMBOL_KIND.UNDEFINED;
+                        let completion_kind mut = Symbols.COMPLETION_KIND.UNDEFINED;
 
                         if dotnet_type.is_value_type then
                             symbol_kind = Symbols.SYMBOL_KIND.STRUCT;
@@ -112,7 +112,7 @@ namespace Semantic.DotNet is
                 return result;
             fi
 
-            let type_details = _type_details_lookup.get_type_details_by_dotnet_type(type);
+            let type_details mut = _type_details_lookup.get_type_details_by_dotnet_type(type);
 
             if !type_details? then
                 Std.error.write_line("warning: no type details for type {type} in assembly {type.assembly.get_name()}");

--- a/src/semantic/dotnet/type_details_lookup.ghul
+++ b/src/semantic/dotnet/type_details_lookup.ghul
@@ -75,7 +75,7 @@ namespace Semantic.DotNet is
 
             let ghul_namespace = type_details.ghul_namespace;
 
-            let list: MutableList[TYPE_DETAILS];
+            let list: MutableList[TYPE_DETAILS] mut;
 
             if !_type_details_by_ghul_namespace.try_get_value(ghul_namespace, list ref) then
                 list = LIST[TYPE_DETAILS]();
@@ -83,7 +83,7 @@ namespace Semantic.DotNet is
                 _type_details_by_ghul_namespace.add(ghul_namespace, list);
             fi
 
-            let is_found = false;
+            let is_found mut = false;
             for d in list do
                 if d.dotnet_type == dotnet_type then
                     is_found = true;

--- a/src/semantic/dotnet/type_mapper.ghul
+++ b/src/semantic/dotnet/type_mapper.ghul
@@ -29,7 +29,7 @@ namespace Semantic.DotNet is
         si
 
         create(symbol_table: SYMBOL_TABLE, type: TYPE) -> Type is
-            let result: Type;
+            let result: Type mut;
 
             if type.is_generic_type_definition then
                 result = GENERIC_TYPE_WRAPPER(symbol_table, _mapper, type);
@@ -139,8 +139,8 @@ namespace Semantic.DotNet is
         si
 
         get_type(type: TYPE) -> Type is
-            let result: Type;
-            let unsafe_constraints = false;
+            let result: Type mut;
+            let unsafe_constraints mut = false;
 
             if !type? then
                 Std.error.write_line("warning: materializing null type");
@@ -170,7 +170,7 @@ namespace Semantic.DotNet is
             if type.is_generic_type_definition \/ type.is_generic_type then
                 let b = type.get_generic_type_definition();
 
-                let creator: TypeCreator;
+                let creator: TypeCreator mut;
 
                 if !_type_creators.try_get_value(b, creator ref) then
                     creator = _generic_type_creator;

--- a/src/semantic/dotnet/type_name_map.ghul
+++ b/src/semantic/dotnet/type_name_map.ghul
@@ -213,7 +213,7 @@ namespace Semantic.DotNet is
         si
         
         get_member_name(owner_ghul_name: string, member_dotnet_name: string, is_private: bool, is_special_name: bool) -> string is
-            let result: string;
+            let result: string mut;
 
             result = de_camel(member_dotnet_name);
 
@@ -231,7 +231,7 @@ namespace Semantic.DotNet is
         si
 
         get_constant_name(owner_ghul_name: string, member_dotnet_name: string, is_private: bool) -> string is
-            let result: string;
+            let result: string mut;
 
             result = de_camel(member_dotnet_name).to_upper_invariant();
 
@@ -248,7 +248,7 @@ namespace Semantic.DotNet is
 
         de_camel(name: string) -> string is
             let buffer = StringBuilder();
-            let seenAnyLowerCase = false;
+            let seenAnyLowerCase mut = false;
 
             for c in name do
                 // FIXME: use System.Char.IsUpper here:

--- a/src/semantic/function_caller.ghul
+++ b/src/semantic/function_caller.ghul
@@ -67,7 +67,7 @@ namespace Semantic is
 
         call_instance_method(
             location: Source.LOCATION,
-            from: Value, 
+            from: Value mut, 
             function: Symbols.Function, 
             arguments: Collections.List[Value], 
             argument_types: Collections.List[Type],
@@ -92,7 +92,7 @@ namespace Semantic is
 
         call_struct_method(
             location: Source.LOCATION,
-            from: Value, 
+            from: Value mut, 
             function: Symbols.Function, 
             arguments: Collections.List[Value], 
             argument_types: Collections.List[Type],
@@ -115,7 +115,7 @@ namespace Semantic is
 
         call_abstract_method(
             location: Source.LOCATION,
-            from: Value, 
+            from: Value mut, 
             function: Symbols.Function, 
             arguments: Collections.List[Value], 
             argument_types: Collections.List[Type],

--- a/src/semantic/least_upper_bound_map.ghul
+++ b/src/semantic/least_upper_bound_map.ghul
@@ -130,7 +130,7 @@ namespace Semantic is
             // arg is concrete, or fail the merge if both are concrete.
             if a.is_value_tuple /\ b.is_value_tuple then
                 let merged_names = LIST[string](ga.arguments.count);
-                let any_name = false;
+                let any_name mut = false;
 
                 for j in 0..ga.arguments.count do
                     let name_a = ga.symbol.get_element_name(j);
@@ -155,7 +155,7 @@ namespace Semantic is
             return ga.create(ga.symbol.location, sa.symbol, merged_args);
         si
 
-        _try_merge_element_name(name_a: string, name_b: string, arg_a: Types.Type, arg_b: Types.Type) -> string is
+        _try_merge_element_name(name_a: string mut, name_b: string mut, arg_a: Types.Type, arg_b: Types.Type) -> string is
             // Auto-generated positional names like `0 / `1 don't carry
             // user intent; treat them as absent.
             if name_a? /\ name_a.starts_with('`') then name_a = null; fi
@@ -245,7 +245,7 @@ namespace Semantic is
         si
 
         _try_get_best_assignable() -> Type is
-            let best: Type;
+            let best: Type mut;
 
             for type in types do
                 if !best? then
@@ -301,8 +301,8 @@ namespace Semantic is
         si
 
         _get_best() -> Type is
-            let best: Type;
-            let is_ambiguous = false;
+            let best: Type mut;
+            let is_ambiguous mut = false;
 
             for list in result.values do
                 for type in list do
@@ -435,7 +435,7 @@ namespace Semantic is
             // per unspecialized generic type. we then only need
             // to search under the matching root specialized from symbol
 
-            let list: LIST[Type];
+            let list: LIST[Type] mut;
 
             if !result.try_get_value(rsf, list ref) then
                 list = LIST[Type]();
@@ -457,7 +457,7 @@ namespace Semantic is
                 return;
             fi
 
-            let list: LIST[Type];
+            let list: LIST[Type] mut;
 
             if !current.try_get_value(rsf, list ref) then
                 list = LIST[Type]();

--- a/src/semantic/lookups/stubs_innate_symbol_lookup.ghul
+++ b/src/semantic/lookups/stubs_innate_symbol_lookup.ghul
@@ -137,7 +137,7 @@ namespace Semantic.Lookups is
             => get_type(name, types, 0, create);
 
         get_type(
-            name: string,
+            name: string mut,
             types: Collections.List[Types.Type],
             exclude_count: int,
             create: (

--- a/src/semantic/overload_resolver.ghul
+++ b/src/semantic/overload_resolver.ghul
@@ -104,12 +104,12 @@ namespace Semantic is
             // FIXME: this could just as well be applied to any parameters of generic type, not just anon functions
             let needs_second_call = arguments | .any(a => a? /\ a.is_function_with_any_implicit_argument_types);
 
-            let is_ambiguous = false;
+            let is_ambiguous mut = false;
 
-            let best_score = cast int (Types.MATCH.DIFFERENT);
-            let result: Symbols.Function;
+            let best_score mut = cast int (Types.MATCH.DIFFERENT);
+            let result: Symbols.Function mut;
 
-            let ambiguous_matches: Collections.LIST[Symbols.Function];
+            let ambiguous_matches: Collections.LIST[Symbols.Function] mut;
 
             let functions_to_search = group.functions | .filter(f => want_instance \/ !f.is_instance);
 
@@ -119,15 +119,15 @@ namespace Semantic is
             // again
 
             for f in functions_to_search do
-                let actual = f;
+                let actual mut = f;
 
                 if f.arguments == null then
                     return OVERLOAD_RESOLVE_RESULT(f, Types.MATCH.DIFFERENT);
                 elif f.arguments.count == 0 /\ arguments.count == 0 then
                     return OVERLOAD_RESOLVE_RESULT(f, Types.MATCH.SAME);
                 elif f.arguments.count == arguments.count then
-                    let want_try_bind_owner_generic_arguments = false;
-                    let want_try_bind_function_generic_arguments = false;
+                    let want_try_bind_owner_generic_arguments mut = false;
+                    let want_try_bind_function_generic_arguments mut = false;
 
                     if is_constructor_call then
                         want_try_bind_owner_generic_arguments = true;
@@ -153,13 +153,13 @@ namespace Semantic is
                         want_try_bind_function_generic_arguments = false;
                     fi
 
-                    let try_bind_generic_arguments = false;
-                    let score = cast int(Types.MATCH.SAME);
+                    let try_bind_generic_arguments mut = false;
+                    let score mut = cast int(Types.MATCH.SAME);
 
                     let owner_symbol = cast Symbols.Classy(f.owner);
 
                     for i in 0..f.arguments.count do
-                        let match: Types.MATCH;
+                        let match: Types.MATCH mut;
 
                         let f_arg = f.arguments[i];
                         let arg = arguments[i];
@@ -404,7 +404,7 @@ namespace Semantic is
                 fi
             od
 
-            let maybe_static = "";
+            let maybe_static mut = "";
 
             if !want_instance then
                 maybe_static = "static ";
@@ -472,15 +472,15 @@ namespace Semantic is
 
             let results = Collections.LIST[Symbols.Function]();
 
-            let best_score = cast int(Types.MATCH.DIFFERENT) * arguments.count;
-            let best_index = -1;
+            let best_score mut = cast int(Types.MATCH.DIFFERENT) * arguments.count;
+            let best_index mut = -1;
 
             for f in group.functions do
                 if f.arguments.count >= arguments.count then
-                    let score = cast int(Types.MATCH.SAME);
+                    let score mut = cast int(Types.MATCH.SAME);
 
                     for i in 0..arguments.count do
-                        let match: Types.MATCH;
+                        let match: Types.MATCH mut;
 
                         if f.arguments[i]? /\ arguments[i]? then
                             match = f.arguments[i].compare(arguments[i]);

--- a/src/semantic/owner_constraint_specializer.ghul
+++ b/src/semantic/owner_constraint_specializer.ghul
@@ -77,7 +77,7 @@ namespace Semantic is
                 owner_classy.is_variant /\
                 cast Symbols.Symbol(owner_classy.owner) =~ constraint_generic.symbol;
 
-            let type_map: Collections.Map[string,Type];
+            let type_map: Collections.Map[string,Type] mut;
 
             if is_direct \/ is_variant_of_constraint then
                 type_map = constraint_generic.type_map;
@@ -144,7 +144,7 @@ namespace Semantic is
                 fi
 
                 let candidate = Collections.MAP[string,Type]();
-                let ok = true;
+                let ok mut = true;
 
                 for j in 0..ancestor_generic.arguments.count do
                     let slot = ancestor_generic.arguments[j];

--- a/src/semantic/owner_type_arg_specializer.ghul
+++ b/src/semantic/owner_type_arg_specializer.ghul
@@ -35,7 +35,7 @@ namespace Semantic is
             fi
 
             let binding_results = Types.GENERIC_ARGUMENT_BIND_RESULTS();
-            let count = candidate.arguments.count;
+            let count mut = candidate.arguments.count;
 
             if count > argument_types.count then
                 count = argument_types.count;

--- a/src/semantic/scope/namespace_scope.ghul
+++ b/src/semantic/scope/namespace_scope.ghul
@@ -93,7 +93,7 @@ namespace Semantic is
 
             let search = NAMESPACE_SEARCH(_namespace, name);
 
-            let symbol = find_direct(name);
+            let symbol mut = find_direct(name);
             
             if search.add(ns_location, symbol, false) then
                 return cache_result(search);

--- a/src/semantic/scope/namespace_search_result.ghul
+++ b/src/semantic/scope/namespace_search_result.ghul
@@ -34,7 +34,7 @@ namespace Semantic is
             let result = FUNCTION_GROUP(Source.LOCATION.unknown, owner, name);
 
             for s in functions do
-                let seen_any = false;
+                let seen_any mut = false;
 
                 for f in s.iterable do
                     assert !seen_any else "oops: multiple functions with same signature pulled into namespace scope: {s}";

--- a/src/semantic/symbol_loader.ghul
+++ b/src/semantic/symbol_loader.ghul
@@ -212,7 +212,7 @@ namespace Semantic is
         store_global_variable(symbol: Symbols.Variable, value: Value) -> Value =>
             Store.GLOBAL_FIELD(symbol, _value_boxer.box_if_needed(value, symbol.type));
             
-        load_instance_variable(location: Source.LOCATION, from: Value, symbol: Symbols.Variable) -> Value is
+        load_instance_variable(location: Source.LOCATION, from: Value mut, symbol: Symbols.Variable) -> Value is
             if from == null then
                 from = load_self(location);
             fi
@@ -220,7 +220,7 @@ namespace Semantic is
             return Load.INSTANCE_FIELD(from, symbol);
         si
 
-        store_instance_variable(location: Source.LOCATION, from: Value, symbol: Symbols.Variable, value: Value) -> Value is
+        store_instance_variable(location: Source.LOCATION, from: Value mut, symbol: Symbols.Variable, value: Value) -> Value is
             if from == null then
                 from = load_self(location);
             fi
@@ -228,7 +228,7 @@ namespace Semantic is
             return Store.INSTANCE_FIELD(from, symbol, _value_boxer.box_if_needed(value, symbol.type));
         si
 
-        load_struct_variable(location: Source.LOCATION, from: Value, symbol: Symbols.Variable) -> Value is
+        load_struct_variable(location: Source.LOCATION, from: Value mut, symbol: Symbols.Variable) -> Value is
             if from == null then
                 from = load_self(location);
             elif from.has_address then
@@ -238,7 +238,7 @@ namespace Semantic is
             return Load.INSTANCE_FIELD(from, symbol);
         si
 
-        store_struct_variable(location: Source.LOCATION, from: Value, symbol: Symbols.Variable, value: Value) -> Value is
+        store_struct_variable(location: Source.LOCATION, from: Value mut, symbol: Symbols.Variable, value: Value) -> Value is
             if from == null then
                 from = load_self(location);
             elif from.has_address then
@@ -261,7 +261,7 @@ namespace Semantic is
         load_static_property(location: Source.LOCATION, symbol: Symbols.Property) -> Value => load_property(location, null, symbol, true);
         load_global_property(location: Source.LOCATION, symbol: Symbols.Property) -> Value => load_property(location, null, symbol, true);
 
-        load_property(location: Source.LOCATION, from: Value, symbol: Symbols.Property, is_static: bool) -> Value is
+        load_property(location: Source.LOCATION, from: Value mut, symbol: Symbols.Property, is_static: bool) -> Value is
             if !symbol? then
                 return null;
             fi
@@ -284,7 +284,7 @@ namespace Semantic is
         store_static_property(location: Source.LOCATION, symbol: Symbols.Property, value: Value) -> Value => store_property(location, null, symbol, value, true);
         store_global_property(location: Source.LOCATION, symbol: Symbols.Property, value: Value) -> Value => store_property(location, null, symbol, value, true);
 
-        store_property(location: Source.LOCATION, from: Value, symbol: Symbols.Property, value: Value, is_static: bool) -> Value is
+        store_property(location: Source.LOCATION, from: Value mut, symbol: Symbols.Property, value: Value, is_static: bool) -> Value is
             if symbol == null then
                 return null;
             fi

--- a/src/semantic/symbol_use_locations.ghul
+++ b/src/semantic/symbol_use_locations.ghul
@@ -31,7 +31,7 @@ namespace Semantic is
             _symbol_reference_map = Collections.MAP[Symbols.Symbol,Collections.SET[LOCATION]](65521);
         si
 
-        add_symbol_use(location: LOCATION, symbol: Symbols.Symbol) is
+        add_symbol_use(location: LOCATION, symbol: Symbols.Symbol mut) is
             if 
                 !symbol? \/
                 location.is_internal \/
@@ -65,8 +65,8 @@ namespace Semantic is
             elif matches.count == 1 then
                 matches[0].value;
             else
-                let shortest_length = 1_000_000_000;
-                let best_match: Symbols.Symbol;
+                let shortest_length mut = 1_000_000_000;
+                let best_match: Symbols.Symbol mut;
 
                 for m in matches do
                     let location = m.location;
@@ -89,7 +89,7 @@ namespace Semantic is
         // - for methods and properties, include all definitions that override the searched symbol
         // - for classes and traits, include all definitions that inherit from the searched symbol
         // - for other symbols, return only the searched symbol
-        find_declarations_of_symbol(symbol: Symbols.Symbol) -> Collections.Iterable[LOCATION] is
+        find_declarations_of_symbol(symbol: Symbols.Symbol mut) -> Collections.Iterable[LOCATION] is
             symbol = symbol.root_specialized_from;
 
             let results = Collections.SET[Symbols.Symbol]();
@@ -112,7 +112,7 @@ namespace Semantic is
         // - for methods and properties, include all definitions that override the searched symbol
         // - for classes and traits, include all definitions that inherit from the searched symbol
         // - for other symbols, return only the searched symbol
-        find_implementations_of_symbol(symbol: Symbols.Symbol) -> Collections.Iterable[LOCATION] is
+        find_implementations_of_symbol(symbol: Symbols.Symbol mut) -> Collections.Iterable[LOCATION] is
             symbol = symbol.root_specialized_from;
 
             let results = Collections.SET[Symbols.Symbol]();
@@ -129,7 +129,7 @@ namespace Semantic is
         // - include uses but not definitions
         // - for methods and properties, include references to all symbols that override the searched symbol
         // - for classes, traits and other symbols, include only references to the searched symbol
-        find_references_to_symbol(symbol: Symbols.Symbol) -> Collections.Iterable[LOCATION] is
+        find_references_to_symbol(symbol: Symbols.Symbol mut) -> Collections.Iterable[LOCATION] is
             symbol = symbol.root_specialized_from;
 
             let definitions = Collections.SET[Symbols.Symbol]();
@@ -152,7 +152,7 @@ namespace Semantic is
         // - for methods and properties, search up the inheritance tree to find the root symbols that are overridden
         // - include references to all symbols that override the root overridee symbols
         // - for classes, traits and other symbols, include only references to the searched symbol
-        find_references_to_symbol_for_rename(symbol: Symbols.Symbol) -> Collections.Iterable[LOCATION] is
+        find_references_to_symbol_for_rename(symbol: Symbols.Symbol mut) -> Collections.Iterable[LOCATION] is
             symbol = symbol.root_specialized_from;
 
             if symbol.is_constructor then
@@ -341,10 +341,10 @@ namespace Semantic is
             return results;
         si
 
-        _get_references_set(symbol: Symbols.Symbol) -> Collections.SET[LOCATION] is
+        _get_references_set(symbol: Symbols.Symbol mut) -> Collections.SET[LOCATION] is
             // FIXME: is this correct in all cases?
             symbol = symbol.root_specialized_from;
-            let results: Collections.SET[LOCATION];                
+            let results: Collections.SET[LOCATION] mut;                
 
             if !_symbol_reference_map.try_get_value(symbol, results ref) then
                 results = Collections.SET[LOCATION]();
@@ -367,7 +367,7 @@ namespace Semantic is
         si
 
         put(location: LOCATION, value: T) is
-            let file = _get_file(location.file_name);
+            let file mut = _get_file(location.file_name);
 
             if file == null then
                 file = Collections.MAP[int, Collections.LIST[Pair[LOCATION,T]]]();
@@ -377,7 +377,7 @@ namespace Semantic is
             let start_line = location.start_line;
             let end_line = location.end_line;
 
-            let list: Collections.LIST[Pair[LOCATION,T]];
+            let list: Collections.LIST[Pair[LOCATION,T]] mut;
 
             for line in start_line::end_line do
                 if file.contains_key(line) then

--- a/src/semantic/symbols/classy.ghul
+++ b/src/semantic/symbols/classy.ghul
@@ -307,7 +307,7 @@ namespace Semantic.Symbols is
         si
 
         gen_formal_type_arguments(buffer: StringBuilder) is
-            let seen_any = false;
+            let seen_any mut = false;
 
             for argument in argument_names do
                 if seen_any then
@@ -324,7 +324,7 @@ namespace Semantic.Symbols is
         si
 
         gen_actual_type_arguments(buffer: StringBuilder) is
-            let seen_any = false;
+            let seen_any mut = false;
 
             for index in 0..argument_names.count do
                 if seen_any then
@@ -358,7 +358,7 @@ namespace Semantic.Symbols is
         si
 
         gen_implements(buffer: StringBuilder) is
-            let seen_any = false;
+            let seen_any mut = false;
 
             for ancestor in ancestors do
                 assert isa Types.NAMED(ancestor);
@@ -496,7 +496,7 @@ namespace Semantic.Symbols is
         si
 
         declare_function(location: LOCATION, span: LOCATION, name: string, is_static: bool, is_private: bool, has_body: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Symbol is
-            let result: Function;
+            let result: Function mut;
 
             if is_static then
                 result = Symbols.STATIC_METHOD(location, span, self, name, enclosing);
@@ -518,7 +518,7 @@ namespace Semantic.Symbols is
         si        
 
         declare_variable(location: LOCATION, name: string, is_static: bool, symbol_definition_listener: SymbolDefinitionListener) -> Symbol is
-            let result: Variable;
+            let result: Variable mut;
             
             if is_static then
                 result = Symbols.STATIC_FIELD(location, self, name);
@@ -532,7 +532,7 @@ namespace Semantic.Symbols is
         si
 
         declare_property(location: LOCATION, span: LOCATION, name: string, is_static: bool, is_private: bool, is_assignable: bool, symbol_definition_listener: SymbolDefinitionListener) -> Symbol is
-            let result: Property;
+            let result: Property mut;
 
             if is_static then
                 result = Symbols.STATIC_PROPERTY(location, span, self, name, is_assignable, is_private);
@@ -595,7 +595,7 @@ namespace Semantic.Symbols is
         si
 
         declare_function(location: LOCATION, span: LOCATION, name: string, is_static: bool, is_private: bool, has_body: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Symbol is
-            let result: Function;
+            let result: Function mut;
 
             if is_static then
                 IoC.CONTAINER.instance.logger.error(location, "cannot declare static method in trait");
@@ -612,7 +612,7 @@ namespace Semantic.Symbols is
         si
 
         declare_property(location: LOCATION, span: LOCATION, name: string, is_static: bool, is_private: bool, is_assignable: bool, symbol_definition_listener: SymbolDefinitionListener) -> Symbol is
-            let result: Property;
+            let result: Property mut;
 
             if is_static then
                 IoC.CONTAINER.instance.logger.error(location, "cannot declare static property in trait");
@@ -684,7 +684,7 @@ namespace Semantic.Symbols is
         si
 
         declare_function(location: LOCATION, span: LOCATION, name: string, is_static: bool, is_private: bool, has_body: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Symbol is
-            let result: Function;
+            let result: Function mut;
 
             if is_static then
                 result = Symbols.STATIC_METHOD(location, span, self, name, enclosing);
@@ -698,7 +698,7 @@ namespace Semantic.Symbols is
         si
 
         declare_variable(location: LOCATION, name: string, is_static: bool, symbol_definition_listener: SymbolDefinitionListener) -> Symbol is
-            let result: Variable;
+            let result: Variable mut;
             
             if is_static then
                 result = Symbols.STATIC_FIELD(location, self, name);
@@ -712,7 +712,7 @@ namespace Semantic.Symbols is
         si
 
         declare_property(location: LOCATION, span: LOCATION, name: string, is_static: bool, is_private: bool, is_assignable: bool, symbol_definition_listener: SymbolDefinitionListener) -> Symbol is
-            let result: Property;
+            let result: Property mut;
 
             if is_static then
                 result = Symbols.STATIC_PROPERTY(location, span, self, name, is_assignable, is_private);
@@ -768,7 +768,7 @@ namespace Semantic.Symbols is
         si
 
         declare_function(location: LOCATION, span: LOCATION, name: string, is_static: bool, is_private: bool, has_body: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Symbol is
-            let result: Function;
+            let result: Function mut;
 
             if is_static then
                 result = Symbols.STATIC_METHOD(location, span, self, name, enclosing);
@@ -782,7 +782,7 @@ namespace Semantic.Symbols is
         si
 
         declare_property(location: LOCATION, span: LOCATION, name: string, is_static: bool, is_private: bool, is_assignable: bool, symbol_definition_listener: SymbolDefinitionListener) -> Symbol is
-            let result: Property;
+            let result: Property mut;
 
             if is_static then
                 result = Symbols.STATIC_PROPERTY(location, span, self, name, is_assignable, is_private);
@@ -876,7 +876,7 @@ namespace Semantic.Symbols is
         si
 
         declare_function(location: LOCATION, span: LOCATION, name: string, is_static: bool, is_private: bool, has_body: bool, enclosing: Scope, symbol_definition_listener: SymbolDefinitionListener) -> Symbol is
-            let result: Function;
+            let result: Function mut;
 
             if is_static then
                 result = Symbols.STATIC_METHOD(location, span, self, name, enclosing);
@@ -908,7 +908,7 @@ namespace Semantic.Symbols is
         si
 
         declare_property(location: LOCATION, span: LOCATION, name: string, is_static: bool, is_private: bool, is_assignable: bool, symbol_definition_listener: SymbolDefinitionListener) -> Symbol is
-            let result: Property;
+            let result: Property mut;
 
             if is_static then
                 result = Symbols.STATIC_PROPERTY(location, span, self, name, is_assignable, is_private);
@@ -963,7 +963,7 @@ namespace Semantic.Symbols is
             return loader.load_struct(self);
         si
 
-        declare_enum_member(location: LOCATION, name: string, value: string, symbol_definition_listener: SymbolDefinitionListener) is
+        declare_enum_member(location: LOCATION, name: string, value: string mut, symbol_definition_listener: SymbolDefinitionListener) is
             if !value? then
                 value = "{next_value}";
             fi
@@ -1005,7 +1005,7 @@ namespace Semantic.Symbols is
         si        
 
         init(owner: Scope, closure: Closure) is
-            let owner_owner: Scope;
+            let owner_owner: Scope mut;
 
             if isa Symbol(owner) then
                 let owner_symbol = cast Symbol(owner);

--- a/src/semantic/symbols/closure.ghul
+++ b/src/semantic/symbols/closure.ghul
@@ -460,8 +460,8 @@ namespace Semantic.Symbols is
 
             let stack = symbol_table.stack;
 
-            let index = stack.count - 1;
-            let seen_self = false;
+            let index mut = stack.count - 1;
+            let seen_self mut = false;
 
             while index >= 0 do
                 let scope = stack[index];
@@ -511,8 +511,8 @@ namespace Semantic.Symbols is
 
             let stack = IoC.CONTAINER.instance.symbol_table.stack;
 
-            let index = stack.count - 1;
-            let seen_self = false;
+            let index mut = stack.count - 1;
+            let seen_self mut = false;
 
             while index >= 0 do
                 let scope = stack[index];

--- a/src/semantic/symbols/function.ghul
+++ b/src/semantic/symbols/function.ghul
@@ -128,7 +128,7 @@ namespace Semantic.Symbols is
             self.argument_names = argument_names;
         si
 
-        add_overrider(overrider: Symbol) is
+        add_overrider(overrider: Symbol mut) is
             let rsf = root_specialized_from;
             if rsf != self then
                 rsf.add_overrider(overrider);
@@ -144,7 +144,7 @@ namespace Semantic.Symbols is
             _overriders.add(overrider);
         si
 
-        add_overridee(overridee: Symbol) is
+        add_overridee(overridee: Symbol mut) is
             let rsf = root_specialized_from;
             if rsf != self then
                 rsf.add_overridee(overridee);
@@ -639,7 +639,7 @@ namespace Semantic.Symbols is
         gen_reference(buffer: StringBuilder) is
             gen_calling_convention(buffer);
 
-            let rt = unspecialized_return_type;
+            let rt mut = unspecialized_return_type;
 
             if !rt? then
                 rt = return_type;
@@ -675,7 +675,7 @@ namespace Semantic.Symbols is
         gen_reference_for_property(buffer: StringBuilder) is
             gen_calling_convention(buffer);
 
-            let rt = unspecialized_return_type;
+            let rt mut = unspecialized_return_type;
 
             if !rt? then
                 rt = return_type;
@@ -743,7 +743,7 @@ namespace Semantic.Symbols is
         si
         
         gen_formal_arguments_list(buffer: StringBuilder) is
-            let seen_any = false;
+            let seen_any mut = false;
 
             for i in 0..argument_names.count do
                 if seen_any then
@@ -762,8 +762,8 @@ namespace Semantic.Symbols is
         si
 
         gen_actual_arguments_list(buffer: StringBuilder) is
-            let seen_any = false;
-            let args = unspecialized_arguments;
+            let seen_any mut = false;
+            let args mut = unspecialized_arguments;
 
             if !args? then
                 args = arguments;
@@ -781,7 +781,7 @@ namespace Semantic.Symbols is
         si
 
         gen_generic_arguments_list(buffer: StringBuilder) is
-            let seen_any = false;
+            let seen_any mut = false;
             
             for argument in generic_arguments do
                 if seen_any then
@@ -795,7 +795,7 @@ namespace Semantic.Symbols is
         si
         
         gen_generic_arguments_names(buffer: StringBuilder) is
-            let seen_any = false;
+            let seen_any mut = false;
             
             for argument in generic_arguments do
                 if seen_any then
@@ -857,7 +857,7 @@ namespace Semantic.Symbols is
         gen_reference_for_property(buffer: StringBuilder) is
             gen_calling_convention(buffer);
 
-            let rt = unspecialized_return_type;
+            let rt mut = unspecialized_return_type;
 
             if !rt? then
                 rt = return_type;

--- a/src/semantic/symbols/function_group.ghul
+++ b/src/semantic/symbols/function_group.ghul
@@ -83,7 +83,7 @@ namespace Semantic.Symbols is
 
             if result.is_empty then
                 if expected_argument_counts.count > 0 then
-                    let counts_string = expected_argument_counts | .sort() .join(", ");
+                    let counts_string mut = expected_argument_counts | .sort() .join(", ");
                     let last_comma_index = counts_string.last_index_of(", ");
 
                     if last_comma_index >= 0 then

--- a/src/semantic/symbols/generic.ghul
+++ b/src/semantic/symbols/generic.ghul
@@ -61,7 +61,7 @@ namespace Semantic.Symbols is
         arguments_string: string is
             let result = System.Text.StringBuilder();
 
-            let seen_any = false;
+            let seen_any mut = false;
 
             for a in arguments do
                 if seen_any then
@@ -85,7 +85,7 @@ namespace Semantic.Symbols is
                 .append(name)
                 .append('[');
 
-            let seen_any = false;
+            let seen_any mut = false;
 
             for a in arguments do
                 if seen_any then
@@ -129,7 +129,7 @@ namespace Semantic.Symbols is
             assert symbol.argument_names? else "symbol argument names is null"; 
             assert symbol.is_generic else "symbol is not generic";
 
-            let length = arguments.count;
+            let length mut = arguments.count;
 
             if arguments.count != symbol.argument_names.count then
                 if length > symbol.argument_names.count then
@@ -316,7 +316,7 @@ namespace Semantic.Symbols is
         si
 
         get_hash_code() -> int is
-            let result = symbol.get_hash_code();
+            let result mut = symbol.get_hash_code();
 
             for a in arguments do
                 result = result + a.get_hash_code();
@@ -345,7 +345,7 @@ namespace Semantic.Symbols is
         si
 
         gen_actual_type_arguments(buffer: StringBuilder) is
-            let seen_any = false;
+            let seen_any mut = false;
             for argument in arguments do
                 if seen_any then
                     buffer.append(',');

--- a/src/semantic/symbols/method_override_class.ghul
+++ b/src/semantic/symbols/method_override_class.ghul
@@ -51,7 +51,7 @@ namespace Semantic is
         si
         
         get_hash_code() -> int is
-            let result = 0;
+            let result mut = 0;
 
             for a in arguments do
                 result = result + a.get_hash_code();

--- a/src/semantic/symbols/method_override_map.ghul
+++ b/src/semantic/symbols/method_override_map.ghul
@@ -78,7 +78,7 @@ namespace Semantic is
 
             let c = method.override_class;
 
-            let method_set: METHOD_OVERRIDE_SET;
+            let method_set: METHOD_OVERRIDE_SET mut;
 
             if methods.contains_key(c) then
                 method_set = methods[c];

--- a/src/semantic/symbols/namespace.ghul
+++ b/src/semantic/symbols/namespace.ghul
@@ -15,7 +15,7 @@ namespace Semantic.Symbols is
         type: Type;
 
         description: string is
-            let qn = qualified_name;
+            let qn mut = qualified_name;
             
             if qn.starts_with('.') then
                 qn = qn.substring(1);
@@ -74,7 +74,7 @@ namespace Semantic.Symbols is
 
             let dotnet_symbol_table = IoC.CONTAINER.instance.dotnet_symbol_table.value;
 
-            let qn = qualified_name;
+            let qn mut = qualified_name;
 
             if qn =~ "." \/ qn.length == 0 then
                 return null;
@@ -107,7 +107,7 @@ namespace Semantic.Symbols is
         find_member_matches(prefix: string, matches: Collections.MutableMap[string, Symbols.Symbol]) is
             find_direct_matches(prefix, matches);
 
-            let qn = qualified_name;
+            let qn mut = qualified_name;
 
             let namespaces = IoC.CONTAINER.instance.namespaces;
             let dotnet_symbol_table = IoC.CONTAINER.instance.dotnet_symbol_table.value;
@@ -232,7 +232,7 @@ namespace Semantic.Symbols is
 
             let parts = qualified_name.substring(1).split(['.']);
 
-            let seen_any = false;
+            let seen_any mut = false;
 
             for part in parts do
                 if seen_any then

--- a/src/semantic/symbols/property.ghul
+++ b/src/semantic/symbols/property.ghul
@@ -42,7 +42,7 @@ namespace Semantic.Symbols is
             self.is_private = is_private;
         si
         
-        add_overrider(overrider: Symbol) is
+        add_overrider(overrider: Symbol mut) is
             let rsf = root_specialized_from;
             if rsf != self then
                 rsf.add_overrider(overrider);
@@ -58,7 +58,7 @@ namespace Semantic.Symbols is
             _overriders.add(overrider);
         si
 
-        add_overridee(overridee: Symbol) is
+        add_overridee(overridee: Symbol mut) is
             let rsf = root_specialized_from;
             if rsf != self then
                 rsf.add_overridee(overridee);

--- a/src/semantic/symbols/symbol.ghul
+++ b/src/semantic/symbols/symbol.ghul
@@ -572,7 +572,7 @@ namespace Semantic.Symbols is
 
         declare_function_group(location: LOCATION, function: Function, symbol_definition_listener: SymbolDefinitionListener) is
             let existing = find_direct(function.name);
-            let function_group: Symbols.FUNCTION_GROUP;
+            let function_group: Symbols.FUNCTION_GROUP mut;
 
             if existing? then
                 if !isa Symbols.FUNCTION_GROUP(existing) then

--- a/src/semantic/symbols/symbol_inheritance_resolver.ghul
+++ b/src/semantic/symbols/symbol_inheritance_resolver.ghul
@@ -75,7 +75,7 @@ namespace Semantic is
             let overridees = Collections.MAP[string,METHOD_OVERRIDE_MAP]();
 
             for symbol in members do
-                let overridees_with_this_name: METHOD_OVERRIDE_MAP;
+                let overridees_with_this_name: METHOD_OVERRIDE_MAP mut;
 
                 if overridees.contains_key(symbol.name) then
                     overridees_with_this_name = overridees[symbol.name];
@@ -101,7 +101,7 @@ namespace Semantic is
         is
             let is_stub = into.is_stub;
             let other_overridee_symbols_count = other_overridee_symbols | .count();
-            let overriding_method: Function;
+            let overriding_method: Function mut;
 
             if overriders? then
                 overriding_method = overriders.get_overrider(into);
@@ -222,11 +222,11 @@ namespace Semantic is
             logger: Logging.Logger
         )
         is
-            let concrete: Function;
-            let abstract: Function;
+            let concrete: Function mut;
+            let abstract: Function mut;
 
-            let seen_multiple_concrete = false;
-            let seen_multiple_abstract = false;
+            let seen_multiple_concrete mut = false;
+            let seen_multiple_abstract mut = false;
 
             for f in overridees.iterable do
                 if f.is_abstract then
@@ -349,7 +349,7 @@ namespace Semantic is
                     logger.warn(overrider_symbol.location, "{overrider_symbol} hides {overridee}");
                 fi
             else
-                let overrides = true;
+                let overrides mut = true;
 
                 if overridee.is_assignable then
                     let overridee_assign_is_default_trait =
@@ -415,10 +415,10 @@ namespace Semantic is
             logger: Logging.Logger
         )
         is
-            let type: Type;
-            let inconsistent_types = false;
-            let any_non_properties = false;
-            let property: Symbol;
+            let type: Type mut;
+            let inconsistent_types mut = false;
+            let any_non_properties mut = false;
+            let property: Symbol mut;
 
             for s in overridee_symbols do
                 if isa Symbols.Property(s) then

--- a/src/semantic/symbols/variable.ghul
+++ b/src/semantic/symbols/variable.ghul
@@ -240,7 +240,7 @@ namespace Semantic.Symbols is
     // FIXME: pull up common code into a local + argument superclass:
     class LOCAL_VARIABLE: Variable, Types.SettableTyped is
         description: string is
-            let kind: string;
+            let kind: string mut;
 
             if is_captured then
                 kind = "captured value";
@@ -324,7 +324,7 @@ namespace Semantic.Symbols is
         is_argument: bool => true;
         
         description: string is
-            let kind: string;
+            let kind: string mut;
 
             if is_captured then
                 kind = "captured value";
@@ -393,7 +393,7 @@ namespace Semantic.Symbols is
         si
 
         gen_reference(buffer: StringBuilder) is
-            let t = unspecialized_type;
+            let t mut = unspecialized_type;
 
             if !t? then
                 t = type;
@@ -450,7 +450,7 @@ namespace Semantic.Symbols is
         si
 
         gen_reference(buffer: StringBuilder) is
-            let t = unspecialized_type;
+            let t mut = unspecialized_type;
 
             if !t? then
                 t = type;

--- a/src/semantic/type_arg_placeholder_registry.ghul
+++ b/src/semantic/type_arg_placeholder_registry.ghul
@@ -109,7 +109,7 @@ namespace Semantic is
                 let arg_name = owner_classy.argument_names[i];
                 let origin = origins[i];
                 let resolved = origin.try_get_inferred_type();
-                let arg_type: Type;
+                let arg_type: Type mut;
 
                 if resolved? /\ !resolved.is_inferred /\ !resolved.is_error then
                     arg_type = resolved;
@@ -147,7 +147,7 @@ namespace Semantic is
         // IL with the placeholder's gen_type comment string in the
         // type-arg position, which ilasm rejects.
         fill_in_defaults(object_type: Type) -> bool is
-            let added_any = false;
+            let added_any mut = false;
 
             for kv in _origins do
                 for origin in kv.value do

--- a/src/semantic/type_caster.ghul
+++ b/src/semantic/type_caster.ghul
@@ -88,7 +88,7 @@ namespace Semantic is
             fi
 
             if value.type.is_type_variable \/ target_type.is_type_variable then
-                let result: IR.Values.Value =
+                let result: IR.Values.Value mut =
                     CAST(
                         target_type,
                         value
@@ -138,7 +138,7 @@ namespace Semantic is
                 fi
             fi
 
-            let result: Value =
+            let result: Value mut =
                 CAST(
                     target_type,
                     value

--- a/src/semantic/types/generic.ghul
+++ b/src/semantic/types/generic.ghul
@@ -26,7 +26,7 @@ namespace Semantic.Types is
                 let a = symbol.arguments;
                 let c = a.count;
 
-                let i = 0;
+                let i mut = 0;
 
                 while i < c do
                     if a[i].is_wild then
@@ -65,7 +65,7 @@ namespace Semantic.Types is
                 .append(symbol.name)
                 .append('[');
 
-            let seen_any = false;
+            let seen_any mut = false;
 
             for a in arguments do
                 assert a? else "argument is null";
@@ -162,7 +162,7 @@ namespace Semantic.Types is
 
             let we_are_generic = context? /\ context.arguments.count > 0;
             
-            let seen_any_new = false;
+            let seen_any_new mut = false;
 
             let generic_symbol = cast Symbols.GENERIC(symbol);
 
@@ -265,12 +265,12 @@ namespace Semantic.Types is
                 return Types.MATCH.DIFFERENT;
             fi
 
-            let result = Types.MATCH.SAME;
+            let result mut = Types.MATCH.SAME;
 
             for i in 0..generic_symbol.arguments.count do
                 let variance = generic_other.get_argument_type_variance(i);
 
-                let argument_score: Types.MATCH;
+                let argument_score: Types.MATCH mut;
 
                 if variance == TYPE_VARIANCE.COVARIANT then
                     argument_score = generic_symbol.arguments[i].compare(generic_other_symbol.arguments[i]);
@@ -335,7 +335,7 @@ namespace Semantic.Types is
                 let generic_other_symbol = cast Symbols.GENERIC(other_generic.symbol);
     
                 if generic_symbol.symbol == generic_other_symbol.symbol then
-                    let result = true;
+                    let result mut = true;
 
                     for i in 0..arguments.count do
                         result = arguments[i].bind_type_variables(other.arguments[i], results) /\ result;

--- a/src/semantic/types/generic_argument_bind_results.ghul
+++ b/src/semantic/types/generic_argument_bind_results.ghul
@@ -50,7 +50,7 @@ namespace Semantic.Types is
             bindings = MAP[string,GENERIC_ARGUMENT_BINDING]();
         si
 
-        bind(type_argument: GenericArgument, actual_type: Type) -> bool is
+        bind(type_argument: GenericArgument, actual_type: Type mut) -> bool is
             let existing: GENERIC_ARGUMENT_BINDING;
 
             actual_type =
@@ -137,7 +137,7 @@ namespace Semantic.Types is
             fi
 
             for expected_argument in expected_arguments do
-                let argument_is_bound = false;
+                let argument_is_bound mut = false;
 
                 for bound_argument in bindings.values do
                     if bound_argument.type_argument.symbol == expected_argument.symbol then
@@ -163,7 +163,7 @@ namespace Semantic.Types is
         to_string() -> string is
             let result = System.Text.StringBuilder();
 
-            let seen_any = false;
+            let seen_any mut = false;
 
             for binding in bindings.values do
                 if seen_any then

--- a/src/source/location.ghul
+++ b/src/source/location.ghul
@@ -106,8 +106,8 @@ namespace Source is
             "{file_name} {start_line},{start_column}..{end_line},{end_column}";
 
         ::(with: LOCATION) -> LOCATION is
-            let new_start: int;
-            let new_end: int;
+            let new_start: int mut;
+            let new_end: int mut;
 
             if start < with.start then
                 new_start = start;
@@ -125,8 +125,8 @@ namespace Source is
         si
 
         ..(with: LOCATION) -> LOCATION is
-            let new_start: int;
-            let new_end: int;
+            let new_start: int mut;
+            let new_end: int mut;
 
             if start < with.start then
                 new_start = start;

--- a/src/syntax/parsers/context.ghul
+++ b/src/syntax/parsers/context.ghul
@@ -129,7 +129,7 @@ namespace Syntax.Parsers is
         current_string: string => current.value_string;
 
         current_token_name: string is
-            let result = Lexical.TOKEN_NAMES[current_token];
+            let result mut = Lexical.TOKEN_NAMES[current_token];
 
             if result == null then
                 result = "unknown";

--- a/src/syntax/parsers/definitions/class.ghul
+++ b/src/syntax/parsers/definitions/class.ghul
@@ -34,14 +34,14 @@ namespace Syntax.Parsers.Definitions is
                 context.next_token(Lexical.TOKEN.CLASS);
                 let identifier = identifier_parser.parse(context);
     
-                let is_poisoned = false;
+                let is_poisoned mut = false;
     
                 if identifier == null then
                     return null;
                 fi            
     
-                let arguments: Trees.TypeExpressions.LIST;
-                let ancestors: Trees.TypeExpressions.LIST;
+                let arguments: Trees.TypeExpressions.LIST mut;
+                let ancestors: Trees.TypeExpressions.LIST mut;
     
                 if context.current.token == Lexical.TOKEN.SQUARE_OPEN then
                     context.next_token();
@@ -69,10 +69,10 @@ namespace Syntax.Parsers.Definitions is
     
                 let modifiers = modifier_list_parser.parse(context);
     
-                let read_a_body = false;
+                let read_a_body mut = false;
     
-                let body: Trees.Definitions.LIST;
-                let expect_body = false;
+                let body: Trees.Definitions.LIST mut;
+                let expect_body mut = false;
 
                 if !is_poisoned then
                     if context.next_token(Lexical.TOKEN.IS) then

--- a/src/syntax/parsers/definitions/enum.ghul
+++ b/src/syntax/parsers/definitions/enum.ghul
@@ -28,7 +28,7 @@ namespace Syntax.Parsers.Definitions is
 
             let members = Collections.LIST[Trees.Definitions.ENUM_MEMBER]();
 
-            let expect_si = false;
+            let expect_si mut = false;
 
             if (name? /\ !name.is_poisoned) \/ context.current.token == Lexical.TOKEN.IS then
                 if context.next_token(Lexical.TOKEN.IS) then
@@ -45,8 +45,8 @@ namespace Syntax.Parsers.Definitions is
                         let member_name = identifier_parser.parse(context);
 
                         if member_name? then
-                            let member_end = member_name.location;
-                            let member_initializer: Trees.Expressions.Expression;
+                            let member_end mut = member_name.location;
+                            let member_initializer: Trees.Expressions.Expression mut;
                             if context.current.token == Lexical.TOKEN.ASSIGN then
                                 context.next_token();
 
@@ -68,7 +68,7 @@ namespace Syntax.Parsers.Definitions is
                 fi
             fi                    
 
-            let result: Trees.Definitions.ENUM;
+            let result: Trees.Definitions.ENUM mut;
 
             if name? then
                 result = Trees.Definitions.ENUM(start::context.location, name, modifiers, members);

--- a/src/syntax/parsers/definitions/function.ghul
+++ b/src/syntax/parsers/definitions/function.ghul
@@ -38,7 +38,7 @@ namespace Syntax.Parsers.Definitions is
                 let generic_arguments = type_list_parser.parse(context);
                 generic_arguments.check_no_reference_types(context.logger);
 
-                let is_poisoned = false;
+                let is_poisoned mut = false;
 
                 if generic_arguments | .any(a => !a.is_bare_identifier) then
                     context.error(generic_arguments.location, "type constraints are not supported");
@@ -65,7 +65,7 @@ namespace Syntax.Parsers.Definitions is
         ) -> 
             (arguments: Trees.Variables.LIST, function: Trees.Definitions.FUNCTION)
         is
-            let is_poisoned = false;
+            let is_poisoned mut = false;
             let arguments_open_parenthesis_location = context.location;
 
             context.next_token(Lexical.TOKEN.PAREN_OPEN);
@@ -73,10 +73,10 @@ namespace Syntax.Parsers.Definitions is
             let use arguments_tokenizer_snapshot = context.tokenizer_speculate_then_commit();
             let use arguments_logger_snaphot = context.logger_speculate_then_commit();
 
-            let arguments: Trees.Variables.LIST;
-            let function: Trees.Definitions.FUNCTION;
+            let arguments: Trees.Variables.LIST mut;
+            let function: Trees.Definitions.FUNCTION mut;
 
-            let any_bad_arguments = false;
+            let any_bad_arguments mut = false;
 
             if context.current_token != Lexical.TOKEN.PAREN_CLOSE then
                 if context.current.token != Lexical.TOKEN.IDENTIFIER then
@@ -87,7 +87,7 @@ namespace Syntax.Parsers.Definitions is
 
                 any_bad_arguments = arguments.is_poisoned;
 
-                let last_valid_argument_line = 0;
+                let last_valid_argument_line mut = 0;
 
                 for (index, a) in arguments | .index() do
                     if !a? \/ a.is_poisoned then
@@ -112,7 +112,7 @@ namespace Syntax.Parsers.Definitions is
                     // signature into the start of a following function
                     // signature
 
-                    let could_be_next_function = false;
+                    let could_be_next_function mut = false;
 
                     // TODO not sure all these conditions are necessary/meaningful
                     if !arguments? \/ arguments.variables.count == 0 then
@@ -193,9 +193,9 @@ namespace Syntax.Parsers.Definitions is
         ) -> 
         (type_expression: Trees.TypeExpressions.TypeExpression, function: Trees.Definitions.FUNCTION)
         is
-            let is_poisoned = false;
-            let type_expression: Trees.TypeExpressions.TypeExpression;
-            let function: Trees.Definitions.FUNCTION;
+            let is_poisoned mut = false;
+            let type_expression: Trees.TypeExpressions.TypeExpression mut;
+            let function: Trees.Definitions.FUNCTION mut;
 
             if context.current.token == Lexical.TOKEN.ARROW_THIN then
                 let arrow_location = context.location;
@@ -245,7 +245,7 @@ namespace Syntax.Parsers.Definitions is
             fi
 
             try
-                let is_poisoned = false;
+                let is_poisoned mut = false;
                 let start = context.location;
                 let name = identifier_function_name_parser.parse(context);
 
@@ -278,7 +278,7 @@ namespace Syntax.Parsers.Definitions is
                 let modifiers = modifier_list_parser.parse(context);
                 let expect_semicolon = context.current.token != Lexical.TOKEN.IS;
 
-                let body: Trees.Bodies.Body;
+                let body: Trees.Bodies.Body mut;
 
                 try 
                     body = body_parser.parse(context)

--- a/src/syntax/parsers/definitions/global_list.ghul
+++ b/src/syntax/parsers/definitions/global_list.ghul
@@ -15,7 +15,7 @@ namespace Syntax.Parsers.Definitions is
 
         parse(context: CONTEXT) -> Trees.Definitions.LIST is
             let start = context.location;
-            let end = context.location;
+            let end mut = context.location;
             let definitions = Collections.LIST[Trees.Definitions.Definition]();
 
             while !context.is_end_of_file /\ context.current.token != Lexical.TOKEN.SI do

--- a/src/syntax/parsers/definitions/indexer.ghul
+++ b/src/syntax/parsers/definitions/indexer.ghul
@@ -29,7 +29,7 @@ namespace Syntax.Parsers.Definitions is
         si
 
         parse(context: CONTEXT) -> Trees.Definitions.INDEXER is
-            let name: Trees.Identifiers.Identifier;
+            let name: Trees.Identifiers.Identifier mut;
             let start = context.location;
 
             if context.current.token == Lexical.TOKEN.IDENTIFIER then
@@ -42,9 +42,9 @@ namespace Syntax.Parsers.Definitions is
             
             let index_argument = variable_parser.parse(context);
             
-            let fail = !context.next_token(Lexical.TOKEN.SQUARE_CLOSE);
+            let fail mut = !context.next_token(Lexical.TOKEN.SQUARE_CLOSE);
 
-            let type_expression: Trees.TypeExpressions.TypeExpression;
+            let type_expression: Trees.TypeExpressions.TypeExpression mut;
 
             if !fail \/ context.current.token == Lexical.TOKEN.COLON then
                 context.next_token();
@@ -55,12 +55,12 @@ namespace Syntax.Parsers.Definitions is
             fi
 
             let modifiers = modifier_list_parser.parse(context);
-            let read_body: Trees.Bodies.Body;
-            let assign_body: Trees.Bodies.Body;
-            let setter_argument_name: Trees.Identifiers.Identifier;
-            let expect_semicolon = true;
+            let read_body: Trees.Bodies.Body mut;
+            let assign_body: Trees.Bodies.Body mut;
+            let setter_argument_name: Trees.Identifiers.Identifier mut;
+            let expect_semicolon mut = true;
 
-            let progress = false;
+            let progress mut = false;
 
             do
                 if fail then break ; fi
@@ -126,7 +126,7 @@ namespace Syntax.Parsers.Definitions is
                 read_body = Trees.Bodies.NULL(context.location);
             fi
 
-            let result: Trees.Definitions.INDEXER;
+            let result: Trees.Definitions.INDEXER mut;
             
             if index_argument? then
                 result = 

--- a/src/syntax/parsers/definitions/member_list.ghul
+++ b/src/syntax/parsers/definitions/member_list.ghul
@@ -15,7 +15,7 @@ namespace Syntax.Parsers.Definitions is
 
         parse(context: CONTEXT) -> Trees.Definitions.LIST is
             let start = context.location;
-            let end = context.location;
+            let end mut = context.location;
             let definitions = Collections.LIST[Trees.Definitions.Definition]();
 
             while !context.is_end_of_file /\ context.current.token != Lexical.TOKEN.SI do

--- a/src/syntax/parsers/definitions/pragma.ghul
+++ b/src/syntax/parsers/definitions/pragma.ghul
@@ -59,15 +59,15 @@ namespace Syntax.Parsers.Definitions is
         
             // FIXME: factor this out
             if pragma? /\ !pragma.is_poisoned then
-                let operator_name: string;
+                let operator_name: string mut;
                 let precedence_to_restore: PRECEDENCE;
     
-                let restore_status = PRECEDENCE_RESTORE_STATUS.NO_RESTORE_NEEDED;
+                let restore_status mut = PRECEDENCE_RESTORE_STATUS.NO_RESTORE_NEEDED;
 
                 if 
                     pragma.is_name_equal_to("precedence")
                 then
-                    let is_precedence_valid = true;
+                    let is_precedence_valid mut = true;
 
                     operator_name = pragma.try_get_string_literal_at(0);
                     let precedence_name = pragma.try_get_string_literal_at(1);
@@ -79,7 +79,7 @@ namespace Syntax.Parsers.Definitions is
                     fi
 
                     let precedence_int: int;
-                    let precedence_to_set: PRECEDENCE;
+                    let precedence_to_set: PRECEDENCE mut;
 
                     if !precedence_name? then
                         context.error(pragma.location, "expected operator precedence argument");

--- a/src/syntax/parsers/definitions/property.ghul
+++ b/src/syntax/parsers/definitions/property.ghul
@@ -26,8 +26,8 @@ namespace Syntax.Parsers.Definitions is
         si
 
         parse(context: CONTEXT) -> Trees.Definitions.PROPERTY is
-            let fail = false;
-            let progress = false;
+            let fail mut = false;
+            let progress mut = false;
 
             try
                 if context.in_classy then
@@ -40,7 +40,7 @@ namespace Syntax.Parsers.Definitions is
     
                 let start = context.location;
                 let name = identifier_parser.parse(context);
-                let type_expression: Trees.TypeExpressions.TypeExpression;
+                let type_expression: Trees.TypeExpressions.TypeExpression mut;
     
                 if context.current.token == Lexical.TOKEN.COLON then
                     context.next_token();
@@ -56,10 +56,10 @@ namespace Syntax.Parsers.Definitions is
                 fi
         
                 let modifiers = modifier_list_parser.parse(context);
-                let read_body: Trees.Bodies.Body;
-                let assign_body: Trees.Bodies.Body;
-                let setter_argument_name: Trees.Identifiers.Identifier;
-                let expect_semicolon = true;
+                let read_body: Trees.Bodies.Body mut;
+                let assign_body: Trees.Bodies.Body mut;
+                let setter_argument_name: Trees.Identifiers.Identifier mut;
+                let expect_semicolon mut = true;
     
                 do
                     if context.current.token == Lexical.TOKEN.ASSIGN then

--- a/src/syntax/parsers/definitions/struct.ghul
+++ b/src/syntax/parsers/definitions/struct.ghul
@@ -35,10 +35,10 @@ namespace Syntax.Parsers.Definitions is
 
                 let identifier = identifier_parser.parse(context);
                             
-                let arguments: Trees.TypeExpressions.LIST;
-                let ancestors: Trees.TypeExpressions.LIST;
+                let arguments: Trees.TypeExpressions.LIST mut;
+                let ancestors: Trees.TypeExpressions.LIST mut;
 
-                let is_poisoned = false;
+                let is_poisoned mut = false;
 
                 if context.current.token == Lexical.TOKEN.SQUARE_OPEN then
                     context.next_token();

--- a/src/syntax/parsers/definitions/trait.ghul
+++ b/src/syntax/parsers/definitions/trait.ghul
@@ -34,14 +34,14 @@ namespace Syntax.Parsers.Definitions is
                 context.next_token(Lexical.TOKEN.TRAIT);
                 let identifier = identifier_parser.parse(context);
 
-                let is_poisoned = false;
+                let is_poisoned mut = false;
 
                 if identifier == null then
                     return null;
                 fi            
 
-                let arguments: Trees.TypeExpressions.LIST;
-                let ancestors: Trees.TypeExpressions.LIST;
+                let arguments: Trees.TypeExpressions.LIST mut;
+                let ancestors: Trees.TypeExpressions.LIST mut;
 
                 if context.current.token == Lexical.TOKEN.SQUARE_OPEN then
                     context.next_token();
@@ -70,9 +70,9 @@ namespace Syntax.Parsers.Definitions is
                 let modifiers = modifier_list_parser.parse(context);
 
                 let expect_body = !is_poisoned \/ context.current.token == Lexical.TOKEN.IS;
-                let have_body = false;
+                let have_body mut = false;
 
-                let body: Trees.Definitions.LIST;
+                let body: Trees.Definitions.LIST mut;
                 
                 if expect_body /\ context.next_token(Lexical.TOKEN.IS) then
                     let in_trait = context.in_trait;

--- a/src/syntax/parsers/definitions/union.ghul
+++ b/src/syntax/parsers/definitions/union.ghul
@@ -52,13 +52,13 @@ namespace Syntax.Parsers.Definitions is
 
                 let identifier = identifier_parser.parse(context);
     
-                let should_poison = false;
+                let should_poison mut = false;
     
                 if identifier == null then
                     return null;
                 fi
     
-                let arguments: Trees.TypeExpressions.LIST;
+                let arguments: Trees.TypeExpressions.LIST mut;
     
                 if context.current.token == Lexical.TOKEN.SQUARE_OPEN then
                     context.next_token();
@@ -81,10 +81,10 @@ namespace Syntax.Parsers.Definitions is
 
                 let modifiers = modifier_list_parser.parse(context);
     
-                let read_a_body = false;
+                let read_a_body mut = false;
     
-                let body: Trees.Definitions.LIST;
-                let expect_body = false;
+                let body: Trees.Definitions.LIST mut;
+                let expect_body mut = false;
 
                 if !should_poison then
                     if context.next_token(Lexical.TOKEN.IS) then

--- a/src/syntax/parsers/definitions/use.ghul
+++ b/src/syntax/parsers/definitions/use.ghul
@@ -16,7 +16,7 @@ namespace Syntax.Parsers.Definitions is
 
             context.next_token(Lexical.TOKEN.USE);
 
-            let `use = identifier_qualified_parser.parse(context);
+            let `use mut = identifier_qualified_parser.parse(context);
 
             if !`use? then
                 return Trees.Definitions.USE(start::context.location, null, null);                

--- a/src/syntax/parsers/definitions/variant.ghul
+++ b/src/syntax/parsers/definitions/variant.ghul
@@ -35,7 +35,7 @@ namespace Syntax.Parsers.Definitions is
             try
                 let identifier = identifier_parser.parse(context);
     
-                let should_poison = false;
+                let should_poison mut = false;
     
                 if identifier == null then
                     return null;
@@ -43,7 +43,7 @@ namespace Syntax.Parsers.Definitions is
       
                 should_poison = identifier.is_poisoned;
                 
-                let members: Trees.Variables.LIST;
+                let members: Trees.Variables.LIST mut;
                 
                 if context.current_token == Lexical.TOKEN.PAREN_OPEN then
                     context.next_token();

--- a/src/syntax/parsers/definitions/variant_list.ghul
+++ b/src/syntax/parsers/definitions/variant_list.ghul
@@ -15,7 +15,7 @@ namespace Syntax.Parsers.Definitions is
 
         parse(context: CONTEXT) -> Trees.Definitions.LIST is
             let start = context.location;
-            let should_poison = false;
+            let should_poison mut = false;
 
             /*
             parse a list of typed-union variants using the supplied variant parser
@@ -28,7 +28,7 @@ namespace Syntax.Parsers.Definitions is
                 let variants = Collections.LIST[Trees.Definitions.Definition]();
 
                 let start = context.location;
-                let end = context.location;
+                let end mut = context.location;
 
                 while context.current_token != Lexical.TOKEN.SI /\ context.current_token != Lexical.TOKEN.END_OF_INPUT do
                     let variant_start = context.location;

--- a/src/syntax/parsers/expressions/expression.ghul
+++ b/src/syntax/parsers/expressions/expression.ghul
@@ -119,7 +119,7 @@ namespace Syntax.Parsers.Expressions is
         si
 
         // precedence climbing expression parser:
-        parse(context: CONTEXT, left: Trees.Expressions.Expression, min_precedence: PRECEDENCE) -> Trees.Expressions.Expression is
+        parse(context: CONTEXT, left: Trees.Expressions.Expression mut, min_precedence: PRECEDENCE) -> Trees.Expressions.Expression is
             do
                 let left_precedence = precedence(context);
 
@@ -129,7 +129,7 @@ namespace Syntax.Parsers.Expressions is
 
                 let apparent_op = context.current.value_string;
 
-                let real_op = apparent_op;
+                let real_op mut = apparent_op;
 
                 if _real_operation.contains_key(apparent_op) then
                     real_op = _real_operation[apparent_op];
@@ -139,7 +139,7 @@ namespace Syntax.Parsers.Expressions is
 
                 context.next_token();
 
-                let right: Trees.Expressions.Expression = expression_tertiary_parser.parse(context);
+                let right: Trees.Expressions.Expression mut = expression_tertiary_parser.parse(context);
 
                 assert right? else "parse right failed";
 

--- a/src/syntax/parsers/expressions/primary.ghul
+++ b/src/syntax/parsers/expressions/primary.ghul
@@ -46,9 +46,9 @@ namespace Syntax.Parsers.Expressions is
                     let identifier = identifier_parser.parse(context);
                     if context.allow_tuple_element /\ !identifier.is_qualified then
                         context.allow_tuple_element = false;
-                        let end = identifier.location;
-                        let type_expression: Trees.TypeExpressions.TypeExpression;
-                        let initializer: Trees.Expressions.Expression;
+                        let end mut = identifier.location;
+                        let type_expression: Trees.TypeExpressions.TypeExpression mut;
+                        let initializer: Trees.Expressions.Expression mut;
 
                         if context.current.token == Lexical.TOKEN.COLON then
                             context.next_token();
@@ -82,8 +82,8 @@ namespace Syntax.Parsers.Expressions is
                     let start = context.location;
                     context.next_token();
                     let elements = expression_list_parser.parse(context);
-                    let type_expression: Trees.TypeExpressions.TypeExpression;
-                    let end = context.location;
+                    let type_expression: Trees.TypeExpressions.TypeExpression mut;
+                    let end mut = context.location;
                     context.next_token(Lexical.TOKEN.SQUARE_CLOSE);
                     if context.current.token == Lexical.TOKEN.COLON then
                         context.next_token();
@@ -117,13 +117,13 @@ namespace Syntax.Parsers.Expressions is
                     // call argument with a known formal type).
                     // Distinguished from `new TYPE(args)` by an
                     // immediately-following `(`.
-                    let type_expression: Trees.TypeExpressions.TypeExpression;
+                    let type_expression: Trees.TypeExpressions.TypeExpression mut;
 
                     if context.current.token != Lexical.TOKEN.PAREN_OPEN then
                         type_expression = type_parser.parse(context);
                     fi
 
-                    let arguments: Trees.Expressions.LIST;
+                    let arguments: Trees.Expressions.LIST mut;
 
                     if context.next_token(Lexical.TOKEN.PAREN_OPEN) then
                         if context.current.token != Lexical.TOKEN.PAREN_CLOSE then
@@ -301,7 +301,7 @@ namespace Syntax.Parsers.Expressions is
 
                     let variable_list = variable_list_parser.parse(context);
 
-                    let expression: Trees.Expressions.Expression;
+                    let expression: Trees.Expressions.Expression mut;
 
                     if context.next_token(Lexical.TOKEN.IN) then
                         expression = expression_parser.parse(context);
@@ -331,9 +331,9 @@ namespace Syntax.Parsers.Expressions is
 
             let fragments = Collections.LIST[Trees.Expressions.INTERPOLATION_FRAGMENT]();
 
-            let is_first = true;
-            let success = false;
-            let line = start.start_line;
+            let is_first mut = true;
+            let success mut = false;
+            let line mut = start.start_line;
 
             while
                 context.current_token != Lexical.TOKEN.EXIT_STRING
@@ -394,9 +394,9 @@ namespace Syntax.Parsers.Expressions is
 
             let end = context.location;
 
-            let expression_count = 0;
-            let should_poison = false;
-            let total_fragment_length = 0;
+            let expression_count mut = 0;
+            let should_poison mut = false;
+            let total_fragment_length mut = 0;
 
             for e in fragments do
                 if e.is_expression then
@@ -418,7 +418,7 @@ namespace Syntax.Parsers.Expressions is
         si
 
         skip_to_end_of_string_with_interpolations(context: CONTEXT, line: int) is
-            let retries = 50;
+            let retries mut = 50;
 
             while 
                 context.current_token != Lexical.TOKEN.EXIT_STRING /\ 
@@ -482,7 +482,7 @@ namespace Syntax.Parsers.Expressions is
 
             let start = context.location;
 
-            let expression: Trees.Expressions.Expression;
+            let expression: Trees.Expressions.Expression mut;
 
             if context.current_token != Lexical.TOKEN.CONTINUE_STRING then
                 expression = expression_parser.parse(context);
@@ -503,10 +503,10 @@ namespace Syntax.Parsers.Expressions is
                 fi
             fi
 
-            let alignment: Trees.Expressions.Expression = null;
-            let format: string = null;
+            let alignment: Trees.Expressions.Expression mut = null;
+            let format: string mut = null;
 
-            let line = 0;
+            let line mut = 0;
 
             if context.current_token == Lexical.TOKEN.COMMA then
                 context.next_token();

--- a/src/syntax/parsers/expressions/secondary.ghul
+++ b/src/syntax/parsers/expressions/secondary.ghul
@@ -39,16 +39,16 @@ namespace Syntax.Parsers.Expressions is
             let use tokenizer_state = context.tokenizer_speculate_then_commit();
 
             let start = context.location;
-            let result: Trees.Expressions.Expression = expression_primary_parser.parse(context);
+            let result: Trees.Expressions.Expression mut = expression_primary_parser.parse(context);
 
-            let previous_left: Trees.Expressions.Expression;
-            let previous_identifier: Trees.Identifiers.Identifier;
+            let previous_left: Trees.Expressions.Expression mut;
+            let previous_identifier: Trees.Identifiers.Identifier mut;
 
             do
                 case context.current.token
                 when Lexical.TOKEN.PAREN_OPEN:
                     context.next_token();
-                    let arguments: Trees.Expressions.LIST;
+                    let arguments: Trees.Expressions.LIST mut;
                     if context.current.token != Lexical.TOKEN.PAREN_CLOSE then
                         arguments = expression_list_parser.parse(context);
                     else
@@ -60,10 +60,10 @@ namespace Syntax.Parsers.Expressions is
                 when Lexical.TOKEN.SQUARE_OPEN:
                     context.next_token();
 
-                    let done = false;
+                    let done mut = false;
 
-                    let left: Trees.Expressions.Expression;
-                    let identifier: Trees.Identifiers.Identifier;
+                    let left: Trees.Expressions.Expression mut;
+                    let identifier: Trees.Identifiers.Identifier mut;
 
                     if result.is_member then
                         left = previous_left;
@@ -81,7 +81,7 @@ namespace Syntax.Parsers.Expressions is
                         let type_arguments = type_list_parser.parse(context);
 
                         if type_arguments? /\ !type_arguments.is_poisoned /\ context.next_token(Lexical.TOKEN.SQUARE_CLOSE) then
-                            let index_expression: Trees.Expressions.Expression;
+                            let index_expression: Trees.Expressions.Expression mut;
 
                             if type_arguments.count == 1 then
                                 let index = type_arguments.elements[0].try_copy_as_value_expression();
@@ -154,7 +154,7 @@ namespace Syntax.Parsers.Expressions is
                     // we'll need a heuristic to try to decide if the user is trying to define a nested function or if they've missed off a closing `si`
                     // and actually this is a method definition (if we're in a classy context) or a global function definition (if we're not in a classy context)
 
-                    let is_nested_function_definition = false;
+                    let is_nested_function_definition mut = false;
 
                     if result.could_be_nested_function_definition /\ tokenizer_state.is_speculating then
                         // TODO need same logic but for nested within a global function
@@ -200,7 +200,7 @@ namespace Syntax.Parsers.Expressions is
                     // and we'll think we've let the enclosing function or method when we reach the closing
                     // `si` of the function literal
 
-                    let should_poison = false;
+                    let should_poison mut = false;
                     
                     if result.could_be_nested_function_definition then
                         should_poison = true;
@@ -210,8 +210,8 @@ namespace Syntax.Parsers.Expressions is
                         context.error(result.location, "expected function literal formal arguments");
                     fi
     
-                    let type_expression: Trees.TypeExpressions.TypeExpression;
-                    let arguments: Trees.Expressions.LIST;
+                    let type_expression: Trees.TypeExpressions.TypeExpression mut;
+                    let arguments: Trees.Expressions.LIST mut;
 
                     if context.current.token == Lexical.TOKEN.ARROW_THIN then
                         context.next_token();
@@ -315,8 +315,8 @@ namespace Syntax.Parsers.Expressions is
                     
                     let type_arguments = type_list_parser.parse(context);
 
-                    let left: Trees.Expressions.Expression;
-                    let identifier: Trees.Identifiers.Identifier;
+                    let left: Trees.Expressions.Expression mut;
+                    let identifier: Trees.Identifiers.Identifier mut;
 
                     if result.is_member then
                         left = previous_left;

--- a/src/syntax/parsers/expressions/tuple.ghul
+++ b/src/syntax/parsers/expressions/tuple.ghul
@@ -17,7 +17,7 @@ namespace Syntax.Parsers.Expressions is
             let start = context.location;
 
             if context.next_token(Lexical.TOKEN.PAREN_OPEN, syntax_error_message) then
-                let expressions: Trees.Expressions.LIST;
+                let expressions: Trees.Expressions.LIST mut;
 
                 if context.current.token != Lexical.TOKEN.PAREN_CLOSE then
                     expressions = expression_list_parser.parse(context);

--- a/src/syntax/parsers/identifiers/qualified.ghul
+++ b/src/syntax/parsers/identifiers/qualified.ghul
@@ -16,7 +16,7 @@ namespace Syntax.Parsers.Identifiers is
             
             if context.expect_token(Lexical.TOKEN.IDENTIFIER, syntax_error_message) then
                 let name = context.current.value_string;
-                let result = Trees.Identifiers.Identifier(context.location, name);
+                let result mut = Trees.Identifiers.Identifier(context.location, name);
 
                 context.next_token();
 

--- a/src/syntax/parsers/modifiers/list.ghul
+++ b/src/syntax/parsers/modifiers/list.ghul
@@ -12,10 +12,10 @@ namespace Syntax.Parsers.Modifiers is
 
         parse(context: CONTEXT) -> Trees.Modifiers.LIST is
             let start = context.location;
-            let end = context.location;
-            let modifier = modifier_parser.parse(context);
-            let access_modifier: Trees.Modifiers.AccessModifier;
-            let storage_class: Trees.Modifiers.StorageClass;
+            let end mut = context.location;
+            let modifier mut = modifier_parser.parse(context);
+            let access_modifier: Trees.Modifiers.AccessModifier mut;
+            let storage_class: Trees.Modifiers.StorageClass mut;
 
             if modifier? /\ isa Trees.Modifiers.AccessModifier(modifier) then
                 access_modifier = cast Trees.Modifiers.AccessModifier(modifier);

--- a/src/syntax/parsers/pragmas/pragma.ghul
+++ b/src/syntax/parsers/pragmas/pragma.ghul
@@ -35,7 +35,7 @@ namespace Syntax.Parsers.Pragmas is
             fi
 
             if context.next_token(Lexical.TOKEN.PAREN_OPEN) then
-                let arguments: Trees.Expressions.LIST;
+                let arguments: Trees.Expressions.LIST mut;
                 
                 if context.current.token != Lexical.TOKEN.PAREN_CLOSE then
                     arguments = expression_list_parser.parse(context);

--- a/src/syntax/parsers/statements/list.ghul
+++ b/src/syntax/parsers/statements/list.ghul
@@ -21,10 +21,10 @@ namespace Syntax.Parsers.Statements is
             self.terminators = terminators;
 
             let start = context.location;
-            let end = context.location;
+            let end mut = context.location;
             let statements = Collections.LIST[Trees.Statements.Statement]();
 
-            let want_semicolon = false;
+            let want_semicolon mut = false;
 
             while !context.is_end_of_file /\ !at_terminator(context) do
                 if context.current.token == Lexical.TOKEN.SEMICOLON then

--- a/src/syntax/parsers/statements/node.ghul
+++ b/src/syntax/parsers/statements/node.ghul
@@ -71,7 +71,7 @@ namespace Syntax.Parsers.Statements is
                 (context) -> Trees.Statements.Statement is
                     let start = context.location;
                     if context.next_token(Lexical.TOKEN.LET, syntax_error_message) then
-                        let want_dispose = false;
+                        let want_dispose mut = false;
                         if context.current_token == Lexical.TOKEN.USE then
                             context.next_token();
 
@@ -105,10 +105,10 @@ namespace Syntax.Parsers.Statements is
             add_parser(
                 (context) is
                     let start = context.location;
-                    let end = context.location;
+                    let end mut = context.location;
 
                     if context.next_token(Lexical.TOKEN.RETURN, syntax_error_message) then
-                        let expression: Trees.Expressions.Expression;
+                        let expression: Trees.Expressions.Expression mut;
                         if 
                             context.current.token != Lexical.TOKEN.SEMICOLON /\
                             primary_expression_tokens | .any(t => t == context.current.token)
@@ -126,9 +126,9 @@ namespace Syntax.Parsers.Statements is
             add_parser(
                 (context) is
                     let start = context.location;
-                    let end = context.location;
+                    let end mut = context.location;
                     if context.next_token(Lexical.TOKEN.THROW, syntax_error_message) then
-                        let expression: Trees.Expressions.Expression;
+                        let expression: Trees.Expressions.Expression mut;
                         if context.current.token != Lexical.TOKEN.SEMICOLON then
                             expression = expression_parser.parse(context);
                             end = expression.location;
@@ -146,12 +146,12 @@ namespace Syntax.Parsers.Statements is
                 (context) is
                     let start = context.location;
                     if context.next_token(Lexical.TOKEN.ASSERT, syntax_error_message) then
-                        let end = start;
+                        let end mut = start;
 
                         let expression = expression_parser.parse(context);
                         end = expression.location;
                         
-                        let message: Trees.Expressions.Expression;
+                        let message: Trees.Expressions.Expression mut;
 
                         if context.current_token == Lexical.TOKEN.ELSE then
                             context.next_token();
@@ -185,7 +185,7 @@ namespace Syntax.Parsers.Statements is
 
                     context.next_token(Lexical.TOKEN.CASE);
                     let expression = expression_parser.parse(context);
-                    let seen_default = false;
+                    let seen_default mut = false;
                     let match_list = Collections.LIST[Trees.Statements.CASE_MATCH]();
 
                     while 
@@ -193,7 +193,7 @@ namespace Syntax.Parsers.Statements is
                         context.current.token == Lexical.TOKEN.DEFAULT
                     do
                         let match_start = context.location;
-                        let match_expressions: Trees.Expressions.LIST = null;
+                        let match_expressions: Trees.Expressions.LIST mut = null;
                         if context.current.token != Lexical.TOKEN.DEFAULT then
                             context.next_token(Lexical.TOKEN.WHEN);
                             match_expressions = expression_list_parser.parse(context);
@@ -234,7 +234,7 @@ namespace Syntax.Parsers.Statements is
                         catches.add(Trees.Statements.CATCH(catch_start::catch_body.location, catch_variable, catch_body));
                     od
 
-                    let `finally: Trees.Statements.LIST;
+                    let `finally: Trees.Statements.LIST mut;
 
                     if context.current.token == Lexical.TOKEN.FINALLY then
                         context.next_token();
@@ -260,14 +260,14 @@ namespace Syntax.Parsers.Statements is
             add_parser(
                 (context) is
                     let start = context.location;
-                    let condition: Trees.Expressions.Expression;
+                    let condition: Trees.Expressions.Expression mut;
 
                     if context.current.token == Lexical.TOKEN.WHILE then
                         context.next_token();
                         condition = expression_parser.parse(context);
                     fi
 
-                    let body: Trees.Statements.LIST;
+                    let body: Trees.Statements.LIST mut;
 
                     if context.next_token(Lexical.TOKEN.DO, syntax_error_message) then                        
                         body = statement_list_parser.parse(context);
@@ -294,8 +294,8 @@ namespace Syntax.Parsers.Statements is
                     context.next_token(Lexical.TOKEN.FOR);
 
                     let variable = variable_parser.parse(context);
-                    let expression: Trees.Expressions.Expression;
-                    let body: Trees.Statements.LIST;
+                    let expression: Trees.Expressions.Expression mut;
+                    let body: Trees.Statements.LIST mut;
 
                     if (variable? /\ !variable.is_poisoned) \/ context.current_token == Lexical.TOKEN.IN then
                         if context.next_token(Lexical.TOKEN.IN, "in for statement") then
@@ -325,9 +325,9 @@ namespace Syntax.Parsers.Statements is
             add_parser(
                 (context) is
                     let start = context.location;
-                    let end = context.location;
+                    let end mut = context.location;
                     context.next_token();
-                    let label: Trees.Identifiers.Identifier;
+                    let label: Trees.Identifiers.Identifier mut;
                     if context.current.token == Lexical.TOKEN.IDENTIFIER then
                         label = identifier_parser.parse(context);
                         end = label.location;
@@ -342,9 +342,9 @@ namespace Syntax.Parsers.Statements is
             add_parser(
                 (context) is
                     let start = context.location;
-                    let end = context.location;
+                    let end mut = context.location;
                     context.next_token();
-                    let label: Trees.Identifiers.Identifier;
+                    let label: Trees.Identifiers.Identifier mut;
                     if context.current.token == Lexical.TOKEN.IDENTIFIER then
                         label = identifier_parser.parse(context);
                         end = label.location;
@@ -369,11 +369,11 @@ namespace Syntax.Parsers.Statements is
             let start = context.location;
             let branches = Collections.LIST[Trees.Statements.IF_BRANCH]();
         
-            let should_poison = false;
+            let should_poison mut = false;
 
             do
                 let branch_start = context.location;
-                let condition: Trees.Expressions.Expression;
+                let condition: Trees.Expressions.Expression mut;
 
                 if 
                     context.current.token == Lexical.TOKEN.ELIF \/ context.current.token == Lexical.TOKEN.IF

--- a/src/syntax/parsers/type_expressions/list.ghul
+++ b/src/syntax/parsers/type_expressions/list.ghul
@@ -12,7 +12,7 @@ namespace Syntax.Parsers.TypeExpressions is
         parse(context: CONTEXT) -> Trees.TypeExpressions.LIST is
             let elements = Collections.LIST[Trees.TypeExpressions.TypeExpression]();
             let start = context.location;
-            let end = context.location;
+            let end mut = context.location;
 
             do
                 let element = type_parser.parse(context);

--- a/src/syntax/parsers/type_expressions/type_expression.ghul
+++ b/src/syntax/parsers/type_expressions/type_expression.ghul
@@ -77,7 +77,7 @@ namespace Syntax.Parsers.TypeExpressions is
 
                         types.check_no_reference_types(context.logger);
 
-                        let poison = types.is_poisoned \/ identifier.is_poisoned;
+                        let poison mut = types.is_poisoned \/ identifier.is_poisoned;
 
                         let result = Trees.TypeExpressions.GENERIC(start::context.location, identifier, types);
 
@@ -99,13 +99,13 @@ namespace Syntax.Parsers.TypeExpressions is
                 (context: CONTEXT) -> Trees.TypeExpressions.TypeExpression is
                     let start = context.location;
                     context.next_token();
-                    let types: Trees.TypeExpressions.LIST;
+                    let types: Trees.TypeExpressions.LIST mut;
                     if context.current.token != Lexical.TOKEN.PAREN_CLOSE then
                         types = type_list_parser.parse(context);
                     else
                         types = Trees.TypeExpressions.LIST(start, Collections.LIST[Trees.TypeExpressions.TypeExpression](0));
                     fi
-                    let end = context.location;
+                    let end mut = context.location;
                     context.next_token(Lexical.TOKEN.PAREN_CLOSE, syntax_error_message);
                     if context.current.token == Lexical.TOKEN.ARROW_THIN then
                         context.next_token();
@@ -159,7 +159,7 @@ namespace Syntax.Parsers.TypeExpressions is
             element: Trees.TypeExpressions.TypeExpression
         ) -> Trees.TypeExpressions.TypeExpression
         is
-            let result = element;
+            let result mut = element;
 
             do
                 let token = context.current.token;
@@ -217,7 +217,7 @@ namespace Syntax.Parsers.TypeExpressions is
         si
 
         other_token(context: CONTEXT) -> Trees.TypeExpressions.TypeExpression is
-            let should_skip_next_token = false;
+            let should_skip_next_token mut = false;
 
             if context.current.token == Lexical.TOKEN.IN then
                 should_skip_next_token = true;

--- a/src/syntax/parsers/variables/destructure_left.ghul
+++ b/src/syntax/parsers/variables/destructure_left.ghul
@@ -15,10 +15,10 @@ namespace Syntax.Parsers.Variables is
 
         parse(context: CONTEXT) -> Trees.Variables.DESTRUCTURING_VARIABLE_LEFT is
             let start = context.location;
-            let end = context.location;
+            let end mut = context.location;
             let elements = Collections.LIST[Trees.Variables.VariableLeft]();
 
-            let should_poison = false;
+            let should_poison mut = false;
 
             if !context.next_token(Lexical.TOKEN.PAREN_OPEN) then
                 return null;
@@ -27,7 +27,7 @@ namespace Syntax.Parsers.Variables is
             end = context.location;
             
             do
-                let element: Trees.Variables.VariableLeft;
+                let element: Trees.Variables.VariableLeft mut;
 
                 if context.current_token == Lexical.TOKEN.PAREN_OPEN then
                     // we've reached the start of a nested list of destructure elements

--- a/src/syntax/parsers/variables/list.ghul
+++ b/src/syntax/parsers/variables/list.ghul
@@ -16,14 +16,14 @@ namespace Syntax.Parsers.Variables is
 
         parse(context: CONTEXT) -> Trees.Variables.LIST is
             let start = context.location;
-            let end = context.location;
+            let end mut = context.location;
             let variables = Collections.LIST[Trees.Variables.VARIABLE]();
             
             if 
                 context.current_token == Lexical.TOKEN.IDENTIFIER \/ context.current_token == Lexical.TOKEN.PAREN_OPEN \/ !allow_empty
             then
                 do
-                    let variable: Trees.Variables.VARIABLE;
+                    let variable: Trees.Variables.VARIABLE mut;
                     
                     variable = variable_parser.parse(context);
 

--- a/src/syntax/parsers/variables/variable.ghul
+++ b/src/syntax/parsers/variables/variable.ghul
@@ -23,7 +23,7 @@ namespace Syntax.Parsers.Variables is
         parse(context: CONTEXT) -> Trees.Variables.VARIABLE is
             let start = context.location;
 
-            let variable_left: Trees.Variables.VariableLeft;
+            let variable_left: Trees.Variables.VariableLeft mut;
 
             if context.current_token == Lexical.TOKEN.PAREN_OPEN then
                 variable_left = destructure_left_parser.parse(context);
@@ -40,10 +40,10 @@ namespace Syntax.Parsers.Variables is
                 return null;
             fi
                 
-            let end = variable_left.location;
-            let type_expression: Trees.TypeExpressions.TypeExpression = Trees.TypeExpressions.INFER(start::context.location);
-            let initializer: Trees.Expressions.Expression;
-            let is_explicit_type = false;
+            let end mut = variable_left.location;
+            let type_expression: Trees.TypeExpressions.TypeExpression mut = Trees.TypeExpressions.INFER(start::context.location);
+            let initializer: Trees.Expressions.Expression mut;
+            let is_explicit_type mut = false;
 
             if context.current.token == Lexical.TOKEN.COLON then
                 is_explicit_type = true;
@@ -53,7 +53,7 @@ namespace Syntax.Parsers.Variables is
                 end = type_expression.location;
             fi
 
-            let is_mutable_marked = false;
+            let is_mutable_marked mut = false;
             if context.current_token == Lexical.TOKEN.MUT then
                 context.next_token();
                 is_mutable_marked = true;

--- a/src/syntax/process/add_accessors_for_properties.ghul
+++ b/src/syntax/process/add_accessors_for_properties.ghul
@@ -100,7 +100,7 @@ namespace Syntax.Process is
 
             let backing_variable_name = "${property.name.name}";
 
-            let assign_argument_name = "$$value";
+            let assign_argument_name mut = "$$value";
 
             if property.assign_argument != null then
                 assign_argument_name = property.assign_argument.name;
@@ -221,8 +221,8 @@ namespace Syntax.Process is
         si
 
         pre(indexer: Definitions.INDEXER) -> bool is
-            let name: string;
-            let location: LOCATION;
+            let name: string mut;
+            let location: LOCATION mut;
 
             if indexer.name? then
                 name = indexer.name.name;
@@ -324,8 +324,8 @@ namespace Syntax.Process is
                 return false;
             fi
 
-            let unit_variant_count = 0;
-            let non_unit_variant_count = 0;
+            let unit_variant_count mut = 0;
+            let non_unit_variant_count mut = 0;
 
             for definition in `union.body do
                 if isa Definitions.VARIANT(definition) then
@@ -903,7 +903,7 @@ namespace Syntax.Process is
             )
         );
 
-        let condition: Trees.Expressions.Expression = isa_check;
+        let condition: Trees.Expressions.Expression mut = isa_check;
 
         for f in variant.fields do
             let other_cast = Trees.Expressions.CAST(
@@ -1084,7 +1084,7 @@ namespace Syntax.Process is
             )
         );
 
-        let combined: Trees.Expressions.Expression = seed;
+        let combined: Trees.Expressions.Expression mut = seed;
 
         for f in variant.fields do
             // Cast the field to `object` so we can call

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -155,7 +155,7 @@ namespace Syntax.Process is
                 return null;
             fi
 
-            let symbol = (cast Semantic.Types.NAMED(type)).symbol;
+            let symbol mut = (cast Semantic.Types.NAMED(type)).symbol;
 
             if isa Semantic.Symbols.GENERIC(symbol) then
                 symbol = (cast Semantic.Symbols.GENERIC(symbol)).symbol;
@@ -243,8 +243,8 @@ namespace Syntax.Process is
                 return null;
             fi
 
-            let other: Semantic.Symbols.Classy;
-            let saw_match = false;
+            let other: Semantic.Symbols.Classy mut;
+            let saw_match mut = false;
 
             for v in variants do
                 if v.name? /\ v.name.to_lower_invariant() =~ suffix then
@@ -407,7 +407,7 @@ namespace Syntax.Process is
             let move_next = get_zero_argument_function(type, "move_next");
             
             if move_next? then
-                let read_current = get_zero_argument_function(type, "$get_current");
+                let read_current mut = get_zero_argument_function(type, "$get_current");
 
                 if !read_current? then
                     read_current = get_zero_argument_function(type, "$get_Current");                    
@@ -616,7 +616,7 @@ namespace Syntax.Process is
         _pre(`for: Trees.Statements.FOR) -> bool is
             let symbol: Semantic.Symbols.Symbol;
 
-            let type: Type = Semantic.Types.ERROR();
+            let type: Type mut = Semantic.Types.ERROR();
     
             if `for.expression? /\ !`for.expression.is_poisoned then
                 `for.expression.walk(self);
@@ -731,7 +731,7 @@ namespace Syntax.Process is
                 return true;
             fi
 
-            let from_types: Collections.List[Type];
+            let from_types: Collections.List[Type] mut;
 
             if from_type.is_error then
                 return true;
@@ -750,7 +750,7 @@ namespace Syntax.Process is
 
             let elements = left.elements;
 
-            let count = elements.count;
+            let count mut = elements.count;
 
             if elements.count != from_types.count then
                 _logger.error(left.location, "expected {elements.count} destructuring elements but found {from_types.count}");
@@ -915,7 +915,7 @@ namespace Syntax.Process is
             fi
 
             let mark = _logger.mark();
-            let type: Type;
+            let type: Type mut;
 
             try
                 _logger.speculate();
@@ -1354,7 +1354,7 @@ namespace Syntax.Process is
             closure.map_type_arguments();
 
             let implied_type: Type;
-            let implied_argument_types: Collections.List[Type];
+            let implied_argument_types: Collections.List[Type] mut;
 
             // have we been passed expected arguments types? If so we'll use them
             // to argument types of any anonymous function literal arguments.
@@ -1372,7 +1372,7 @@ namespace Syntax.Process is
             let arguments_resolved = _closure_arg_resolver.resolve(function.arguments.expressions, closure, implied_argument_types);
 
             if arguments_resolved then
-                let return_type: Type;
+                let return_type: Type mut;
 
                 if function.type_expression.type? then
                     return_type = function.type_expression.type;
@@ -1464,12 +1464,12 @@ namespace Syntax.Process is
         si
 
         visit(tuple: Trees.Expressions.TUPLE) is
-            let names = Collections.LIST[string]();
+            let names mut = Collections.LIST[string]();
             let values = Collections.LIST[Value]();
             let types = Collections.LIST[Type]();
 
-            let element_constraints: Collections.List[Type] = null;
-            let constraint_error_message: string = null;
+            let element_constraints: Collections.List[Type] mut = null;
+            let constraint_error_message: string mut = null;
 
             if tuple.constraint? /\ tuple.constraint.is_value_tuple then
                 element_constraints = tuple.constraint.arguments;
@@ -1486,7 +1486,7 @@ namespace Syntax.Process is
                 return;
             fi
 
-            let seen_any_named = false;
+            let seen_any_named mut = false;
 
             for (index, v) in tuple.elements | .index() do
                 let element_type_constraint =
@@ -1607,7 +1607,7 @@ namespace Syntax.Process is
                 // aware element types (notably function literals) use
                 // it to infer their argument types; element types that
                 // ignore constraint (most literals) are unaffected.
-                let element_constraint: Type;
+                let element_constraint: Type mut;
 
                 if sequence.type_expression? /\ !isa Trees.TypeExpressions.INFER(sequence.type_expression) /\ sequence.type_expression.type? then
                     element_constraint = sequence.type_expression.type.get_element_type();
@@ -1637,12 +1637,12 @@ namespace Syntax.Process is
         si
 
         _visit(sequence: Trees.Expressions.SEQUENCE) is
-            let type: Type;
-            let have_explicit_type: bool;
+            let type: Type mut;
+            let have_explicit_type: bool mut;
 
             let elements = Collections.LIST[Trees.Expressions.Expression](sequence.elements);
 
-            let constraint_type: Type;
+            let constraint_type: Type mut;
             if sequence.constraint? then
                 constraint_type = sequence.constraint.get_element_type();
             fi
@@ -1667,10 +1667,10 @@ namespace Syntax.Process is
                     return;
                 fi
             else
-                let seen_any = false;
-                let seen_error = false;
-                let all_tuple_literals = elements.count > 0; // assume all tuples until proved otherwise
-                let tuples_element_count = -1;
+                let seen_any mut = false;
+                let seen_error mut = false;
+                let all_tuple_literals mut = elements.count > 0; // assume all tuples until proved otherwise
+                let tuples_element_count mut = -1;
                 let lub = LEAST_UPPER_BOUND_MAP();
 
                 for v in elements do
@@ -1812,7 +1812,7 @@ namespace Syntax.Process is
         visit(`self: Trees.Expressions.SELF) is
             let s = current_instance_context;
 
-            let type: Type;
+            let type: Type mut;
 
             if s? then
                 let f = current_function;
@@ -1871,7 +1871,7 @@ namespace Syntax.Process is
                 fi
 
                 let `classy = cast Semantic.Symbols.Classy(s);
-                let super_type = `classy.ancestors[0];
+                let super_type mut = `classy.ancestors[0];
 
                 // If the enclosing method overrides exactly one trait method,
                 // prefer that trait as the super type so super.foo() resolves
@@ -1984,7 +1984,7 @@ namespace Syntax.Process is
 
             `new.value = null;
 
-            let type: Type;
+            let type: Type mut;
 
             if `new.type_expression? then
                 type = `new.type_expression.type;
@@ -2021,7 +2021,7 @@ namespace Syntax.Process is
             fi
 
             let named_type = cast Semantic.Types.NAMED(type);
-            let type_symbol = named_type.symbol;
+            let type_symbol mut = named_type.symbol;
 
             let symbol = named_type.scope.find_direct("init");
 
@@ -2071,7 +2071,7 @@ namespace Syntax.Process is
                 return;
             fi
 
-            let function = overload_result.function;
+            let function mut = overload_result.function;
 
             function = _owner_constraint_specializer.specialize_from_constraint(`new.location, function, `new.constraint);
 
@@ -2080,7 +2080,7 @@ namespace Syntax.Process is
                 type = function.owner.type;
             fi;
 
-            let is_directly_owned = false;
+            let is_directly_owned mut = false;
 
             if isa Semantic.Symbols.GENERIC(type_symbol) /\ isa Semantic.Symbols.Symbol(function.owner) then
                 is_directly_owned = cast Semantic.Symbols.GENERIC(type_symbol) =~ cast Semantic.Symbols.Symbol(function.owner);
@@ -2150,8 +2150,8 @@ namespace Syntax.Process is
             arg_count: int,
             want_instance: bool
         ) -> Semantic.Symbols.Function is
-            let result: Semantic.Symbols.Function;
-            let count = 0;
+            let result: Semantic.Symbols.Function mut;
+            let count mut = 0;
 
             for f in group.functions do
                 if !want_instance /\ f.is_instance then
@@ -2181,7 +2181,7 @@ namespace Syntax.Process is
         resolve_constructor(
             location: LOCATION,
             right_location: LOCATION,
-            type: Semantic.Types.Type,
+            type: Semantic.Types.Type mut,
             argument_expressions: Trees.Expressions.LIST,
             constraint: Semantic.Types.Type,
             cache_key: Trees.Node
@@ -2189,7 +2189,7 @@ namespace Syntax.Process is
             let result: Value;
 
             let named_type = cast Semantic.Types.NAMED(type);
-            let type_symbol = named_type.symbol;
+            let type_symbol mut = named_type.symbol;
 
             let symbol = named_type.scope.find_direct("init");
 
@@ -2221,7 +2221,7 @@ namespace Syntax.Process is
                 return (cast Value(DUMMY(type, location)), cast Value(DUMMY(type, location)));
             fi
 
-            let overload_result = _overload_resolver.resolve(location, function_group, argument_types, false, true, true);
+            let overload_result mut = _overload_resolver.resolve(location, function_group, argument_types, false, true, true);
 
             // Sibling-arg fall-back: first resolve returned null AND
             // there's at least one FUNCTION-literal arg in the call.
@@ -2313,7 +2313,7 @@ namespace Syntax.Process is
                 fi
             fi
 
-            let function = overload_result.function;
+            let function mut = overload_result.function;
 
             function = _owner_constraint_specializer.specialize_from_constraint(location, function, constraint);
             function = _type_arg_placeholder_registry.specialize_with_placeholders(location, function, cache_key);
@@ -2323,7 +2323,7 @@ namespace Syntax.Process is
                 type = function.owner.type;
             fi;
 
-            let is_directly_owned = false;
+            let is_directly_owned mut = false;
 
             if isa Semantic.Symbols.GENERIC(type_symbol) /\ isa Semantic.Symbols.Symbol(function.owner) then
                 is_directly_owned = cast Semantic.Symbols.GENERIC(type_symbol) =~ cast Semantic.Symbols.Symbol(function.owner);
@@ -2463,9 +2463,9 @@ namespace Syntax.Process is
             let left_is_consumable = binary.left.value.check_is_consumable(_logger, binary.left.location);
             let right_is_consumable = binary.right.value.check_is_consumable(_logger, binary.right.location);
             
-            let binary_function_group: Semantic.Symbols.FUNCTION_GROUP;
-            let binary_overload_result: Semantic.OVERLOAD_RESOLVE_RESULT;
-            let binary_errors: Logging.DIAGNOSTICS_STATE;
+            let binary_function_group: Semantic.Symbols.FUNCTION_GROUP mut;
+            let binary_overload_result: Semantic.OVERLOAD_RESOLVE_RESULT mut;
+            let binary_errors: Logging.DIAGNOSTICS_STATE mut;
 
             let binary_name = binary.operation.name.to_string();
 
@@ -2490,9 +2490,9 @@ namespace Syntax.Process is
                 binary_errors = logger_snapshot.backtrack();
             fi
 
-            let member_overload_result: Semantic.OVERLOAD_RESOLVE_RESULT;
-            let member_function_group: Semantic.Symbols.FUNCTION_GROUP;
-            let member_errors: Logging.DIAGNOSTICS_STATE;
+            let member_overload_result: Semantic.OVERLOAD_RESOLVE_RESULT mut;
+            let member_function_group: Semantic.Symbols.FUNCTION_GROUP mut;
+            let member_errors: Logging.DIAGNOSTICS_STATE mut;
 
             if binary.left.value.type? then
                 let member_function_symbol = 
@@ -2518,7 +2518,7 @@ namespace Syntax.Process is
                 fi
             fi
 
-            let function: Semantic.Symbols.Function;
+            let function: Semantic.Symbols.Function mut;
 
             if member_overload_result? /\ binary_overload_result? then
                 if cast int(member_overload_result.score) <= cast int(binary_overload_result.score) then
@@ -2535,8 +2535,8 @@ namespace Syntax.Process is
             if function? then
                 _symbol_use_locations.add_symbol_use(binary.operation.location, function);
 
-                let force_type: Type;
-                let want_not = false;
+                let force_type: Type mut;
+                let want_not mut = false;
 
                 if binary.operation.name =~ "<>" then
                     if function.return_type !~ _innate_symbol_lookup.get_int_type() then
@@ -2561,7 +2561,7 @@ namespace Syntax.Process is
                     want_not = true;
                 fi
 
-                let value: Value;
+                let value: Value mut;
 
                 if function.is_unsafe_constraints then
                     _logger.warn(binary.location, "call to {function} has unchecked constraints");
@@ -2640,9 +2640,9 @@ namespace Syntax.Process is
 
                 let named_type = cast Semantic.Types.NAMED(type);
 
-                let function_name: string;
-                let arguments: Collections.LIST[Value];
-                let argument_types: Collections.LIST[Type];
+                let function_name: string mut;
+                let arguments: Collections.LIST[Value] mut;
+                let argument_types: Collections.LIST[Type] mut;
 
                 if need_store then
                     function_name = "set_Item";
@@ -2682,7 +2682,7 @@ namespace Syntax.Process is
                     _logger.poison(index.index.location, "indexer is not a function group: {symbol}");
                 fi
 
-                let overload_result: Semantic.OVERLOAD_RESOLVE_RESULT;
+                let overload_result: Semantic.OVERLOAD_RESOLVE_RESULT mut;
 
                 let use logger_snapshot = _logger.speculate_then_backtrack();
 
@@ -2737,7 +2737,7 @@ namespace Syntax.Process is
 
         visit(member: Trees.Expressions.MEMBER) is
             let need_store = member.value? /\ isa Need.STORE(member.value);
-            let need_deref = false;
+            let need_deref mut = false;
             
             if member.identifier == null then
                 member.value = DUMMY(Semantic.Types.ERROR(), member.location);
@@ -2745,7 +2745,7 @@ namespace Syntax.Process is
             fi
 
             if member.left? /\ member.left.value? then
-                let type = member.left.value.type;
+                let type mut = member.left.value.type;
 
                 if type == null then
                     _logger.poison(member.left.location, "member left has no type");
@@ -2829,7 +2829,7 @@ namespace Syntax.Process is
                         return result;
                     si;
 
-                let value: Value;
+                let value: Value mut;
 
                 if need_store then
                     let store_value = cast Need.STORE(member.value).value;
@@ -2912,7 +2912,7 @@ namespace Syntax.Process is
                 return;
             fi
 
-            let symbol = explicit_specialization.left.value.symbol;
+            let symbol mut = explicit_specialization.left.value.symbol;
 
             symbol = 
                 symbol.try_specialize(
@@ -2922,7 +2922,7 @@ namespace Syntax.Process is
                         .map(t => t.type).collect()
                 );
 
-            let from: IR.Values.Value;
+            let from: IR.Values.Value mut;
 
             if isa IR.Values.Load.SYMBOL(explicit_specialization.left.value) then
                 let load = cast IR.Values.Load.SYMBOL(explicit_specialization.left.value);
@@ -2955,7 +2955,7 @@ namespace Syntax.Process is
 
             arg.walk(self);
 
-            let symbol: Semantic.Symbols.Symbol;
+            let symbol: Semantic.Symbols.Symbol mut;
 
             if ambiguous_expression.left? then
                 ambiguous_expression.left.walk(self);
@@ -2978,8 +2978,8 @@ namespace Syntax.Process is
 
             _symbol_use_locations.add_symbol_use(ambiguous_expression.identifier.location, symbol);
 
-            let result_type: Semantic.Types.Type;
-            let result_symbol: Semantic.Symbols.Symbol;
+            let result_type: Semantic.Types.Type mut;
+            let result_symbol: Semantic.Symbols.Symbol mut;
 
             if symbol.is_type then
                 ambiguous_expression.result = Trees.Expressions.AMBIGUOUS_EXPRESSION_RESULT.TYPE;
@@ -3039,7 +3039,7 @@ namespace Syntax.Process is
         pre(generic_application: Trees.Expressions.GENERIC_APPLICATION) -> bool is
             generic_application.type_arguments.walk(self);
 
-            let symbol: Semantic.Symbols.Symbol;
+            let symbol: Semantic.Symbols.Symbol mut;
 
             if generic_application.left? then
                 generic_application.left.walk(self);
@@ -3063,8 +3063,8 @@ namespace Syntax.Process is
 
             _symbol_use_locations.add_symbol_use(generic_application.identifier.location, symbol);
 
-            let result_type: Semantic.Types.Type;
-            let result_symbol: Semantic.Symbols.Symbol;
+            let result_type: Semantic.Types.Type mut;
+            let result_symbol: Semantic.Symbols.Symbol mut;
 
             if symbol.is_type then
                 generic_application.result = Trees.Expressions.AMBIGUOUS_EXPRESSION_RESULT.TYPE;
@@ -3212,7 +3212,7 @@ namespace Syntax.Process is
                 return true;
             fi
 
-            let from_type =
+            let from_type mut =
                 if left.explicit_type? then
                     left.explicit_type;
                 else
@@ -3238,7 +3238,7 @@ namespace Syntax.Process is
             fi
 
             let elements = left.elements;
-            let count = elements.count;
+            let count mut = elements.count;
 
             if count != from_types.count then
                 _logger.error(left.location, "expected {count} destructuring elements but found {from_types.count}");
@@ -3355,7 +3355,7 @@ namespace Syntax.Process is
                 return;
             fi
 
-            let from_types: Collections.List[Type];
+            let from_types: Collections.List[Type] mut;
 
             if from_type.is_value_tuple then
                 from_types = from_type.arguments;
@@ -3370,7 +3370,7 @@ namespace Syntax.Process is
 
             let elements = left.elements;
 
-            let count = elements.count;
+            let count mut = elements.count;
 
             if elements.count != from_types.count then
                 _logger.error(left.location, "expected {elements.count} destructuring elements but found {from_types.count}");
@@ -3442,8 +3442,8 @@ namespace Syntax.Process is
         si
 
         visit(float: Trees.Expressions.Literals.FLOAT) is
-            let type: Type;
-            let suffix: string;
+            let type: Type mut;
+            let suffix: string mut;
 
             let value_string = float.value_string;
 
@@ -3478,7 +3478,7 @@ namespace Syntax.Process is
 
         visit(character: Trees.Expressions.Literals.CHARACTER) is
             let value_string = character.value_string;
-            let c: int = 0;
+            let c: int mut = 0;
 
             if value_string.length < 1 \/ value_string.length > 1 then
                 _logger.error(character.location, "invalid character literal");
@@ -3496,7 +3496,7 @@ namespace Syntax.Process is
         visit(boolean: Trees.Expressions.Literals.BOOLEAN) is
             let value_string = boolean.value_string;
 
-            let value: string;
+            let value: string mut;
 
             if value_string =~ "true" then
                 value = "1";
@@ -3584,14 +3584,14 @@ namespace Syntax.Process is
             // we could also treat consuming a bare type as a constructor call
             // this would be done in the symbol loader
 
-            let load_symbol: Semantic.Symbols.Symbol;
+            let load_symbol: Semantic.Symbols.Symbol mut;
 
             if isa Load.SYMBOL(call.function.value) then
                 let load = cast Load.SYMBOL(call.function.value);
                 load_symbol = load.symbol;
 
                 if load_symbol? /\ load_symbol.is_function_group then
-                    let want_instance: bool;
+                    let want_instance: bool mut;
 
                     want_instance = 
                         if load.from? then 
@@ -3601,7 +3601,7 @@ namespace Syntax.Process is
                         fi;
                     
                     let function_group = cast Semantic.Symbols.FUNCTION_GROUP(load_symbol);
-                    let overload_result = _overload_resolver.resolve(call.arguments.location, function_group, argument_types, true, want_instance, false);
+                    let overload_result mut = _overload_resolver.resolve(call.arguments.location, function_group, argument_types, true, want_instance, false);
 
                     // Constraint-push retry: when the first resolve fails AND
                     // there's exactly one arity-matching candidate AND at least
@@ -3634,7 +3634,7 @@ namespace Syntax.Process is
                             // generic short-circuit inside
                             // OWNER_TYPE_ARG_SPECIALIZER and the
                             // pre-existing behaviour is preserved.
-                            let push_candidate = candidate;
+                            let push_candidate mut = candidate;
 
                             if argument_types | .any(a => a? /\ a.is_function_with_any_implicit_argument_types) then
                                 push_candidate = _specialise_candidate_from_concrete_siblings(candidate, argument_types, call, call.arguments.location);
@@ -3843,7 +3843,7 @@ namespace Syntax.Process is
                 return;                    
             fi
 
-            let ok = true;
+            let ok mut = true;
 
             for i in 0..arguments.count do
                 // Back-feed BEFORE the compare so a Closure-call with
@@ -3954,7 +3954,7 @@ namespace Syntax.Process is
             let has_value_member =
                 has_value.left.value.type.find_member("has_value");
             let bool_type = _innate_symbol_lookup.get_bool_type();
-            let has_value_valid = false;
+            let has_value_valid mut = false;
 
             if has_value_member? then
                 if !isa Semantic.Symbols.Property(has_value_member) then
@@ -4140,9 +4140,9 @@ namespace Syntax.Process is
             // receiver's resolved type after the cond walk.
             let frame = ELSE_COMPLEMENT_FRAME();
 
-            let count = 0;
-            let first_has_condition = false;
-            let second_is_else = false;
+            let count mut = 0;
+            let first_has_condition mut = false;
+            let second_is_else mut = false;
 
             for b in `if.branches do
                 count = count + 1;
@@ -4192,12 +4192,12 @@ namespace Syntax.Process is
                 return;
             fi
 
-            let type = `if.constraint;
+            let type mut = `if.constraint;
 
-            let seen_any_values = false;
-            let seen_non_null_values = false;
-            let seen_null_values = false;
-            let all_tuple_literals = true;
+            let seen_any_values mut = false;
+            let seen_non_null_values mut = false;
+            let seen_null_values mut = false;
+            let all_tuple_literals mut = true;
 
             let lub = LEAST_UPPER_BOUND_MAP();
 

--- a/src/syntax/process/completer.ghul
+++ b/src/syntax/process/completer.ghul
@@ -174,7 +174,7 @@ namespace Syntax.Process is
                 return;
             fi
 
-            let type: Semantic.Types.Type;
+            let type: Semantic.Types.Type mut;
 
             if member.left.value.type.is_named then
                 type = member.left.value.type;

--- a/src/syntax/process/conditional_compilation.ghul
+++ b/src/syntax/process/conditional_compilation.ghul
@@ -31,9 +31,9 @@ namespace Syntax.Process is
             _flags[name] = value;
         si
 
-        get_is_enabled(name: string) -> bool is
-            let not_result = false;
-            let result = false;
+        get_is_enabled(name: string mut) -> bool is
+            let not_result mut = false;
+            let result mut = false;
 
             if name.starts_with("not.") then
                 name = name.substring(4);

--- a/src/syntax/process/declare_symbols.ghul
+++ b/src/syntax/process/declare_symbols.ghul
@@ -114,7 +114,7 @@ namespace Syntax.Process is
 
                 let il_name = cast Expressions.Literals.STRING(argument).value_string;
 
-                let definition = pragma.definition;
+                let definition mut = pragma.definition;
 
                 while isa Definitions.PRAGMA(definition) do
                     definition = cast Definitions.PRAGMA(definition).definition;
@@ -201,13 +201,13 @@ namespace Syntax.Process is
                 // FIXME: this is a bodge - generic class definition arguments are not type expressions, they're
                 // their own thing and should support type variance and type constraints - need syntax tree
                 // node classes to represent them:
-                let index = 0;
+                let index mut = 0;
 
                 let names = Collections.LIST[string]();
 
                 for a in arguments do
-                    let s: Semantic.Symbols.Symbol;
-                    let name: string;
+                    let s: Semantic.Symbols.Symbol mut;
+                    let name: string mut;
 
                     if isa Trees.TypeExpressions.NAMED(a) then
                         let named = cast Trees.TypeExpressions.NAMED(a);
@@ -243,7 +243,7 @@ namespace Syntax.Process is
             classy: Definitions.Classy,
             declare_symbol: (Semantic.DeclarationContext, LOCATION, LOCATION, string, Collections.List[string], bool, Semantic.Scope, Semantic.SymbolDefinitionListener) -> Semantic.Symbols.Symbol    
         ) -> bool is
-            let symbol: Semantic.Scope;
+            let symbol: Semantic.Scope mut;
             let stable_symbol: Semantic.STABLE_SYMBOL;
 
             if _keep_depth > 0 /\ _stable_symbols.try_get_symbol(classy, stable_symbol ref) then
@@ -348,7 +348,7 @@ namespace Syntax.Process is
         si
 
         pre(enum_member: Definitions.ENUM_MEMBER) -> bool is
-            let value: string;
+            let value: string mut;
 
             if enum_member.initializer? then
                 let i = enum_member.initializer;
@@ -374,7 +374,7 @@ namespace Syntax.Process is
 
             let is_private = function.modifiers.is_private;
 
-            let property: Semantic.Symbols.Property;
+            let property: Semantic.Symbols.Property mut;
 
             _local_id_generator.enter_function();
 
@@ -661,7 +661,7 @@ namespace Syntax.Process is
                 // anonymous function formal arguments until we know the context, so re-write
                 // them now to be variables:
                 for index in 0..arguments.count do
-                    let a = arguments[index];
+                    let a mut = arguments[index];
 
                     if isa Trees.Expressions.IDENTIFIER(a) then
                         let infer = Trees.TypeExpressions.INFER(a.location);

--- a/src/syntax/process/expand_namespaces.ghul
+++ b/src/syntax/process/expand_namespaces.ghul
@@ -21,8 +21,8 @@ namespace Syntax.Process is
 
             let list = cast Definitions.LIST(node);
 
-            let seen_any_namespaces = false;
-            let seen_any_other_definitions = false;
+            let seen_any_namespaces mut = false;
+            let seen_any_other_definitions mut = false;
 
             for definition in list do
                 if isa Definitions.NAMESPACE(definition) then
@@ -75,7 +75,7 @@ namespace Syntax.Process is
             return root_path =~ info.full_name;
         si
 
-        convert_file_name_to_identifier(name: string) -> string is
+        convert_file_name_to_identifier(name: string mut) -> string is
             if name.length == 0 then
                 return name;
             fi
@@ -95,8 +95,8 @@ namespace Syntax.Process is
         si
 
         get_namespace_name(path: string) -> string is
-            let local_path: string;
-            let uri: Uri;
+            let local_path: string mut;
+            let uri: Uri mut;
 
             if Uri.is_well_formed_uri_string(path, UriKind.ABSOLUTE) then
                 uri = Uri(path);
@@ -108,7 +108,7 @@ namespace Syntax.Process is
                 local_path = path;
             fi
 
-            let result =             
+            let result mut =             
                 convert_file_name_to_identifier(
                     _file_system.path.get_file_name_without_extension(local_path)
                 );
@@ -120,7 +120,7 @@ namespace Syntax.Process is
             return result;
         si
         
-        get_namespace_name_for_folder(path: string) -> string is
+        get_namespace_name_for_folder(path: string mut) -> string is
             let original_path = path;
 
             if !path? \/ path =~ "" then
@@ -135,7 +135,7 @@ namespace Syntax.Process is
         si        
 
         get_namespace_name_for_folder(info: IDirectoryInfo) -> string is
-            let result = "{convert_file_name_to_identifier(info.name)}__";
+            let result mut = "{convert_file_name_to_identifier(info.name)}__";
 
             if 
                 _file_system.file.exists(_file_system.path.combine(info.full_name, "ghul.json")) \/

--- a/src/syntax/process/generate_il.ghul
+++ b/src/syntax/process/generate_il.ghul
@@ -604,7 +604,7 @@ namespace Syntax.Process is
             // Property AST node carries either a Property symbol or a Variable
             // symbol (declare_symbols collapses `_name: T;` to a variable). Both
             // need wrapping when at namespace scope.
-            let globals_namespace: Semantic.Symbols.NAMESPACE;
+            let globals_namespace: Semantic.Symbols.NAMESPACE mut;
 
             let global_property = cast Semantic.Symbols.GLOBAL_PROPERTY(symbol);
 
@@ -825,7 +825,7 @@ namespace Syntax.Process is
             fi
 
             let buffer = System.Text.StringBuilder();
-            let globals_namespace: Semantic.Symbols.NAMESPACE;
+            let globals_namespace: Semantic.Symbols.NAMESPACE mut;
 
             for name in variable.names do
                 let symbol = find(name);
@@ -936,7 +936,7 @@ namespace Syntax.Process is
             super.visit(r);
 
             let function = current_function;
-            let value: Value;
+            let value: Value mut;
 
             if
                 r.expression? /\
@@ -1001,7 +1001,7 @@ namespace Syntax.Process is
                 end
             );
 
-            let need_exception_wrapper = true;
+            let need_exception_wrapper mut = true;
 
             if `assert.message? then
                 let message_value = `assert.message.value; 
@@ -1049,11 +1049,11 @@ namespace Syntax.Process is
 
             let return_type = current_function.return_type;
 
-            let return_needed: TEMP;
-            let return_value: TEMP;
-            let label: LOOP_LABELS;
+            let return_needed: TEMP mut;
+            let return_value: TEMP mut;
+            let label: LOOP_LABELS mut;
 
-            let outer_try: LOOP_LABELS;
+            let outer_try: LOOP_LABELS mut;
 
             let brancher = get_brancher_for_block();
 
@@ -1094,12 +1094,12 @@ namespace Syntax.Process is
 
                 let to_dispose = list.variables_to_dispose;
 
-                let i = to_dispose.count - 1;
+                let i mut = to_dispose.count - 1;
 
                 while i >= 0 do
                     let v = to_dispose[i];
 
-                    let skip_label: LABEL = null;
+                    let skip_label: LABEL mut = null;
 
                     if !v.type.is_value_type then
                         skip_label = LABEL();
@@ -1142,8 +1142,8 @@ namespace Syntax.Process is
         si
         
         visit(`if: Statements.IF) is
-            let is_first = true;
-            let seen_else = false;
+            let is_first mut = true;
+            let seen_else mut = false;
 
             let end = LABEL();
 
@@ -1274,8 +1274,8 @@ namespace Syntax.Process is
         get_exception_handler_temps() -> (outer_try: LOOP_LABELS, return_needed: TEMP, return_value: TEMP) is
             let return_type = current_function.return_type;
 
-            let return_needed: TEMP;
-            let return_value: TEMP;
+            let return_needed: TEMP mut;
+            let return_value: TEMP mut;
 
             let outer_try = _loops.get_current_try();
 
@@ -1457,7 +1457,7 @@ namespace Syntax.Process is
             let brancher = get_brancher_for_block();
             let loop = _loops.enter_loop();
 
-            let iterator: Value;
+            let iterator: Value mut;
 
             if `for.read_iterator? then
                 iterator = `for.read_iterator.call(`for.expression.location, `for.expression.value, Collections.LIST[Value](0), null, _function_caller);
@@ -1589,7 +1589,7 @@ namespace Syntax.Process is
 
                     add(call);
                 else
-                    let append_formatted: Semantic.Symbols.Symbol;
+                    let append_formatted: Semantic.Symbols.Symbol mut;
                     let args = Collections.LIST[Value](3);
 
                     args.add(expression.value);
@@ -1665,7 +1665,7 @@ namespace Syntax.Process is
         is_in_try: bool => get_current_try() != null;
 
         get_current_try() -> LOOP_LABELS is
-            let index: int = loops.count - 1;
+            let index: int mut = loops.count - 1;
             
             while index >= 0 do
                 let result = loops[index];
@@ -1679,7 +1679,7 @@ namespace Syntax.Process is
         si
 
         get_current_loop() -> LOOP_LABELS is
-            let index: int = loops.count - 1;
+            let index: int mut = loops.count - 1;
             
             while index >= 0 do
                 let result = loops[index];

--- a/src/syntax/process/narrowing.ghul
+++ b/src/syntax/process/narrowing.ghul
@@ -163,7 +163,7 @@ namespace Syntax.Process is
 
             let declared = declared_type_of(target);
 
-            let i = _saves.count - 1;
+            let i mut = _saves.count - 1;
 
             while i >= 0 do
                 let save = _saves[i];
@@ -171,7 +171,7 @@ namespace Syntax.Process is
                 if save.symbol == target then
                     _saves.remove_at(i);
 
-                    let m = 0;
+                    let m mut = 0;
                     while m < _marks.count do
                         if _marks[m] > i then
                             _marks[m] = _marks[m] - 1;

--- a/src/syntax/process/numeric_literal_classifier.ghul
+++ b/src/syntax/process/numeric_literal_classifier.ghul
@@ -34,16 +34,16 @@ namespace Syntax.Process is
         si
 
         classify_integer(location: LOCATION, value_string: string) -> Literal.NUMBER is
-            let type: Type;
-            let suffix = "i4";
-            let conv: string;
-            let working = value_string;
+            let type: Type mut;
+            let suffix mut = "i4";
+            let conv: string mut;
+            let working mut = value_string;
 
             let last_char = working.get_chars(working.length - 1);
 
             if "bBcCsSiIlLwWuU".contains(last_char) then
-                let is_unsigned = false;
-                let cutoff = working.length;
+                let is_unsigned mut = false;
+                let cutoff mut = working.length;
 
                 if last_char == 'u' \/ last_char == 'U' then
                     is_unsigned = true;
@@ -183,10 +183,10 @@ namespace Syntax.Process is
                 return (false, 0UL);
             fi
 
-            let value: ulong = 0UL;
+            let value: ulong mut = 0UL;
 
             for c in s do
-                let digit: int;
+                let digit: int mut;
 
                 if c >= '0' /\ c <= '9' then
                     digit = cast int(c) - cast int('0');

--- a/src/syntax/process/printer/base.ghul
+++ b/src/syntax/process/printer/base.ghul
@@ -58,7 +58,7 @@ namespace Syntax.Process.Printer is
 
         write_indent() is
             if _indent_needed then
-                let i = 0;
+                let i mut = 0;
                 while i < _indent*_depth do
                     _result.append(' ');
                     i = i + 1;
@@ -120,7 +120,7 @@ namespace Syntax.Process.Printer is
 
         visit(variables: Variables.LIST) is
             location(variables);
-            let first = true;
+            let first mut = true;
             for v in variables do
                 if !first then
                     write(", ");
@@ -151,7 +151,7 @@ namespace Syntax.Process.Printer is
             `enum.name.accept(self);
             write_line(" is");
             indent();
-            let seen_any = false;
+            let seen_any mut = false;
             for member in `enum.members do
                 if seen_any then
                     write_line(",");
@@ -258,7 +258,7 @@ namespace Syntax.Process.Printer is
 
         visit(types: TypeExpressions.LIST) is
             location(types);
-            let seen_any = false;
+            let seen_any mut = false;
             for t in types do
                 if seen_any then
                     write(',');
@@ -380,7 +380,7 @@ namespace Syntax.Process.Printer is
 
         visit(expressions: Expressions.LIST) is
             location(expressions);
-            let seen_any = false;
+            let seen_any mut = false;
             for e in expressions do
                 if seen_any then
                     write(',');
@@ -423,7 +423,7 @@ namespace Syntax.Process.Printer is
         visit(interpolation: Expressions.STRING_INTERPOLATION) is
             location(interpolation);
 
-            let in_expression = false;
+            let in_expression mut = false;
 
             write("\"");
             for e in interpolation.values do
@@ -476,7 +476,7 @@ namespace Syntax.Process.Printer is
         si
 
         visit(destructure_left: Trees.Expressions.DESTRUCTURING_LEFT_EXPRESSION) is
-            let seen_any = false;
+            let seen_any mut = false;
             write("(");
             for e in destructure_left.elements do
                 if seen_any then
@@ -549,8 +549,8 @@ namespace Syntax.Process.Printer is
 
         visit(i: Statements.IF) is
             location(i);
-            let is_first = true;
-            let seen_else = false;
+            let is_first mut = true;
+            let seen_else mut = false;
 
             assert i?;
             assert i.branches?;

--- a/src/syntax/process/printer/ghul.ghul
+++ b/src/syntax/process/printer/ghul.ghul
@@ -31,7 +31,7 @@ namespace Syntax.Process.Printer is
         visit(destructure_element_list: Variables.DESTRUCTURING_VARIABLE_LEFT) is
             write("(");
 
-            let seen_any = false;
+            let seen_any mut = false;
             for e in destructure_element_list.elements do
                 if seen_any then
                     write(", ");

--- a/src/syntax/process/resolve_ancestors.ghul
+++ b/src/syntax/process/resolve_ancestors.ghul
@@ -36,8 +36,8 @@ namespace Syntax.Process is
 
             let class_symbol = cast Semantic.Symbols.CLASS(scope_for(`class));
 
-            let seen_class_ancestor = false;
-            let is_first = true;
+            let seen_class_ancestor mut = false;
+            let is_first mut = true;
 
             if `class.ancestors? then
                 for a in `class.ancestors do
@@ -85,7 +85,7 @@ namespace Syntax.Process is
 
             let trait_symbol = cast Semantic.Symbols.TRAIT(scope_for(`trait));
 
-            let seen_valid_ancestor = false;
+            let seen_valid_ancestor mut = false;
 
             if `trait.ancestors? then
                 for a in `trait.ancestors do

--- a/src/syntax/process/resolve_explicit_variable_types copy.ghul
+++ b/src/syntax/process/resolve_explicit_variable_types copy.ghul
@@ -236,8 +236,8 @@ namespace Syntax.Process is
         si
 
         set_type_ancestors(a: Trees.TypeExpressions.TypeExpression) is
-            let symbol: Semantic.Symbols.Symbol;
-            let type: Type;
+            let symbol: Semantic.Symbols.Symbol mut;
+            let type: Type mut;
 
             a.check_is_not_void(_logger, "cannot use void type here");            
 

--- a/src/syntax/process/resolve_type_expressions.ghul
+++ b/src/syntax/process/resolve_type_expressions.ghul
@@ -120,7 +120,7 @@ namespace Syntax.Process is
         explicit_specialize_symbol(
             location: Source.LOCATION, 
             left_value: IR.Values.Value,
-            symbol: Semantic.Symbols.Symbol, 
+            symbol: Semantic.Symbols.Symbol mut, 
             type_arguments: Collections.List[Semantic.Types.Type]
         ) -> IR.Values.Value
         is
@@ -131,7 +131,7 @@ namespace Syntax.Process is
                     type_arguments
                 );
 
-            let from: IR.Values.Value;
+            let from: IR.Values.Value mut;
 
             if isa IR.Values.Load.SYMBOL(left_value) then
                 let load = cast IR.Values.Load.SYMBOL(left_value);
@@ -219,10 +219,10 @@ namespace Syntax.Process is
         si
 
         visit(tuple: Trees.TypeExpressions.TUPLE) is
-            let names = Collections.LIST[string]();
+            let names mut = Collections.LIST[string]();
             let types = Collections.LIST[Type]();
 
-            let seen_any_named = false;
+            let seen_any_named mut = false;
 
             for (index, a) in tuple.elements | .index() do
                 if isa Trees.TypeExpressions.NAMED_TUPLE_ELEMENT(a) then
@@ -258,7 +258,7 @@ namespace Syntax.Process is
             // possibility and parsed this as a GENERIC_APPLICATION tree
             let arg = ambiguous_expression.type_arguments.elements[0];
 
-            let type_argument_walk_succeeded = false;
+            let type_argument_walk_succeeded mut = false;
             try
                 arg.walk(self);
                 type_argument_walk_succeeded = true;

--- a/src/syntax/process/resolve_uses.ghul
+++ b/src/syntax/process/resolve_uses.ghul
@@ -42,7 +42,7 @@ namespace Syntax.Process is
                     continue;
                 fi
 
-                let use_name = used_symbol.name;
+                let use_name mut = used_symbol.name;
 
                 if u.name? /\ u.name.name? then
                     use_name = u.name.name;
@@ -77,7 +77,7 @@ namespace Syntax.Process is
 
                     let existing_used_symbol = namespace_scope.get_used_symbol(use_name);
 
-                    let use_function_group: Semantic.Symbols.FUNCTION_GROUP;
+                    let use_function_group: Semantic.Symbols.FUNCTION_GROUP mut;
                    
                     if existing_used_symbol? then
                         use_function_group = cast Semantic.Symbols.FUNCTION_GROUP(existing_used_symbol);

--- a/src/syntax/process/scopedvisitor.ghul
+++ b/src/syntax/process/scopedvisitor.ghul
@@ -40,7 +40,7 @@ namespace Syntax.Process is
                 return null;
             fi
 
-            let result: Semantic.Symbols.Symbol;
+            let result: Semantic.Symbols.Symbol mut;
 
             if identifier.qualifier? then                
                 let qualifier = find(identifier.qualifier);

--- a/src/syntax/process/signature_help.ghul
+++ b/src/syntax/process/signature_help.ghul
@@ -92,7 +92,7 @@ namespace Syntax.Process is
             let last = arguments.count - 1;
 
             for i in 0..arguments.count do
-                let location: LOCATION;
+                let location: LOCATION mut;
 
                 if i == 0 then
                     location = LOCATION(

--- a/src/syntax/trees/definitions/list.ghul
+++ b/src/syntax/trees/definitions/list.ghul
@@ -57,7 +57,7 @@ namespace Syntax.Trees.Definitions is
 
         walk(visitor: Visitor) is
             if !visitor.pre(self) then
-                let i = 0;
+                let i mut = 0;
 
                 while i < definitions.count do
                     definitions[i].walk(visitor);

--- a/src/syntax/trees/identifiers/identifier.ghul
+++ b/src/syntax/trees/identifiers/identifier.ghul
@@ -18,7 +18,7 @@ namespace Syntax.Trees.Identifiers is
 
         iterator: Collections.Iterator[string] => names.iterator;
 
-        init(location: LOCATION, name: string) is
+        init(location: LOCATION, name: string mut) is
             super.init(location);
 
             if name == null then
@@ -59,7 +59,7 @@ namespace Syntax.Trees.Identifiers is
 
         qualifier_names: Collections.LIST[string] is
             let result = Collections.LIST[string]();
-            let p = qualifier;
+            let p mut = qualifier;
 
             while p? do
                 result.add(p.name);
@@ -74,7 +74,7 @@ namespace Syntax.Trees.Identifiers is
 
             result.add(name);
 
-            let p = qualifier;
+            let p mut = qualifier;
 
             while p? do
                 result.add(p.name);
@@ -89,7 +89,7 @@ namespace Syntax.Trees.Identifiers is
 
             result.add(name);
 
-            let p = qualifier;
+            let p mut = qualifier;
 
             while p? do
                 result.add(p.name);
@@ -116,7 +116,7 @@ namespace Syntax.Trees.Identifiers is
         si
 
         copy() -> Identifier is
-            let np: Identifier;
+            let np: Identifier mut;
 
             if qualifier? then
                 np = qualifier.copy();

--- a/src/syntax/trees/modifiers/list.ghul
+++ b/src/syntax/trees/modifiers/list.ghul
@@ -25,8 +25,8 @@ namespace Syntax.Trees.Modifiers is
         si
 
         copy() -> LIST is
-            let nam: AccessModifier;
-            let nsc: StorageClass;
+            let nam: AccessModifier mut;
+            let nsc: StorageClass mut;
 
             if access_modifier? then
                 nam = access_modifier.copy();


### PR DESCRIPTION
Follow-up to ghul#1124 applied to the compiler itself: bare `let` bindings that are subsequently reassigned are flagged by the new `--warn-implicit-mutable-let` warning; each such site in ghul/src is rewritten to declare with trailing `mut` (`<binding> mut`, matching the existing `name: type public` modifier-after-name convention).

Enhancements:
- 560+ reassigned bindings across ~95 source files now declare with trailing `mut`. Bulk-applied via script over the warning emitter's output; handful of manual fixes for destructure patterns and backticked identifiers (`` `use ``, `` `finally ``).
- A few function parameters use the new `f(x: T mut)` form (the same per-variable parser slot supports parameter-mut) where the function reassigned its argument.

Technical:
- Compiler pin bumped to 0.9.5 (first published release supporting `let mut`).
- No semantic or IL change. `<binding> mut` is identical to bare `<binding>` at the IL level; the difference is purely a source-level marker (`is_mutable_marked`) consumed by the warning emitter to opt out of the warning.
- 263/263 unit tests pass under 0.9.5; bootstrap validated as byte-identical against the equivalent workspace-alpha compiler earlier.
- Zero remaining `--warn-implicit-mutable-let` warnings.