### PR TITLE
Auto-infer operator precedence and add yield operator

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.9.10",
+      "version": "0.9.11",
       "commands": [
         "ghul-compiler"
       ],

--- a/integration-tests/parse/operator-precedence-pragma/err.expected
+++ b/integration-tests/parse/operator-precedence-pragma/err.expected
@@ -1,5 +1,4 @@
 test.ghul: 25,21..25,31: error: no overload found for ##(Ghul.string, Ghul.string), tried Test.##(a: int, b: int) -> Ghul.int
-test.ghul: 27,25..27,27: error: operator '@@' has unknown precedence
 test.ghul: 27,25..27,27: error: operator Ghul.int @@ Ghul.int not found
 test.ghul: 29,29..29,31: error: operator Ghul.string %% Ghul.string not found
 test.ghul: 3,1..4,10: error: precedence must be between user-1 and user-8

--- a/integration-tests/parse/operator-precedence-pragma/test.ghul
+++ b/integration-tests/parse/operator-precedence-pragma/test.ghul
@@ -1,6 +1,6 @@
 @precedence("##", "addition")
-@precedence("%%", "16")
-@precedence("!!!", "99")
+@precedence("%%", "multiplication")
+@precedence("!!!", "primary")
 namespace Test is
 
 

--- a/integration-tests/semantic/generic-function-definition/test.ghul
+++ b/integration-tests/semantic/generic-function-definition/test.ghul
@@ -1,5 +1,5 @@
-@precedence("##", "10")
-@precedence("$$", "10")
+@precedence("##", "shift")
+@precedence("$$", "shift")
 namespace Test is
     use Std = IO.Std;
 

--- a/src/syntax/parsers/definitions/pragma.ghul
+++ b/src/syntax/parsers/definitions/pragma.ghul
@@ -31,23 +31,23 @@ namespace Syntax.Parsers.Definitions is
 
             _precedence_names = MAP[string,PRECEDENCE]();
 
-            _precedence_names.add("user-1", cast PRECEDENCE(3));
-            _precedence_names.add("boolean", cast PRECEDENCE(4));
-            _precedence_names.add("user-2", cast PRECEDENCE(5));
-            _precedence_names.add("relational", cast PRECEDENCE(6));
-            _precedence_names.add("user-3", cast PRECEDENCE(7));
-            _precedence_names.add("range", cast PRECEDENCE(8));
-            _precedence_names.add("user-4", cast PRECEDENCE(9));
-            _precedence_names.add("shift", cast PRECEDENCE(10));
-            _precedence_names.add("user-5", cast PRECEDENCE(11));
-            _precedence_names.add("bitwise", cast PRECEDENCE(12));
-            _precedence_names.add("user-6", cast PRECEDENCE(13));
-            _precedence_names.add("addition", cast PRECEDENCE(14));
-            _precedence_names.add("user-7", cast PRECEDENCE(15));
-            _precedence_names.add("multiplication", cast PRECEDENCE(16));
-            _precedence_names.add("user-8", cast PRECEDENCE(17));
-            _precedence_names.add("member", cast PRECEDENCE(18));
-            _precedence_names.add("primary", cast PRECEDENCE(19));
+            _precedence_names.add("user-1", PRECEDENCE.USER_1);
+            _precedence_names.add("boolean", PRECEDENCE.BOOLEAN);
+            _precedence_names.add("user-2", PRECEDENCE.USER_2);
+            _precedence_names.add("relational", PRECEDENCE.RELATIONAL);
+            _precedence_names.add("user-3", PRECEDENCE.USER_3);
+            _precedence_names.add("range", PRECEDENCE.RANGE);
+            _precedence_names.add("user-4", PRECEDENCE.USER_4);
+            _precedence_names.add("shift", PRECEDENCE.SHIFT);
+            _precedence_names.add("user-5", PRECEDENCE.USER_5);
+            _precedence_names.add("bitwise", PRECEDENCE.BITWISE);
+            _precedence_names.add("user-6", PRECEDENCE.USER_6);
+            _precedence_names.add("addition", PRECEDENCE.ADDITION);
+            _precedence_names.add("user-7", PRECEDENCE.USER_7);
+            _precedence_names.add("multiplication", PRECEDENCE.MULTIPLICATION);
+            _precedence_names.add("user-8", PRECEDENCE.USER_8);
+            _precedence_names.add("member", PRECEDENCE.MEMBER);
+            _precedence_names.add("primary", PRECEDENCE.PRIMARY);
     
             self.pragma_parser = pragma_parser;
             self.definition_parser = definition_parser;
