### PR TITLE
HOVER doesn't show the narrowed type of a local at the use site

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.10.7",
+      "version": "0.11.0",
       "commands": [
         "ghul-compiler"
       ],

--- a/analysis-tests/fixtures/narrowing-hover/narrowing-hover.ghul
+++ b/analysis-tests/fixtures/narrowing-hover/narrowing-hover.ghul
@@ -1,0 +1,26 @@
+namespace NarrowingHover is
+    use IO.Std;
+
+    // In-branch narrowing: the parameter `x` is declared `object`
+    // but is narrowed to `string` inside the `isa` then-branch.
+    describe(x: object) -> int is
+        if isa string(x) then
+            return x.length;
+        fi
+        return 0;
+    si
+
+    // Divergent-guard narrowing: after the guard returns, `y` is
+    // known to be `string` for the rest of the method.
+    guarded(y: object) -> int is
+        if !isa string(y) then
+            return -1;
+        fi
+        return y.length;
+    si
+
+    entry() is
+        Std.write_line("{describe("hello")}");
+        Std.write_line("{guarded("world")}");
+    si
+si

--- a/analysis-tests/src/tests/narrowing_hover_tests.ghul
+++ b/analysis-tests/src/tests/narrowing_hover_tests.ghul
@@ -1,0 +1,104 @@
+namespace Analysis.Tests is
+    use Collections.LIST;
+
+    use IO.File;
+
+    use Analysis.Protocol.ANALYSER_PROCESS;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    // HOVER on a local whose type is refined by flow-sensitive
+    // narrowing. The narrowed type is observed at the use-site AST
+    // node; the symbol's own `type` is restored once the compile
+    // walk finishes, so HOVER must read the node, not the symbol.
+    // Each test asserts the narrowed type shows at a narrowed use
+    // site, and the declared type still shows where unnarrowed.
+    class NARROWING_HOVER_TESTS is
+        @test()
+
+        init() is si
+
+        load_fixture() -> string is
+            let path = fixture_path("narrowing-hover/narrowing-hover.ghul");
+
+            assert File.exists(path) else "fixture missing: {path}";
+
+            return File.read_all_text(path);
+        si
+
+        prime(analyser: ANALYSER_PROCESS, source: string) is
+            analyser.send_edit("narrowing-hover.ghul", source);
+
+            let diagnostics = analyser.read_response();
+            Assert.are_equal("DIAGNOSTICS", diagnostics.header);
+
+            let user_diagnostics = LIST(diagnostics.user_diagnostics);
+            Assert.are_equal(
+                0,
+                user_diagnostics.count,
+                diagnostics_summary("EDIT had unexpected diagnostics", user_diagnostics)
+            );
+
+            let partial_done = analyser.read_response();
+            Assert.are_equal("PARTIAL DONE", partial_done.header);
+        si
+
+        hover_description(analyser: ANALYSER_PROCESS, line: int, column: int) -> string is
+            analyser.send_hover("narrowing-hover.ghul", line, column);
+            let response = analyser.read_query_response();
+            Assert.are_equal("HOVER", response.header);
+            let lines = LIST[string](response.lines);
+            if lines.count == 0 then
+                return "";
+            fi
+            return lines[0];
+        si
+
+        assert_hover_contains(actual: string, expected_substring: string, where: string, analyser: ANALYSER_PROCESS) is
+            Assert.is_true(
+                actual? /\ actual.contains(expected_substring),
+                "{where}: expected HOVER to contain '{expected_substring}', got '{actual}'.\n--- analyser stderr ---\n{analyser.stderr_capture}"
+            );
+        si
+
+        // `describe(x: object)` — HOVER on the parameter declaration
+        // shows the declared type; nothing is narrowed here.
+        hover_on_param_decl__shows_declared_object() is
+            @test()
+
+            let source = load_fixture();
+            let use analyser = ANALYSER_PROCESS();
+            prime(analyser, source);
+
+            let description = hover_description(analyser, 6, 14);
+            assert_hover_contains(description, "x: Ghul.object", "hover on `x` parameter decl", analyser);
+        si
+
+        // `return x.length;` inside `if isa string(x)` — HOVER on the
+        // narrowed use of `x` shows `string`, not the declared
+        // `object`. In-branch narrowing.
+        hover_on_narrowed_use_in_isa_branch__shows_string() is
+            @test()
+
+            let source = load_fixture();
+            let use analyser = ANALYSER_PROCESS();
+            prime(analyser, source);
+
+            let description = hover_description(analyser, 8, 20);
+            assert_hover_contains(description, "x: Ghul.string", "hover on narrowed `x` in isa branch", analyser);
+        si
+
+        // `return y.length;` after `if !isa string(y) then return fi`
+        // — HOVER on `y` shows `string`. Divergent-guard narrowing.
+        hover_on_narrowed_use_after_divergent_guard__shows_string() is
+            @test()
+
+            let source = load_fixture();
+            let use analyser = ANALYSER_PROCESS();
+            prime(analyser, source);
+
+            let description = hover_description(analyser, 19, 16);
+            assert_hover_contains(description, "y: Ghul.string", "hover on narrowed `y` after divergent guard", analyser);
+        si
+    si
+si

