### PR TITLE
Skip compile_all on same-file COMPLETE

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.10.2",
+      "version": "0.10.3",
       "commands": [
         "ghul-compiler"
       ],

--- a/analysis-tests/fixtures/complete-fast-path/caller.ghul
+++ b/analysis-tests/fixtures/complete-fast-path/caller.ghul
@@ -1,0 +1,8 @@
+namespace CompleteFastPath is
+    use IO.Std;
+
+    entry() is
+        let g = GREETER();
+        Std.write_line(g.greet());
+    si
+si

--- a/analysis-tests/fixtures/complete-fast-path/greeter.ghul
+++ b/analysis-tests/fixtures/complete-fast-path/greeter.ghul
@@ -1,0 +1,9 @@
+namespace CompleteFastPath is
+    class GREETER is
+        init() is si
+
+        greet() -> string => "hello";
+
+        farewell() -> string => "goodbye";
+    si
+si

--- a/analysis-tests/src/tests/complete_fast_path_tests.ghul
+++ b/analysis-tests/src/tests/complete_fast_path_tests.ghul
@@ -1,0 +1,122 @@
+namespace Analysis.Tests is
+    use Collections.LIST;
+
+    use IO.File;
+    use IO.Path;
+
+    use Analysis.Protocol.ANALYSER_PROCESS;
+    use Analysis.Protocol.EDIT_FILE;
+    use Analysis.Protocol.RESPONSE;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    // The COMPLETION_HANDLER fast path skips compile_all when the cursor
+    // file is already compiled through expressions (the common case: user
+    // typed, debounced EDIT ran, then COMPLETE arrived in the same file).
+    // The fallback to compile_all stays in place for the cross-file case.
+    //
+    // The wire protocol surfaces this directly: compile_all writes a
+    // "DIAGNOSTICS" frame ahead of "COMPLETION", so a fast-path response
+    // starts with "COMPLETION" and a fallback response starts with
+    // "DIAGNOSTICS" (then "COMPLETION" in the second frame). That's the
+    // observable assertion.
+    class COMPLETE_FAST_PATH_TESTS is
+        @test()
+
+        init() is si
+
+        load_caller() -> string is
+            let path = fixture_path("complete-fast-path/caller.ghul");
+            assert File.exists(path) else "fixture not copied to test output: {path}";
+            return File.read_all_text(path);
+        si
+
+        load_greeter() -> string is
+            let path = fixture_path("complete-fast-path/greeter.ghul");
+            assert File.exists(path) else "fixture not copied to test output: {path}";
+            return File.read_all_text(path);
+        si
+
+        prime(analyser: ANALYSER_PROCESS) is
+            let caller_source = load_caller();
+            let greeter_source = load_greeter();
+
+            analyser.send_edit_files([
+                EDIT_FILE("caller.ghul", caller_source),
+                EDIT_FILE("greeter.ghul", greeter_source)
+            ]);
+
+            // Initial EDIT: DIAGNOSTICS then PARTIAL DONE.
+            let initial_diagnostics = analyser.read_response();
+            Assert.are_equal("DIAGNOSTICS", initial_diagnostics.header);
+
+            let initial_done = analyser.read_response();
+            Assert.are_equal("PARTIAL DONE", initial_done.header);
+
+            // Single-file EDIT of caller — clears every file's
+            // compiled_through (clear_symbols), then sets only caller's
+            // back to "compile-expressions" via the build that follows.
+            analyser.send_edit("caller.ghul", caller_source);
+
+            let edit_diagnostics = analyser.read_response();
+            Assert.are_equal("DIAGNOSTICS", edit_diagnostics.header);
+
+            let edit_done = analyser.read_response();
+            Assert.are_equal("PARTIAL DONE", edit_done.header);
+        si
+
+        // COMPLETE in the file that was just edited — caller's expressions
+        // are current, so the handler should skip compile_all and emit only
+        // a "COMPLETION" frame (no leading "DIAGNOSTICS").
+        completion_in_edited_file_skips_compile_all() is
+            @test()
+
+            let use analyser = ANALYSER_PROCESS();
+
+            prime(analyser);
+
+            // "        Std.write_line(g.greet());" — column 26 lands on
+            // the 'g' just after the dot, well inside the member node.
+            analyser.send_completion("caller.ghul", 6, 26);
+
+            let first = analyser.read_response();
+            Assert.are_equal(
+                "COMPLETION",
+                first.header,
+                "expected fast path (COMPLETION first); got '{first.header}'.\n"
+                "fallback to compile_all would have emitted a DIAGNOSTICS\n"
+                "frame first. Check is_compiled_through_expressions and\n"
+                "that compile_expressions_pass sets compiled_through.\n"
+                "--- analyser stderr ---\n{analyser.stderr_capture}"
+            );
+        si
+
+        // COMPLETE in a file other than the last-edited one — greeter's
+        // compiled_through was cleared by the EDIT of caller and not
+        // re-set, so the handler must fall back to compile_all. The wire
+        // gives that away as a "DIAGNOSTICS" frame preceding "COMPLETION".
+        completion_in_other_file_falls_back_to_compile_all() is
+            @test()
+
+            let use analyser = ANALYSER_PROCESS();
+
+            prime(analyser);
+
+            analyser.send_completion("greeter.ghul", 4, 9);
+
+            let first = analyser.read_response();
+            Assert.are_equal(
+                "DIAGNOSTICS",
+                first.header,
+                "expected fallback path (DIAGNOSTICS first then COMPLETION); got '{first.header}'.\n"
+                "If this asserts COMPLETION it means the fast path mis-fired —\n"
+                "either greeter's compiled_through wasn't cleared by the EDIT\n"
+                "of caller, or the predicate is reading stale state.\n"
+                "--- analyser stderr ---\n{analyser.stderr_capture}"
+            );
+
+            let second = analyser.read_response();
+            Assert.are_equal("COMPLETION", second.header);
+        si
+    si
+si