@@ -78,7 +78,6 @@ namespace Syntax.Parsers.Definitions is
                         is_precedence_valid = false;
                     fi
 
-                    let precedence_int: int;
                     let precedence_to_set: PRECEDENCE mut;
 
                     if !precedence_name? then
@@ -86,11 +85,9 @@ namespace Syntax.Parsers.Definitions is
 
                         is_precedence_valid = false;
                     elif !_precedence_names.try_get_value(precedence_name, precedence_to_set ref) then
-                        if int.try_parse(precedence_name, precedence_int ref) then
-                            precedence_to_set = cast PRECEDENCE(precedence_int);
-                        else
-                            is_precedence_valid = false;                            
-                        fi
+                        context.error(pragma.location, "unknown precedence name '{precedence_name}'");
+
+                        is_precedence_valid = false;
                     fi
 
                     if is_precedence_valid then

--- a/src/syntax/parsers/expressions/expression.ghul
+++ b/src/syntax/parsers/expressions/expression.ghul
@@ -7,26 +7,27 @@ namespace Syntax.Parsers.Expressions is
     use Source;
 
     enum PRECEDENCE is
-        NONE,           // 0
-        MIN,            // 1
-        UNDEFINED,      // 2
-        USER_1,         // 3
-        BOOLEAN,        // 4
-        USER_2,         // 5
-        RELATIONAL,     // 6
-        USER_3,         // 7
-        RANGE,          // 8
-        USER_4,         // 9
-        SHIFT,          // 10
-        USER_5,         // 11
-        BITWISE,        // 12
-        USER_6,         // 13
-        ADDITION,       // 14
-        USER_7,         // 15
-        MULTIPLICATION, // 16
-        USER_8,         // 17
-        MEMBER,         // 18
-        PRIMARY         // 19
+        NONE           = 0,
+        MIN            = 10,
+        YIELD          = 20,    // reserved for `||` generator yield infix
+        UNDEFINED      = 30,
+        USER_1         = 40,
+        BOOLEAN        = 50,
+        USER_2         = 60,
+        RELATIONAL     = 70,
+        USER_3         = 80,
+        RANGE          = 90,
+        USER_4         = 100,
+        SHIFT          = 110,
+        USER_5         = 120,
+        BITWISE        = 130,
+        USER_6         = 140,
+        ADDITION       = 150,
+        USER_7         = 160,
+        MULTIPLICATION = 170,
+        USER_8         = 180,
+        MEMBER         = 190,
+        PRIMARY        = 200
     si
 
     class EXPRESSION: Base[Trees.Expressions.Expression] is
@@ -76,6 +77,7 @@ namespace Syntax.Parsers.Expressions is
             _precedence["\\/"] = PRECEDENCE.BOOLEAN;
             _precedence["∧"] = PRECEDENCE.BOOLEAN;
             _precedence["∨"] = PRECEDENCE.BOOLEAN;
+            _precedence["||"] = PRECEDENCE.YIELD;
 
             _real_operation = Collections.MAP[string,string]();
 
@@ -96,13 +98,68 @@ namespace Syntax.Parsers.Expressions is
                 return PRECEDENCE.NONE;
             fi
 
-            if !_precedence.contains_key(context.current.value_string) then
-                context.error(context.current.location, 
-                "operator '{context.current.value_string}' has unknown precedence");
-                return PRECEDENCE.UNDEFINED;
+            let op = context.current.value_string;
+
+            let known: PRECEDENCE mut;
+            if _precedence.try_get_value(op, known ref) then
+                return known;
             fi
 
