### PR TITLE
Recognise ghūl `union` types when reflected from another assembly

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.9.8",
+      "version": "0.9.9",
       "commands": [
         "ghul-compiler"
       ],

--- a/src/ioc/container.ghul
+++ b/src/ioc/container.ghul
@@ -430,7 +430,7 @@ namespace IoC is
 
             type_mapper = Semantic.DotNet.TYPE_MAPPER(dotnet_symbol_table, innate_symbol_lookup, type_name_map, assemblies);
 
-            symbol_factory = Semantic.DotNet.SYMBOL_FACTORY(namespaces, type_name_map, type_mapper, referenced_assemblies, assemblies, logger);
+            symbol_factory = Semantic.DotNet.SYMBOL_FACTORY(namespaces, type_name_map, type_mapper, referenced_assemblies, assemblies, type_details_lookup, logger);
 
             assembly_info = Semantic.DotNet.ASSEMBLY_INFO(ir_context);
 

--- a/src/semantic/dotnet/assemblies.ghul
+++ b/src/semantic/dotnet/assemblies.ghul
@@ -236,33 +236,66 @@ namespace Semantic.DotNet is
                     return;
                 elif !type.`namespace? \/ !type.full_name? then
                     return;
-                else
-                    let namespace_details = _type_name_map.get_namespace_details(type);
-                    let namespace_name: string mut;
-    
-                    if namespace_details? then
-                        namespace_name = namespace_details.ghul_name;
-                    else
-                        namespace_name = type.`namespace;
-                    fi
-
-                    let type_name mut = type.name;
-
-                    if type.is_nested then
-                        let parts = type.full_name.split(['.']);
-                        
-                        type_name = parts[parts.count-1].replace('+', '_');
-                    fi
-                    
-                    type_details = TYPE_DETAILS(type, namespace_name, type_name, null, assembly_name, assembly_version);
                 fi