--- a/analysis-tests/src/tests/query_after_edit_state_tests.ghul
+++ b/analysis-tests/src/tests/query_after_edit_state_tests.ghul
@@ -12,9 +12,11 @@ namespace Analysis.Tests is
     // Companion to COMPILE_AFTER_EDIT_TESTS: probes that semantic-query
     // handlers which fall back to FULL_COMPILER.compile_all (HOVER,
     // DEFINITION, DECLARATION, REFERENCES on a no-symbol position;
-    // COMPLETION, IMPLEMENTATION, RENAMEREQUEST unconditionally; SYMBOLS
-    // with an empty path) do not surface the same retained-AST state-leak
-    // false positives that #1219 fixed for the COMPILE handler.
+    // IMPLEMENTATION, RENAMEREQUEST unconditionally; SYMBOLS with an empty
+    // path; COMPLETION when the cursor file isn't compiled through
+    // expressions — see COMPLETE_FAST_PATH_TESTS for that conditional)
+    // do not surface the same retained-AST state-leak false positives
+    // that #1219 fixed for the COMPILE handler.
     //
     // The bug shape: after an initial EDIT primes the AST, the query's
     // compile_all clears symbols and re-runs compile-expressions on the
@@ -145,20 +147,6 @@ namespace Analysis.Tests is
             analyser.send_references("object-oriented.ghul", 1, 1);
 
             assert_query_diagnostics_clean(analyser, "REFERENCES");
-        si
-
-        // COMPLETION unconditionally calls compile_all.
-        completion_should_not_leak_diagnostics() is
-            @test()
-
-            let source = load_object_oriented_source();
-            let use analyser = ANALYSER_PROCESS();
-
-            prime(analyser, source);
-
-            analyser.send_completion("object-oriented.ghul", 1, 1);
-
-            assert_query_diagnostics_clean(analyser, "COMPLETION");
         si
 
         // IMPLEMENTATION unconditionally calls compile_all.

--- a/src/analysis/command_handlers.ghul
+++ b/src/analysis/command_handlers.ghul
@@ -195,8 +195,8 @@ namespace Analysis is
         _timers: TIMERS;
 
         init(
-            watchdog: WATCHDOG, 
-            compiler: COMPILER, 
+            watchdog: WATCHDOG,
+            compiler: COMPILER,
             source_files: Iterable[SOURCE_FILE],
             timers: TIMERS
         ) is
@@ -205,6 +205,9 @@ namespace Analysis is
             _source_files = source_files;
             _timers = timers;
         si
+
+        is_compiled_through_expressions(source_file: SOURCE_FILE) -> bool =>
+            _compiler.is_compiled_through_expressions(source_file);
 
         compile_all(writer: IO.TextWriter) is
             try
@@ -506,14 +509,24 @@ namespace Analysis is
         handle(reader: IO.TextReader, writer: IO.TextWriter) is
             let written_header mut = false;
 