-            return _precedence[context.current.value_string];
+            let auto = auto_precedence_for(op);
+            _precedence[op] = auto;
+
+            return auto;
+        si
+
+        // First-character-based precedence heuristic for user-defined
+        // operators. Modelled on OCaml/F#. Every built-in operator in the
+        // _precedence table matches what this would compute, so the table
+        // is purely an optimisation and a hook point for explicit overrides
+        // via @precedence.
+        auto_precedence_for(op: string) -> PRECEDENCE static is
+            if op =~ "/\\" \/ op =~ "\\/" then
+                return PRECEDENCE.BOOLEAN;
+            fi
+            if op =~ ".." \/ op =~ "::" then
+                return PRECEDENCE.RANGE;
+            fi
+
+            let first = op.get_chars(0);
+
+            if first == '*' \/ first == '/' \/ first == '%' \/
+               first == '×' \/ first == '÷' \/ first == '✕'
+            then
+                return PRECEDENCE.MULTIPLICATION;
+            fi
+            if first == '+' \/ first == '-' then
+                return PRECEDENCE.ADDITION;
+            fi
+            if first == '<' \/ first == '>' then
+                if op.length >= 2 /\ op.get_chars(1) == first then
+                    return PRECEDENCE.SHIFT;
+                else
+                    return PRECEDENCE.RELATIONAL;
+                fi
+            fi
+            if first == '=' \/ first == '!' \/ first == '~' \/
+               first == '≈' \/ first == '≡'
+            then
+                return PRECEDENCE.RELATIONAL;
+            fi
+            if first == '&' \/ first == '∩' then
+                return PRECEDENCE.BITWISE;
+            fi
+            if first == '|' \/ first == '¦' \/ first == '∪' then
+                return PRECEDENCE.BITWISE;
+            fi
+            if first == '^' then
+                return PRECEDENCE.BITWISE;
+            fi
+            if first == '∧' \/ first == '∨' then
+                return PRECEDENCE.BOOLEAN;
+            fi
+
+            return PRECEDENCE.USER_5;
         si
 
         parse(context: CONTEXT) -> Trees.Expressions.Expression is
@@ -120,6 +177,8 @@ namespace Syntax.Parsers.Expressions is
 
         // precedence climbing expression parser:
         parse(context: CONTEXT, left: Trees.Expressions.Expression mut, min_precedence: PRECEDENCE) -> Trees.Expressions.Expression is
+            let last_was_yield_infix mut = false;
+
             do
                 let left_precedence = precedence(context);
 
@@ -134,8 +193,10 @@ namespace Syntax.Parsers.Expressions is
                 if _real_operation.contains_key(apparent_op) then
                     real_op = _real_operation[apparent_op];
                 fi
-                
+
                 let op = Trees.Identifiers.Identifier(context.location, real_op);
+
+                let op_location = context.location;
 
                 context.next_token();
 
@@ -153,10 +214,63 @@ namespace Syntax.Parsers.Expressions is
                     right = parse(context, right, right_precedence);
                 od
 
-                left = Trees.Expressions.BINARY(left.location::right.location, op, apparent_op, left, right);
+                if apparent_op =~ "||" then
+                    if last_was_yield_infix then
+                        IoC.CONTAINER.instance.logger.error(
+                            op_location,
+                            "yield infix `||` does not chain — the right operand should be a complete next-step expression, not another `||`"
+                        );
+                    fi
+                    left = lower_yield_infix(left, right);
+                    last_was_yield_infix = true;
+                else
+                    left = Trees.Expressions.BINARY(left.location::right.location, op, apparent_op, left, right);
+                    last_was_yield_infix = false;
+                fi
             od
 
             return left;
+        si
+
+        // Desugar `value || rest_expr` into a call to the lazy-stream
+        // YIELD variant: `Ghul.Pipes.STREAM.YIELD(value, () => rest_expr)`.
+        // The empty-args lambda makes the right-hand side lazy so the
+        // step is produced on demand by the consumer pipe.
+        lower_yield_infix(
+            left: Trees.Expressions.Expression,
+            right: Trees.Expressions.Expression
+        ) -> Trees.Expressions.Expression static is
+            let location = left.location::right.location;
+
+            let ghul   = Trees.Identifiers.Identifier(location, "Ghul");
+            let pipes  = Trees.Identifiers.QUALIFIED(location, ghul,   "Pipes",  location, location);
+            let stream = Trees.Identifiers.QUALIFIED(location, pipes,  "STREAM", location, location);
+            let yield  = Trees.Identifiers.QUALIFIED(location, stream, "YIELD",  location, location);
+
+            let yield_function = Trees.Expressions.IDENTIFIER(location, yield);
+
+            let thunk_arguments = Trees.Expressions.LIST(
+                right.location,
+                Collections.LIST[Trees.Expressions.Expression]()
+            );
+
+            let thunk_type = Trees.TypeExpressions.INFER(right.location);
+            let thunk_body = Trees.Bodies.EXPRESSION(right.location, right);
+
+            let thunk = Trees.Expressions.FUNCTION(
+                right.location,
+                thunk_arguments,
+                thunk_type,
+                thunk_body,
+                false
+            );
+
+            let call_arguments = Trees.Expressions.LIST(
+                location,
+                [left, thunk]: Trees.Expressions.Expression
+            );
+
+            return Trees.Expressions.CALL(location, yield_function, call_arguments);
         si
     si
 si