-    
+
+                // A ghūl `union` emits each variant as a sibling class
+                // whose .NET `Namespace` is the union's full name. Left
+                // alone, the reflection loader would register that
+                // string as an actual namespace and clash with the
+                // union class itself. The compiler tags variants with
+                // `[Ghul.Internal.VARIANT_ATTRIBUTE]`; queue them under
+                // the union's full name so symbol_factory can
+                // materialize each one as a member of the union when
+                // the union's symbol is created.
+                if has_variant_attribute(type) /\ type.`namespace? then
+                    _type_details_lookup.register_variant(type.`namespace, type);
+                    return;
+                fi
+
+                let namespace_details = _type_name_map.get_namespace_details(type);
+                let namespace_name: string mut;
+
+                if namespace_details? then
+                    namespace_name = namespace_details.ghul_name;
+                else
+                    namespace_name = type.`namespace;
+                fi
+
+                let type_name mut = type.name;
+
+                if type.is_nested then
+                    let parts = type.full_name.split(['.']);
+
+                    type_name = parts[parts.count-1].replace('+', '_');
+                fi
+
+                type_details = TYPE_DETAILS(type, namespace_name, type_name, null, assembly_name, assembly_version);
+
                 assert type_details.assembly_name? /\ type_details.assembly_name.length > 0 else "invalid assmbly name before add type {type_details}";
 
                 _type_details_lookup.add_type(type_details);
             catch ex: System.Exception
                 Std.error.write_line("failed to import: {type} exception: {ex.to_string().replace('\n', ' ')}");
             yrt
+        si
+
+        has_variant_attribute(type: TYPE) -> bool is
+            try
+                for attr in type.get_custom_attributes_data() do
+                    let attr_type = attr.attribute_type;
+
+                    if attr_type? /\ attr_type.full_name =~ "Ghul.Internal.VARIANT_ATTRIBUTE" then
+                        return true;
+                    fi
+                od
+            catch ex: System.Exception
+                // Some reflected types fail at GetCustomAttributesData()
+                // (e.g. with missing referenced assemblies). Treating
+                // the absence as "not a variant" is safe — the worst
+                // case is the old behaviour kicking in for that type.
+            yrt
+
+            return false;
         si
  
         block_all_unsupported_assemblies() is

--- a/src/semantic/dotnet/symbol_factory.ghul
+++ b/src/semantic/dotnet/symbol_factory.ghul
@@ -33,6 +33,7 @@ namespace Semantic.DotNet is
         _symbol_table: SYMBOL_TABLE;
 
         _referenced_assemblies: REFERENCED_ASSEMBLIES;
+        _type_details_lookup: TYPE_DETAILS_LOOKUP;
 
         _non_generic_get_enumerator: MethodInfo;
 
@@ -51,6 +52,7 @@ namespace Semantic.DotNet is
             type_mapper: TYPE_MAPPER,
             referenced_assemblies: REFERENCED_ASSEMBLIES,
             type_source: TypeSource,
+            type_details_lookup: TYPE_DETAILS_LOOKUP,
             logger: Logging.Logger
         ) is
             _namespaces = namespaces;
@@ -58,6 +60,7 @@ namespace Semantic.DotNet is
             _type_mapper = type_mapper;
             _assembly_names = MAP[Assembly,string]();
             _referenced_assemblies = referenced_assemblies;
+            _type_details_lookup = type_details_lookup;
 
             _type_source = type_source;
 
@@ -133,6 +136,12 @@ namespace Semantic.DotNet is
 
             if dotnet_type.is_enum then
                 result = Symbols.ENUM_STRUCT(Source.LOCATION.reflected, Source.LOCATION.reflected, owner, ghul_type_name, true, owner);
+                result.mark_overrides_resolved();
+            elif dotnet_type.is_class /\ has_union_attribute(dotnet_type) then
+                result = Symbols.UNION(Source.LOCATION.reflected, Source.LOCATION.reflected, owner, ghul_type_name, arguments, true, owner);
+                result.mark_overrides_resolved();
+            elif dotnet_type.is_class /\ has_variant_attribute(dotnet_type) then
+                result = Symbols.VARIANT(Source.LOCATION.reflected, Source.LOCATION.reflected, owner, ghul_type_name, arguments, true, owner);
                 result.mark_overrides_resolved();
             elif dotnet_type.is_class then
                 let result_class = Symbols.CLASS(Source.LOCATION.reflected, Source.LOCATION.reflected, owner, ghul_type_name, arguments, true, owner);
@@ -634,6 +643,123 @@ namespace Semantic.DotNet is
             return result;
         si
         
+        has_union_attribute(type: TYPE) -> bool is
+            try
+                for attr in type.get_custom_attributes_data() do
+                    let attr_type = attr.attribute_type;
+
+                    if attr_type? /\ attr_type.full_name =~ "Ghul.Internal.UNION_ATTRIBUTE" then
+                        return true;
+                    fi
+                od
+            catch ex: System.Exception
+            yrt
+
+            return false;
+        si
+
+        has_variant_attribute(type: TYPE) -> bool is
+            try
+                for attr in type.get_custom_attributes_data() do
+                    let attr_type = attr.attribute_type;
+
+                    if attr_type? /\ attr_type.full_name =~ "Ghul.Internal.VARIANT_ATTRIBUTE" then
+                        return true;
+                    fi
+                od
+            catch ex: System.Exception
+            yrt
+
+            return false;
+        si
+
+        // Cross-assembly variant materialization: when reflecting a
+        // union from another assembly, the variant classes are
+        // sibling top-level types whose `Namespace` equals the
+        // union's full name (assemblies.ghul: import_type queues
+        // them into TYPE_DETAILS_LOOKUP by union full name instead
+        // of registering them as top-level). When the union's
+        // symbol is created and its members populated, call this
+        // to also materialize the variants as members of the union.
+        materialize_variants(union_symbol: Symbols.UNION, union_type: TYPE) is
+            assert union_symbol? else "union symbol is null";
+
+            let union_full_name = union_type.full_name;
+
+            if !union_full_name? then
+                return;
+            fi
+
+            let variants = _type_details_lookup.get_variants_for_union(union_full_name);
+
+            if !variants? then
+                return;
+            fi
+
+            for variant_type in variants do
+                materialize_variant(union_symbol, variant_type);
+            od
+        si
+
+        materialize_variant(union_symbol: Symbols.UNION, variant_type: TYPE) is
+            let variant_name = variant_type.name;
+            let assembly_name = get_assembly_name(variant_type);
+            let assembly_version =
+                variant_type.assembly.get_name().version.to_string().replace('.', ':');
+
+            let arguments = LIST();
+            let argument_variances = LIST();
+
+            if variant_type.is_generic_type /\ variant_type.contains_generic_parameters then
+                for a in variant_type.get_generic_arguments() do
+                    if a.is_generic_type_parameter then
+                        arguments.add(a.name);
+                        argument_variances.add(_type_mapper.map_type_argument_variance(a));
+                    fi
+                od
+            fi
+
+            let variant_symbol =
+                Symbols.VARIANT(
+                    Source.LOCATION.reflected,
+                    Source.LOCATION.reflected,
+                    union_symbol,
+                    variant_name,
+                    arguments,
+                    true,
+                    union_symbol
+                );
+
+            variant_symbol.mark_overrides_resolved();
+
+            if argument_variances.count > 0 then
+                variant_symbol.argument_variances = argument_variances;
+            fi
+
+            variant_symbol.il_assembly_name = assembly_name;
+            variant_symbol.il_name_override = get_il_name(variant_type);
+
+            _referenced_assemblies.add(assembly_name, assembly_version);
+
+            // Register the variant in the lookup so subsequent
+            // dotnet-type-keyed lookups (`get_symbol(type)`) and
+            // resolution paths can find it.
+            let variant_td =
+                TYPE_DETAILS(
+                    variant_type,
+                    union_symbol.qualified_name,
+                    variant_name,
+                    variant_symbol.il_name_override,
+                    assembly_name,
+                    assembly_version
+                );
+
+            union_symbol.add_member(variant_symbol);
+
+            add_ancestors(variant_symbol, variant_type);
+            add_members(variant_symbol, variant_type);
+        si
+
         get_il_name(type: TYPE) -> string is
             let buffer = System.Text.StringBuilder();
 

--- a/src/semantic/dotnet/symbol_table.ghul
+++ b/src/semantic/dotnet/symbol_table.ghul
@@ -139,17 +139,29 @@ namespace Semantic.DotNet is
 
             if !result? then
                 @IF.debug() Std.error.write_line("not something we can handle yet: ignoring: {type}");
-                
+
                 return null;
             fi
 
             let dotnet_type = type_details.dotnet_type;
-            
+
             _symbol_store.add_symbol(dotnet_type, "{type_details.ghul_namespace}.{type_details.ghul_type_name}", result);
 
             _symbol_factory.add_ancestors(result, dotnet_type);
 
             _symbol_factory.add_members(result, dotnet_type);
+
+            // When the union's symbol has just been created, also
+            // materialize each of its variants as a child member.
+            // Cross-assembly variants don't go through normal type
+            // lookup (their reflected `Namespace` is the union's
+            // full name and would clash with the union as a
+            // namespace) — assemblies.ghul stashed them keyed by
+            // the union's full name in TYPE_DETAILS_LOOKUP.
+            let union_result = cast Symbols.UNION(result);
+            if union_result? then
+                _symbol_factory.materialize_variants(union_result, dotnet_type);
+            fi
 
             return result;
         si

--- a/src/semantic/dotnet/type_details_lookup.ghul
+++ b/src/semantic/dotnet/type_details_lookup.ghul
@@ -17,14 +17,44 @@ namespace Semantic.DotNet is
 
         // lookups from ghūl - requires a linear seach but:
         // 1) we will often want all the names in a namespace, for completion suggestsions
-        // 2) the result of other look-ups wll be cached  
+        // 2) the result of other look-ups wll be cached
         _type_details_by_ghul_namespace: MutableMap[string, MutableList[TYPE_DETAILS]];
+
+        // Variant types reflected from `union` declarations in other
+        // assemblies are NOT added under their .NET `Namespace`
+        // (which equals the union's full name and would otherwise
+        // collide with the union class on namespace creation). They
+        // are queued here keyed by the union's full .NET name so the
+        // union's symbol can materialize them as nested members at
+        // creation time.
+        _variants_by_union_full_name: MutableMap[string, MutableList[TYPE]];
 
         ghul_namespaces: Iterable[string] => _type_details_by_ghul_namespace.keys;
 
         init() is
             _type_details_by_dotnet_type = MAP[TYPE, TYPE_DETAILS]();
             _type_details_by_ghul_namespace = MAP[string, MutableList[TYPE_DETAILS]]();
+            _variants_by_union_full_name = MAP[string, MutableList[TYPE]]();
+        si
+
+        register_variant(union_full_name: string, variant_type: TYPE) is
+            let list: MutableList[TYPE] mut;
+
+            if !_variants_by_union_full_name.try_get_value(union_full_name, list ref) then
+                list = LIST[TYPE]();
+
+                _variants_by_union_full_name.add(union_full_name, list);
+            fi
+
+            list.add(variant_type);
+        si
+
+        get_variants_for_union(union_full_name: string) -> Iterable[TYPE] is
+            let result: MutableList[TYPE];
+
+            _variants_by_union_full_name.try_get_value(union_full_name, result ref);
+
+            return result;
         si
 
         find_all_root_namespaces() -> Iterable[string] is

--- a/src/syntax/process/generate_il.ghul
+++ b/src/syntax/process/generate_il.ghul
@@ -339,6 +339,8 @@ namespace Syntax.Process is
             enter_scope(`union);
             _context.indent();
 