--- a/src/analysis/command_handlers.ghul
+++ b/src/analysis/command_handlers.ghul
@@ -40,19 +40,19 @@ namespace Analysis is
             
             try
                 if !_watchdog.want_restart then
-                    let symbol mut = _symbol_use_locations.find_hover_use(path, line, column);
+                    let hover mut = _symbol_use_locations.find_hover_use(path, line, column);
 
-                    if !symbol? then
+                    if !hover? then
                         _full_compiler.compile_all(writer);
 
-                        symbol = _symbol_use_locations.find_hover_use(path, line, column);
+                        hover = _symbol_use_locations.find_hover_use(path, line, column);
                     fi
 
                     writer.write_line("HOVER");
-                    written_header = true;                    
-    
-                    if symbol? then                        
-                        writer.write_line(symbol.collapse_group_if_single_member().description);
+                    written_header = true;
+
+                    if hover? then
+                        writer.write_line(hover.description);
                     fi
                 fi
             catch ex: Exception

--- a/src/semantic/symbol_use_locations.ghul
+++ b/src/semantic/symbol_use_locations.ghul
@@ -13,7 +13,7 @@ namespace Semantic is
 
     class SYMBOL_USE_LOCATIONS: SymbolUseListener is
         _symbol_use_map: LOCATION_MAP[Symbols.Symbol];
-        _hover_info_map: LOCATION_MAP[Symbols.Symbol];
+        _hover_info_map: LOCATION_MAP[HOVER_USE];
         _symbol_reference_map: Collections.MAP[Symbols.Symbol,Collections.SET[LOCATION]];
 
         init() is
@@ -27,33 +27,64 @@ namespace Semantic is
 
         clear() is
             _symbol_use_map = LOCATION_MAP[Symbols.Symbol]();
-            _hover_info_map = LOCATION_MAP[Symbols.Symbol]();
+            _hover_info_map = LOCATION_MAP[HOVER_USE]();
             _symbol_reference_map = Collections.MAP[Symbols.Symbol,Collections.SET[LOCATION]](65521);
         si
 
-        add_symbol_use(location: LOCATION, symbol: Symbols.Symbol mut) is
-            if 
+        add_symbol_use(location: LOCATION, symbol: Symbols.Symbol) is
+            _add_use(location, symbol, null);
+        si
+
+        // A symbol use that also carries the use-site AST node, so
+        // HOVER can read the type observed at this occurrence off
+        // the node instead of the symbol — see HOVER_USE.description.
+        add_variable_use(location: LOCATION, symbol: Symbols.Symbol, value: IR.Values.Value) is
+            _add_use(location, symbol, value);
+        si
+
+        _add_use(location: LOCATION, symbol: Symbols.Symbol mut, value: IR.Values.Value) is
+            if
                 !symbol? \/
                 location.is_internal \/