-            // TODO if we're completing a member expression, this is not required:
-            _full_compiler.compile_all(writer);
+            let path = reader.read_line();
+            let target_line = System.Convert.to_int32(reader.read_line());
+            let target_column = System.Convert.to_int32(reader.read_line());
+
+            // Most COMPLETEs land in the file the user just typed in, so
+            // that file's expressions are already compiled against the
+            // current symbol table — no point redoing the whole project.
+            // Falls back to compile_all for the rarer cross-file case
+            // (Ctrl-Space in a buffer that wasn't the one most recently
+            // edited), where the cursor file's Expression.value still
+            // references symbols that the last EDIT abandoned.
+            let source_file = _source_file_lookup.find_source_file(path);
+
+            if !_full_compiler.is_compiled_through_expressions(source_file) then
+                _full_compiler.compile_all(writer);
+            fi
 
             try
-                let path = reader.read_line();
-                let target_line = System.Convert.to_int32(reader.read_line());
-                let target_column = System.Convert.to_int32(reader.read_line());
-
                 writer.write_line("COMPLETION");
                 written_header = true;
 

--- a/src/compiler/compiler.ghul
+++ b/src/compiler/compiler.ghul
@@ -20,50 +20,71 @@ namespace Compiler is
 
         build_passes: MutableList[Pass];
 
+        // Cached reference to the compile-expressions pass — lets handlers
+        // ask "is this file compiled through expressions" without exposing
+        // every pass individually.
+        _compile_expressions_pass: Pass;
+
         generated_source_files: MutableList[string];
 
         init() is
             container = IoC.CONTAINER.instance;
-            logger = container.logger;       
+            logger = container.logger;
 
             source_files = LIST[SOURCE_FILE]();
             generated_source_files = LIST[string]();
 
             post_parse_passes = LIST[Pass]();
-            add_pass(post_parse_passes, "conditional-compilation", (source_file) -> void is conditional_compilation_pass(source_file); si);
-            add_pass(post_parse_passes, "rewrite-syntax-trees", (source_file) -> void is rewrite_syntax_tree_pass(source_file); si);
+            add_pass(post_parse_passes, "conditional-compilation", (source_file) -> bool => conditional_compilation_pass(source_file));
+            add_pass(post_parse_passes, "rewrite-syntax-trees", (source_file) -> bool => rewrite_syntax_tree_pass(source_file));
 
             build_passes = LIST[Pass]();
-            add_pass(build_passes, "declare-symbols", (source_file) -> void is declare_symbols_pass(source_file); si);
-            add_pass(build_passes, "resolve-uses", (source_file) -> void is resolve_uses_pass(source_file); si);
-            add_pass(build_passes, "resolve-type-expressions", (source_file: SOURCE_FILE ) -> void is resolve_type_expressions_pass(source_file); si);
-            add_pass(build_passes, "resolve-ancestors", (source_file) -> void is resolve_ancestors_pass(source_file); si);
-            add_pass(build_passes, "resolve-explicit-types", (source_file) -> void is resolve_explicit_types_pass(source_file); si);
+            add_pass(build_passes, "declare-symbols", (source_file) -> bool => declare_symbols_pass(source_file));
+            add_pass(build_passes, "resolve-uses", (source_file) -> bool => resolve_uses_pass(source_file));
+            add_pass(build_passes, "resolve-type-expressions", (source_file: SOURCE_FILE) -> bool => resolve_type_expressions_pass(source_file));
+            add_pass(build_passes, "resolve-ancestors", (source_file) -> bool => resolve_ancestors_pass(source_file));
+            add_pass(build_passes, "resolve-explicit-types", (source_file) -> bool => resolve_explicit_types_pass(source_file));
             add_pass(
-                build_passes, 
-                "resolve-overrides", 
+                build_passes,
+                "resolve-overrides",
                 () -> void is si,
-                (source_file) -> void is resolve_overrides_pass(source_file); si,
+                (source_file) -> bool => resolve_overrides_pass(source_file),
                 () -> void is
                     container.resolve_overrides.check_duplicate_global_functions();
                 si
             );
-            add_pass(build_passes, "record-type-argument-uses", (source_file) -> void is record_type_argument_uses_pass(source_file); si);
+            add_pass(build_passes, "record-type-argument-uses", (source_file) -> bool => record_type_argument_uses_pass(source_file));
 