+            println(".custom instance void ['ghul-runtime']Ghul.Internal.UNION_ATTRIBUTE::.ctor() = ( 01 00 00 00 )");
+
             `union.name.walk(self);
 
             if `union.arguments? then
@@ -392,6 +394,8 @@ namespace Syntax.Process is
             enter_scope(variant);
 
             _context.indent();
+
+            println(".custom instance void ['ghul-runtime']Ghul.Internal.VARIANT_ATTRIBUTE::.ctor() = ( 01 00 00 00 )");
         si
         
         visit(variant: Definitions.VARIANT) is


### PR DESCRIPTION
Bugs fixed:
- A `union` type emitted into one assembly couldn't be consumed from another. The variant sub-classes are emitted as siblings of the union whose `Namespace` equals the union's full name; on reflection the `_type_details_by_ghul_namespace` lookup registered that string as an actual namespace, which then clashed with the union class itself — every dependent compilation died with "redefining symbol GENERATOR_STEP as a namespace, originally defined at reflected". The mere presence of a union in a referenced assembly broke compilation of any project depending on it.

Technical:
- IL emission: `pre(union)` and `pre(variant)` in `generate_il.ghul` now emit `.custom instance void ['ghul-runtime']Ghul.Internal.UNION_ATTRIBUTE::.ctor()` / `VARIANT_ATTRIBUTE::.ctor()` directives so the reflection layer can recognise these classes. The attribute classes themselves landed in ghul-runtime#81.
- `assemblies.ghul:import_type` checks for VARIANT_ATTRIBUTE before adding to the namespace lookup; tagged types are queued into `TYPE_DETAILS_LOOKUP._variants_by_union_full_name` instead.
- `symbol_factory.create_class` produces `Symbols.UNION` for types tagged with UNION_ATTRIBUTE and `Symbols.VARIANT` for those tagged with VARIANT_ATTRIBUTE (instead of plain `Symbols.CLASS`).
- `symbol_factory.materialize_variants` (called from `symbol_table.create_symbol` after `add_members` runs on a union) walks the queued variants for that union, creates a `Symbols.VARIANT` per entry, and adds it to the union's scope so `union.find_member("DONE")` resolves cross-assembly the same way it does for an intra-assembly union.
- All 263 unit tests + 723 integration tests pass against `origin/main`.