-                location.is_reflected \/ 
+                location.is_reflected \/
                 symbol.is_internal
             then
                 return;
             fi
 
-            _hover_info_map.put(location, symbol);
+            _hover_info_map.put(location, HOVER_USE(symbol, value));
 
-            if symbol? then
-                symbol = symbol.root_specialized_from;
-            fi
+            symbol = symbol.root_specialized_from;
 
             _symbol_use_map.put(location, symbol);
             _add_symbol_reference(location, symbol);
         si
 
-        find_hover_use(file_name: string, line: int, column: int) -> Symbols.Symbol =>
-            let matches = _hover_info_map.find_all(file_name, line, column) in
-            find_best_match(matches);
+        find_hover_use(file_name: string, line: int, column: int) -> HOVER_USE is
+            let matches = _hover_info_map.find_all(file_name, line, column);
+
+            if !matches? \/ matches.count == 0 then
+                return null;
+            elif matches.count == 1 then
+                return matches[0].value;
+            fi
+
+            let shortest_length mut = 1_000_000_000;
+            let best_match: HOVER_USE mut;
+
+            for m in matches do
+                let length = m.location.length;
+
+                if length < shortest_length then
+                    best_match = m.value;
+                    shortest_length = length;
+                elif length == shortest_length /\ isa Symbols.Function(m.value.symbol) then
+                    best_match = m.value;
+                fi
+            od
+
+            return best_match;
+        si
 
         find_definition_from_use(file_name: string, line: int, column: int) -> Symbols.Symbol =>
             let matches = _symbol_use_map.find_all(file_name, line, column) in
@@ -426,10 +457,51 @@ namespace Semantic is
     struct LOCATION_SEARCH_RESULT[T] is
         location: LOCATION;
         value: T;
-        
+
         init(location: LOCATION, value: T) is
             self.location = location;
             self.value = value;
-        si 
-    si    
+        si
+    si
+
+    // What HOVER knows about one symbol occurrence: the symbol
+    // itself, plus — for variable uses — the use-site AST node.
+    class HOVER_USE is
+        symbol: Symbols.Symbol public;
+        value: IR.Values.Value public;
+
+        init(symbol: Symbols.Symbol, value: IR.Values.Value) is
+            self.symbol = symbol;
+            self.value = value;
+        si
+
+        // The text shown in an IDE hover tooltip. For a variable
+        // use the type comes from the use-site AST node, not the
+        // symbol: flow-sensitive narrowing mutates a Variable's
+        // `type` field during the compile walk and restores it
+        // afterwards, so by the time a HOVER request is served the
+        // symbol's `type` no longer reflects the narrowed type
+        // observed at this occurrence — but the node snapshots it.
+        // Non-variable uses fall back to the symbol's description.
+        description: string is
+            let s = symbol.collapse_group_if_single_member();
+
+            if isa Symbols.Variable(s) /\ value? /\ value.has_type then
+                let observed = value.type;
+
+                // Use the use-site type only when fully resolved.
+                // A node type can freeze a partly-inferred form
+                // (e.g. `LIST[***]`) when the load was built before
+                // iterative inference settled the variable; the
+                // symbol's own type — read now, after inference
+                // completed — is then the better answer. Narrowed
+                // types are always concrete, so this keeps them.
+                if observed? /\ observed.is_settled then
+                    return cast Symbols.Variable(s).describe_with_type(observed);
+                fi
+            fi
+
+            return s.description;
+        si
+    si
 si

--- a/src/semantic/symbols/variable.ghul
+++ b/src/semantic/symbols/variable.ghul
@@ -18,6 +18,17 @@ namespace Semantic.Symbols is
 
         short_description: string => "{name}: {type.short_description}";
 