-            add_pass(build_passes, "compile-expressions", (source_file) -> void is compile_expressions_pass(source_file); si);
+            _compile_expressions_pass = add_pass(build_passes, "compile-expressions", (source_file) -> bool => compile_expressions_pass(source_file));
 
-            add_pass(build_passes, "warn-implicit-mutable-let", (source_file) -> void is warn_implicit_mutable_let_pass(source_file); si);
+            add_pass(build_passes, "warn-implicit-mutable-let", (source_file) -> bool => warn_implicit_mutable_let_pass(source_file));
 
             // TODO: is this actually needed?
             add_pass(
-                build_passes, 
-                "generate-il", 
+                build_passes,
+                "generate-il",
                 () -> void is
                     container.referenced_assemblies.gen();
                 si,
-                (source_file) -> void is generate_il_pass(source_file); si,
+                (source_file) -> bool => generate_il_pass(source_file),
                 () -> void is si
             );
+
+            // Pass.order is set in registration order so a SOURCE_FILE's
+            // compiled_through.order can be compared numerically against the
+            // order of a target pass (e.g. _compile_expressions_pass). Post-
+            // parse passes get their own counter starting at zero and don't
+            // participate in compiled_through queries.
+            assign_pass_orders(post_parse_passes);
+            assign_pass_orders(build_passes);
+        si
+
+        assign_pass_orders(passes: Collections.Iterable[Pass]) static is
+            let order = 0;
+            for p in passes do
+                p.order = order;
+                order = order + 1;
+            od
         si
 
         dump_counts() is 
@@ -79,25 +100,41 @@ namespace Compiler is
             container.symbol_use_locations.clear();
             container.symbol_definition_locations.clear();
             // container.logger.clear();
+
+            // Every previously-queued file's expression-level state now
+            // references symbols that have just been abandoned. Drop the
+            // marker so query handlers can tell.
+            for f in source_files do
+                f.compiled_through = null;
+            od
         si
+
+        is_compiled_through_expressions(source_file: SOURCE_FILE) -> bool =>
+            source_file? /\
+            source_file.compiled_through? /\
+            source_file.compiled_through.order >= _compile_expressions_pass.order;
 
         clear_queue() is
             source_files.clear();
         si
 
-        add_pass(passes: Collections.MutableList[Pass], description: string, apply: SOURCE_FILE -> void) is
-            passes.add(PASS(container.timers, description, null, apply, null));
+        add_pass(passes: Collections.MutableList[Pass], description: string, apply: SOURCE_FILE -> bool) -> Pass is
+            let pass = PASS(container.timers, description, null, apply, null);
+            passes.add(pass);
+            return pass;
         si
 
         add_pass(
             passes: Collections.MutableList[Pass],
             description: string,
             start: () -> void,
-            apply: SOURCE_FILE -> void, 
+            apply: SOURCE_FILE -> bool,
             finish: () -> void
-        )
+        ) -> Pass
         is
-            passes.add(PASS(container.timers, description, start, apply, finish));
+            let pass = PASS(container.timers, description, start, apply, finish);
+            passes.add(pass);
+            return pass;
         si
 
         add_pass(passes: Collections.MutableList[Pass], pass: Pass) is
@@ -184,45 +221,53 @@ namespace Compiler is
 
         build(passes: Collections.Iterable[Pass], source_files: Collections.Iterable[SOURCE_FILE]) is
             for pass in passes do
-                if !pass? then                    
+                if !pass? then
                     continue;
                 fi
 
                 pass.start();
-                
+
                 for i in source_files do
                     let symbol_table = IoC.CONTAINER.instance.symbol_table;
                     let symbol_table_mark = symbol_table.mark_scope_stack();
                     let diagnostics_mark = logger.mark();
 
+                    let did_work = false;
+
                     try
-                        pass.apply(i);
+                        did_work = pass.apply(i);
                     catch e: Exception
                         logger.exception(i.definition.location, e, "caught exception running pass {pass} on work item {i}");
                     finally
                         logger.release(diagnostics_mark);
-                        symbol_table.release_scope_stack(symbol_table_mark);                    
+                        symbol_table.release_scope_stack(symbol_table_mark);
                     yrt
 
-                    IoC.CONTAINER.instance.namespaces.pop_all_namespaces();                    
+                    if did_work then
+                        i.compiled_through = pass;
+                    fi
+
+                    IoC.CONTAINER.instance.namespaces.pop_all_namespaces();
                 od