--- a/unit-tests/src/syntax/parsers/expressions/auto_precedence_tests.ghul
+++ b/unit-tests/src/syntax/parsers/expressions/auto_precedence_tests.ghul
@@ -1,0 +1,107 @@
+namespace Syntax.Parsers.Expressions.UnitTests is
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    use Syntax.Parsers.Expressions.EXPRESSION;
+    use Syntax.Parsers.Expressions.PRECEDENCE;
+
+    class AUTO_PRECEDENCE_TESTS is
+        @test()
+
+        init() is si
+
+        Multiplication_first_char_should_be_MULTIPLICATION() is
+            @test()
+
+            Assert.are_equal(PRECEDENCE.MULTIPLICATION, EXPRESSION.auto_precedence_for("*"));
+            Assert.are_equal(PRECEDENCE.MULTIPLICATION, EXPRESSION.auto_precedence_for("/"));
+            Assert.are_equal(PRECEDENCE.MULTIPLICATION, EXPRESSION.auto_precedence_for("%"));
+            Assert.are_equal(PRECEDENCE.MULTIPLICATION, EXPRESSION.auto_precedence_for("×"));
+            Assert.are_equal(PRECEDENCE.MULTIPLICATION, EXPRESSION.auto_precedence_for("÷"));
+            Assert.are_equal(PRECEDENCE.MULTIPLICATION, EXPRESSION.auto_precedence_for("✕"));
+            Assert.are_equal(PRECEDENCE.MULTIPLICATION, EXPRESSION.auto_precedence_for("**"));
+            Assert.are_equal(PRECEDENCE.MULTIPLICATION, EXPRESSION.auto_precedence_for("*="));
+        si
+
+        Addition_first_char_should_be_ADDITION() is
+            @test()
+
+            Assert.are_equal(PRECEDENCE.ADDITION, EXPRESSION.auto_precedence_for("+"));
+            Assert.are_equal(PRECEDENCE.ADDITION, EXPRESSION.auto_precedence_for("-"));
+            Assert.are_equal(PRECEDENCE.ADDITION, EXPRESSION.auto_precedence_for("++"));
+            Assert.are_equal(PRECEDENCE.ADDITION, EXPRESSION.auto_precedence_for("+-"));
+            Assert.are_equal(PRECEDENCE.ADDITION, EXPRESSION.auto_precedence_for("-->"));
+        si
+
+        Single_angle_bracket_should_be_RELATIONAL() is
+            @test()
+
+            Assert.are_equal(PRECEDENCE.RELATIONAL, EXPRESSION.auto_precedence_for("<"));
+            Assert.are_equal(PRECEDENCE.RELATIONAL, EXPRESSION.auto_precedence_for(">"));
+            Assert.are_equal(PRECEDENCE.RELATIONAL, EXPRESSION.auto_precedence_for("<="));
+            Assert.are_equal(PRECEDENCE.RELATIONAL, EXPRESSION.auto_precedence_for(">="));
+        si
+
+        Doubled_angle_bracket_should_be_SHIFT() is
+            @test()
+
+            Assert.are_equal(PRECEDENCE.SHIFT, EXPRESSION.auto_precedence_for("<<"));
+            Assert.are_equal(PRECEDENCE.SHIFT, EXPRESSION.auto_precedence_for(">>"));
+            Assert.are_equal(PRECEDENCE.SHIFT, EXPRESSION.auto_precedence_for("<<<"));
+            Assert.are_equal(PRECEDENCE.SHIFT, EXPRESSION.auto_precedence_for(">>="));
+        si
+
+        Equality_family_should_be_RELATIONAL() is
+            @test()
+
+            Assert.are_equal(PRECEDENCE.RELATIONAL, EXPRESSION.auto_precedence_for("=="));
+            Assert.are_equal(PRECEDENCE.RELATIONAL, EXPRESSION.auto_precedence_for("!="));
+            Assert.are_equal(PRECEDENCE.RELATIONAL, EXPRESSION.auto_precedence_for("=~"));
+            Assert.are_equal(PRECEDENCE.RELATIONAL, EXPRESSION.auto_precedence_for("!~"));
+            Assert.are_equal(PRECEDENCE.RELATIONAL, EXPRESSION.auto_precedence_for("≈"));
+            Assert.are_equal(PRECEDENCE.RELATIONAL, EXPRESSION.auto_precedence_for("≡"));
+            Assert.are_equal(PRECEDENCE.RELATIONAL, EXPRESSION.auto_precedence_for("~"));
+        si
+
+        Range_digraphs_should_be_RANGE() is
+            @test()
+
+            Assert.are_equal(PRECEDENCE.RANGE, EXPRESSION.auto_precedence_for(".."));
+            Assert.are_equal(PRECEDENCE.RANGE, EXPRESSION.auto_precedence_for("::"));
+        si
+
+        Boolean_digraphs_should_be_BOOLEAN() is
+            @test()
+
+            Assert.are_equal(PRECEDENCE.BOOLEAN, EXPRESSION.auto_precedence_for("/\\"));
+            Assert.are_equal(PRECEDENCE.BOOLEAN, EXPRESSION.auto_precedence_for("\\/"));
+            Assert.are_equal(PRECEDENCE.BOOLEAN, EXPRESSION.auto_precedence_for("∧"));
+            Assert.are_equal(PRECEDENCE.BOOLEAN, EXPRESSION.auto_precedence_for("∨"));
+        si
+
+        Bitwise_first_char_should_be_BITWISE() is
+            @test()
+
+            Assert.are_equal(PRECEDENCE.BITWISE, EXPRESSION.auto_precedence_for("&"));
+            Assert.are_equal(PRECEDENCE.BITWISE, EXPRESSION.auto_precedence_for("|"));
+            Assert.are_equal(PRECEDENCE.BITWISE, EXPRESSION.auto_precedence_for("¦"));
+            Assert.are_equal(PRECEDENCE.BITWISE, EXPRESSION.auto_precedence_for("^"));
+            Assert.are_equal(PRECEDENCE.BITWISE, EXPRESSION.auto_precedence_for("∩"));
+            Assert.are_equal(PRECEDENCE.BITWISE, EXPRESSION.auto_precedence_for("∪"));
+            // doubled `|` falls through to BITWISE since the table lookup
+            // happens before the heuristic; tested here for the heuristic
+            // case anyway since YIELD only kicks in via _precedence.
+            Assert.are_equal(PRECEDENCE.BITWISE, EXPRESSION.auto_precedence_for("||"));
+            Assert.are_equal(PRECEDENCE.BITWISE, EXPRESSION.auto_precedence_for("&&"));
+        si
+
+        Unrecognised_first_char_should_default_to_USER_5() is
+            @test()
+
+            Assert.are_equal(PRECEDENCE.USER_5, EXPRESSION.auto_precedence_for("@"));
+            Assert.are_equal(PRECEDENCE.USER_5, EXPRESSION.auto_precedence_for("@@"));
+            Assert.are_equal(PRECEDENCE.USER_5, EXPRESSION.auto_precedence_for("##"));
+            Assert.are_equal(PRECEDENCE.USER_5, EXPRESSION.auto_precedence_for("$$"));
+            Assert.are_equal(PRECEDENCE.USER_5, EXPRESSION.auto_precedence_for("?>"));
+        si
+    si
+si