+        // Render this variable's description against an explicitly
+        // supplied type rather than the live `type` field. HOVER
+        // uses this to show the type observed at a particular use
+        // site — flow-sensitive narrowing mutates `type` during the
+        // compile walk and restores it afterwards, so by the time a
+        // HOVER request is served `type` no longer reflects the
+        // narrowed type. Subclasses that show the type in their
+        // `description` override this; the default ignores the
+        // argument.
+        describe_with_type(observed_type: Type) -> string => description;
+
         symbol_kind: SYMBOL_KIND => SYMBOL_KIND.VARIABLE;
         completion_kind: COMPLETION_KIND => COMPLETION_KIND.VARIABLE;
 
@@ -330,7 +341,9 @@ namespace Semantic.Symbols is
 
     // FIXME: pull up common code into a local + argument superclass:
     class LOCAL_VARIABLE: Variable, Types.SettableTyped is
-        description: string is
+        description: string => describe_with_type(type);
+
+        describe_with_type(observed_type: Type) -> string is
             let kind: string mut;
 
             if is_captured then
@@ -343,7 +356,7 @@ namespace Semantic.Symbols is
                 kind = "local value";
             fi
 
-            return "{name}: {type} // {kind}";
+            return "{name}: {observed_type} // {kind}";
         si
             
         init(location: LOCATION, owner: Scope, name: string) is
@@ -423,7 +436,9 @@ namespace Semantic.Symbols is
     class LOCAL_ARGUMENT: Variable, Types.SettableTyped is
         is_argument: bool => true;
         
-        description: string is
+        description: string => describe_with_type(type);
+
+        describe_with_type(observed_type: Type) -> string is
             let kind: string mut;
 
             if is_captured then
@@ -434,7 +449,7 @@ namespace Semantic.Symbols is
                 kind = "local argument";
             fi
 
-            return "{name}: {type} // {kind}";
+            return "{name}: {observed_type} // {kind}";
         si
 
         init(location: LOCATION, owner: Scope, name: string) is

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -4683,14 +4683,14 @@ namespace Syntax.Process is
             let symbol = find(identifier.identifier);
 
             if symbol? then
-                _symbol_use_locations.add_symbol_use(identifier.right_location, symbol);
-
                 if symbol.is_type then
+                    _symbol_use_locations.add_symbol_use(identifier.right_location, symbol);
+
                     identifier.value = TYPE_EXPRESSION(symbol.type, identifier.location);
 
                     // if need_store then
                     //     debug_always("cannot assign to {identifier} at {identifier.location} from BBB {System.Diagnostics.StackTrace().to_string().replace_line_endings(" ")}");
-                    //     _logger.error(identifier.location, "cannot assign to this");                        
+                    //     _logger.error(identifier.location, "cannot assign to this");
                     // fi
                 else
                     _symbol_loader.find_symbol = (name: string) => find(name);
@@ -4698,8 +4698,15 @@ namespace Syntax.Process is
                     if need_store then
                         let store_value = cast Need.STORE(identifier.value).value;
                         identifier.value = symbol.store(identifier.location, null, store_value, _symbol_loader, false);
+
+                        _symbol_use_locations.add_symbol_use(identifier.right_location, symbol);
                     else
                         identifier.value = symbol.load(identifier.location, null, _symbol_loader);
+
+                        // HOVER reads a narrowed local's type off
+                        // this use-site node, not the symbol — the
+                        // symbol's `type` is restored after the walk.
+                        _symbol_use_locations.add_variable_use(identifier.right_location, symbol, identifier.value);
 
                         // Definite assignment: reading a tracked
                         // deferred-init local before it is assigned


### PR DESCRIPTION
Bugs fixed:

- IDE hover over a narrowed local variable showed its declared type rather than the type refined by flow-sensitive narrowing at the hovered occurrence. Hover now reads the type from the use-site AST node, which snapshots the narrowed type, instead of the symbol, whose `type` field is restored once the compile walk completes.