-                
+
                 pass.finish();
             od
         si
 
-        conditional_compilation_pass(source_file: SOURCE_FILE) is
+        conditional_compilation_pass(source_file: SOURCE_FILE) -> bool is
             let flags = source_file.build_flags;
             let definition = source_file.definition;
-            
+
             container
                 .conditional_compilation
                 .apply(
                     definition
                 );
+
+            return true;
         si
-        
-        rewrite_syntax_tree_pass(source_file: SOURCE_FILE) is
+
+        rewrite_syntax_tree_pass(source_file: SOURCE_FILE) -> bool is
             let flags = source_file.build_flags;
             let definition = source_file.definition;
 
@@ -233,9 +278,11 @@ namespace Compiler is
             container
                 .add_accessors_for_properties
                 .apply(definition);
+
+            return true;
         si
 
-        declare_symbols_pass(source_file: SOURCE_FILE) is
+        declare_symbols_pass(source_file: SOURCE_FILE) -> bool is
             let flags = source_file.build_flags;
             let definition = source_file.definition;
 
@@ -243,10 +290,14 @@ namespace Compiler is
                 container
                     .declare_symbols
                     .apply(definition);
+
+                return true;
             fi
+
+            return false;
         si
 
-        resolve_uses_pass(source_file: SOURCE_FILE) is
+        resolve_uses_pass(source_file: SOURCE_FILE) -> bool is
             let flags = source_file.build_flags;
             let definition = source_file.definition;
 
@@ -254,10 +305,14 @@ namespace Compiler is
                 container
                     .resolve_uses
                     .apply(definition);
+
+                return true;
             fi
+
+            return false;
         si
 
-        resolve_ancestors_pass(source_file: SOURCE_FILE) is
+        resolve_ancestors_pass(source_file: SOURCE_FILE) -> bool is
             let flags = source_file.build_flags;
             let definition = source_file.definition;
 
@@ -265,10 +320,14 @@ namespace Compiler is
                 container
                     .resolve_ancestors
                     .apply(definition);
+
+                return true;
             fi
+
+            return false;
         si
 
-        resolve_type_expressions_pass(source_file: SOURCE_FILE) is
+        resolve_type_expressions_pass(source_file: SOURCE_FILE) -> bool is
             let flags = source_file.build_flags;
             let definition = source_file.definition;
 
@@ -276,10 +335,14 @@ namespace Compiler is
                 container
                     .resolve_type_expressions
                     .apply(definition);
+
+                return true;
             fi
+
+            return false;
         si
 
-        resolve_explicit_types_pass(source_file: SOURCE_FILE) is
+        resolve_explicit_types_pass(source_file: SOURCE_FILE) -> bool is
             let flags = source_file.build_flags;
             let definition = source_file.definition;
 
@@ -287,10 +350,14 @@ namespace Compiler is
                 container
                     .resolve_explicit_types
                     .apply(definition);
+
+                return true;
             fi
+
+            return false;
         si
 
-        compile_expressions_pass(source_file: SOURCE_FILE) is
+        compile_expressions_pass(source_file: SOURCE_FILE) -> bool is
             let flags = source_file.build_flags;
             let definition = source_file.definition;
 
@@ -298,10 +365,14 @@ namespace Compiler is
                 container
                     .compile_expressions
                     .apply(definition);
+
+                return true;
             fi
+
+            return false;
         si
 
-        resolve_overrides_pass(source_file: SOURCE_FILE) is
+        resolve_overrides_pass(source_file: SOURCE_FILE) -> bool is
             let flags = source_file.build_flags;
             let definition = source_file.definition;
 
@@ -309,10 +380,14 @@ namespace Compiler is
                 container
                     .resolve_overrides
                     .apply(definition);
+
+                return true;
             fi
+
+            return false;
         si
 
-        record_type_argument_uses_pass(source_file: SOURCE_FILE) is
+        record_type_argument_uses_pass(source_file: SOURCE_FILE) -> bool is
             let flags = source_file.build_flags;
 
             if flags.want_assembler \/ flags.want_executable then
@@ -321,10 +396,14 @@ namespace Compiler is
                 container
                     .record_type_argument_uses
                     .apply(definition);
+
+                return true;
             fi
+
+            return false;
         si
 
