### PR TITLE
Inherit trait default methods onto reflected concrete classes

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.9.9",
+      "version": "0.9.10",
       "commands": [
         "ghul-compiler"
       ],

--- a/src/semantic/dotnet/symbol_factory.ghul
+++ b/src/semantic/dotnet/symbol_factory.ghul
@@ -254,7 +254,7 @@ namespace Semantic.DotNet is
             od
 
             for t in type.get_members(cast BindingFlags(64 + 4 + 32 + 16 + 8)) do
-                add_member(result, type, properties, indexers, methods, t);                    
+                add_member(result, type, properties, indexers, methods, t);
             od
 
             if methods.count > 0 then
@@ -263,6 +263,61 @@ namespace Semantic.DotNet is
                 for m in methods do
                     result.add_member(m.function);
                 od
+            fi
+
+            inherit_default_trait_members(result, type);
+        si
+
+        // Copy any concrete (`is_default_trait_method`) method from
+        // a trait the class implements into the class itself, unless
+        // the class already has a member by that name.
+        //
+        // Why this is its own pass: `mark_overrides_resolved()` runs
+        // on reflected concrete classes in `create_class` so the
+        // full `SYMBOL_INHERITANCE_RESOLVER` skips them — its
+        // override-clash and abstract-method checks would otherwise
+        // fire on .NET-side diamonds (`IList` × `IReadOnlyList`,
+        // `MemberInfo.Module`, …) that the assembly's IL has already
+        // resolved via explicit interface implementation but that
+        // ghul's reflection layer can't see. Pulling down just the
+        // trait defaults keeps the assumption-of-trust for
+        // overrides while still making `find_member("filter")` work
+        // on a reflected class that inherits `filter` from `Pipe[T]`.
+        inherit_default_trait_members(result: Symbols.Scoped, type: TYPE) is
+            if !isa Symbols.Classy(result) then
+                return;
+            fi
+
+            let classy = cast Symbols.Classy(result);
+
+            for i in 0..classy.ancestors.count do
+                let ancestor = classy.get_ancestor(i);
+
+                if !ancestor? \/ !ancestor.scope? then
+                    continue;
+                fi
+
+                for member in ancestor.scope.symbols do
+                    inherit_default_trait_member(classy, member);
+                od
+            od
+        si
+
+        inherit_default_trait_member(into: Symbols.Classy, member: Symbols.Symbol) is
+            if isa Symbols.FUNCTION_GROUP(member) then
+                let group = cast Symbols.FUNCTION_GROUP(member);
+
+                for function in group.functions do
+                    if function.is_default_trait_method then
+                        into.add_member(function);
+                    fi
+                od
+            elif isa Symbols.Function(member) then
+                let function = cast Symbols.Function(member);
+
+                if function.is_default_trait_method then
+                    into.add_member(function);
+                fi
             fi
         si
 


### PR DESCRIPTION
Bugs fixed:
- Cross-assembly: a default trait method (`is_default_trait_method`) defined on a trait wasn't visible on a concrete class implementing that trait when the class came in via reflection. `find_member("filter")` on a reflected `ADAPTOR_PIPE[int]` returned null even though `Pipe[T]` defined `filter` as a default. Same call resolved fine intra-assembly; the failure was specific to reflection.
- Root cause: `create_class` calls `mark_overrides_resolved()` on reflected concrete classes (CLASS, STRUCT, ENUM_STRUCT, UNION, VARIANT) on the assumption that the assembly's IL has resolved any inheritance. `pull_down_super_symbols()` then short-circuits on `_are_overrides_resolved`, so inherited trait defaults never make it into the class's `_symbols`. The full `SYMBOL_INHERITANCE_RESOLVER` can't safely be run in its place because its override-clash / abstract-method checks fire on `MemberInfo.Module`-style `.NET` diamonds the assembly's IL has already resolved via explicit interface implementation but ghul's reflection layer can't see.

Technical:
- New `inherit_default_trait_members(result, type)` runs at the end of `add_members`. For each ancestor of the class, walk the ancestor's `_symbols`; for every `is_default_trait_method` function (or group entry), call `into.add_member(function)`. `add_member` already deduplicates and upgrades a single existing function into a FUNCTION_GROUP for proper override behaviour, so a class that overrides the trait default (e.g. `ADAPTOR_PIPE.count`) ends up with both the override and the default in a group — the override wins at call time.
- Skips abstract methods and ordinary non-trait class methods — those are either already in the class's IL (and so picked up by `add_members`'s normal path) or genuinely missing in a way that's not safe to paper over.
- 263 unit + 723 integration tests all pass against `origin/main`.