--- a/unit-tests/src/syntax/parsers/expressions/yield_infix_tests.ghul
+++ b/unit-tests/src/syntax/parsers/expressions/yield_infix_tests.ghul
@@ -1,0 +1,98 @@
+namespace Syntax.Parsers.Expressions.UnitTests is
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    use Source.LOCATION;
+
+    use Syntax.Parsers.Expressions.EXPRESSION;
+
+    use Syntax.Trees.Expressions.CALL;
+    use Syntax.Trees.Expressions.FUNCTION;
+    use Syntax.Trees.Expressions.IDENTIFIER;
+
+    use Syntax.Trees.Identifiers.Identifier;
+    use Syntax.Trees.Identifiers.QUALIFIED;
+
+    class YIELD_INFIX_TESTS is
+        @test()
+
+        init() is si
+
+        loc() -> LOCATION static => LOCATION.internal;
+
+        named_identifier(name: string) -> IDENTIFIER static =>
+            IDENTIFIER(loc(), Identifier(loc(), name));
+
+        Calling__lower_yield_infix__should_produce_CALL_to_Ghul_Pipes_STREAM_YIELD() is
+            @test()
+
+            let left = named_identifier("left");
+            let right = named_identifier("right");
+
+            let result = EXPRESSION.lower_yield_infix(left, right);
+
+            Assert.is_instance_of_type(result, typeof CALL);
+        si
+
+        Calling__lower_yield_infix__should_pass_left_through_as_first_argument() is
+            @test()
+
+            let left = named_identifier("the_left");
+            let right = named_identifier("right");
+
+            let result = cast CALL(EXPRESSION.lower_yield_infix(left, right));
+
+            Assert.are_equal(2, result.arguments.count);
+            Assert.are_same(left, result.arguments.expressions[0]);
+        si
+
+        Calling__lower_yield_infix__should_wrap_right_in_empty_args_FUNCTION_with_expression_body() is
+            @test()
+
+            let left = named_identifier("left");
+            let right = named_identifier("the_right");
+
+            let result = cast CALL(EXPRESSION.lower_yield_infix(left, right));
+
+            let thunk = cast FUNCTION(result.arguments.expressions[1]);
+
+            Assert.is_not_null(thunk);
+            Assert.are_equal(0, thunk.arguments.count);
+            Assert.is_false(thunk.is_recursive);
+
+            let body = cast Syntax.Trees.Bodies.EXPRESSION(thunk.body);
+
+            Assert.is_not_null(body);
+            Assert.are_same(right, body.expression);
+        si
+
+        Calling__lower_yield_infix__should_target_qualified_STREAM_YIELD_identifier() is
+            @test()
+
+            let left = named_identifier("left");
+            let right = named_identifier("right");
+
+            let result = cast CALL(EXPRESSION.lower_yield_infix(left, right));
+
+            let function = cast IDENTIFIER(result.function);
+
+            Assert.is_not_null(function);
+
+            let yield_qualified = cast QUALIFIED(function.identifier);
+
+            Assert.is_not_null(yield_qualified);
+            Assert.are_equal("YIELD", yield_qualified.name);
+
+            let stream_qualified = cast QUALIFIED(yield_qualified.qualifier);
+
+            Assert.is_not_null(stream_qualified);
+            Assert.are_equal("STREAM", stream_qualified.name);
+
+            let pipes_qualified = cast QUALIFIED(stream_qualified.qualifier);
+
+            Assert.is_not_null(pipes_qualified);
+            Assert.are_equal("Pipes", pipes_qualified.name);
+
+            Assert.are_equal("Ghul", pipes_qualified.qualifier.name);
+        si
+    si
+si