-        warn_implicit_mutable_let_pass(source_file: SOURCE_FILE) is
+        warn_implicit_mutable_let_pass(source_file: SOURCE_FILE) -> bool is
             let flags = source_file.build_flags;
 
             if flags.want_warn_implicit_mutable_let then
@@ -333,10 +412,14 @@ namespace Compiler is
                 container
                     .warn_implicit_mutable_let
                     .apply(definition);
+
+                return true;
             fi
+
+            return false;
         si
-        
-        generate_il_pass(source_file: SOURCE_FILE) is
+
+        generate_il_pass(source_file: SOURCE_FILE) -> bool is
             let flags = source_file.build_flags;
 
             if flags.want_assembler \/ flags.want_executable then
@@ -344,13 +427,17 @@ namespace Compiler is
                 container
                     .ir_context
                     .throw_on_fixme = false;
-    
+
                 let definition = source_file.definition;
 
                 container
                     .generate_il
                     .apply(definition);
+
+                return true;
             fi
+
+            return false;
         si
     si
 si

--- a/src/compiler/pass.ghul
+++ b/src/compiler/pass.ghul
@@ -3,10 +3,15 @@ namespace Compiler is
 
     use Logging.TIMERS;
     use Logging.TIMER;
-    
+
     class Pass is
         _timers: TIMERS;
         description: string;
+
+        // Position in the build pipeline. Assigned by COMPILER after the
+        // pass list is registered; lets callers ask "has this file been
+        // taken at least as far as pass X" by comparing orders.
+        order: int public;
 
         init(
             timers: TIMERS,
@@ -21,13 +26,17 @@ namespace Compiler is
             _timers.start(description);
         si
 
-        apply(source_file: SOURCE_FILE) is
+        // Returns true if the pass actually did work for this file (i.e.
+        // its flag-gated body ran). The build loop uses the result to
+        // advance SOURCE_FILE.compiled_through; passes whose gate was off
+        // for this file must return false so the marker doesn't lie.
+        apply(source_file: SOURCE_FILE) -> bool is
             throw NotImplementedException();
         si
 
         finish() is
             _timers.finish(description);
-        si    
+        si
 
         get_hash_code() -> int => description.get_hash_code();
 
@@ -36,14 +45,14 @@ namespace Compiler is
 
     class PASS: Pass is
         _start: () -> void;
-        _apply: SOURCE_FILE -> void;
+        _apply: SOURCE_FILE -> bool;
         _finish: () -> void;
 
         init(
             timers: TIMERS,
             description: string,
             start: () -> void,
-            apply: SOURCE_FILE -> void,
+            apply: SOURCE_FILE -> bool,
             finish: () -> void
         )
         is
@@ -58,11 +67,11 @@ namespace Compiler is
 
             if _start? then
                 _start();
-            fi            
+            fi
         si
 
-        apply(source_file: SOURCE_FILE) is
-            _apply(source_file);
+        apply(source_file: SOURCE_FILE) -> bool is
+            return _apply(source_file);
         si
 
         finish() is
@@ -71,6 +80,6 @@ namespace Compiler is
             fi
 
             super.finish();
-        si    
+        si
     si
 si

--- a/src/compiler/source_file.ghul
+++ b/src/compiler/source_file.ghul
@@ -6,6 +6,12 @@ namespace Compiler is
         file_name: string;
         definition: Syntax.Trees.Definitions.Definition;
 
+        // Most recent build_passes Pass whose flag-gated body completed for
+        // this file against the current symbol table. Reset to null by
+        // COMPILER.clear_symbols when the table is reallocated; advanced by
+        // the build loop after each successful pass.apply.
+        compiled_through: Pass public;
+
         init(
             build_flags: BUILD_FLAGS,
             file_name: string,


### PR DESCRIPTION
Technical:

- `COMPLETION_HANDLER` now skips `_full_compiler.compile_all` when the cursor file is already compiled through expressions — the common case where the user types in a file, the EDIT debounce fires, then COMPLETE arrives in the same file. Falls back to `compile_all` for cross-file completion (cursor in a buffer that wasn't the most recently edited), since EDIT clears symbols globally and that file's AST then references zombie symbols.
- Mechanism: new `SOURCE_FILE.compiled_through: Pass`, advanced by the build loop after each pass whose flag-gated body ran, reset for every queued file in `clear_symbols`. `Pass.apply` now returns `bool` so the loop knows whether the pass did work for this file. `Pass.order` assigned in registration order lets callers compare "compiled at least through pass X".