### PR DESCRIPTION
Enhancements:
- User-defined infix operators no longer require a `@precedence` pragma at every consumption site. Precedence is inferred from the operator's first character (OCaml/F#-style): `*`/`/`/`%` → MULTIPLICATION, `+`/`-` → ADDITION, `<`/`>` → RELATIONAL (or SHIFT when doubled), `=`/`!`/`~` → RELATIONAL, `&`/`|`/`^` and set-symbols → BITWISE, `/\` / `\/` → BOOLEAN, `..` / `::` → RANGE; anything else → USER_5.
- Behaviour change for valid existing code: zero. Every operator the compiler already knows about matches what the heuristic would return, so the built-in table stays purely a cache + override hook.
- New `||` infix operator for lazy-stream producers: `value || rest_expr` desugars at parse time to `Ghul.Pipes.STREAM.YIELD(value, () => rest_expr)`. The lambda wrap keeps the right operand lazy, so consumers drive evaluation one step at a time:

      counting(n: int) -> STREAM[int] =>
          if n == 0 then DONE() else n || counting(n - 1) fi;

  Chain rejection: `a || b || c` reports "yield infix \`||\` does not chain". The right operand is meant to be a complete next-step expression, not another `||`.

Technical:
- `PRECEDENCE` enum is now explicit-valued with 10-step gaps so future levels slot in without renumbering. `YIELD = 20` is the lowest infix slot — every other infix binds tighter (`a == b || rest` is `(a == b) || rest`).
- `@precedence` keeps its name form as an explicit override but the integer form (`@precedence("##", "13")`) is dropped — the second argument must now be one of the precedence names. The only two consumers of the integer form (compiler integration tests) migrate to the name form in the same commit.
- New unit tests pin (a) the auto-precedence heuristic across nine operator categories and (b) the CALL / FUNCTION / qualified-target shape of the `||` lowering output.

#minor