### PR TITLE
Resolve definite-assignment and definite-return warnings in compiler source

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.11.0",
+      "version": "0.12.0",
       "commands": [
         "ghul-compiler"
       ],

--- a/src/analysis/command_handlers.ghul
+++ b/src/analysis/command_handlers.ghul
@@ -305,11 +305,12 @@ namespace Analysis is
             _source_files_by_path = Collections.MAP[string,SOURCE_FILE]();
         si
 
-        find_source_file(path: string) -> SOURCE_FILE is
+        find_source_file(path: string) -> SOURCE_FILE =>
             if _source_files_by_path.contains_key(path) then
-                return _source_files_by_path[path];
-            fi
-        si
+                _source_files_by_path[path]
+            else
+                null
+            fi;
 
         parse_and_add_file(path: string, writer: IO.TextWriter, reader: IO.TextReader, is_internal_file: bool) is
             IoC.CONTAINER.instance.logger.clear(path, false);

--- a/src/driver/main.ghul
+++ b/src/driver/main.ghul
@@ -176,7 +176,7 @@ namespace Driver is
             si;
 
             let conditional_defines = Collections.LIST[string]();
-            let emit_boilerplate_il_path: string mut;
+            let emit_boilerplate_il_path: string mut = default;
 
             for s in args_iterator do
                 if s =~ "-A" \/ s =~ "--analyse" then

--- a/src/driver/path_config.ghul
+++ b/src/driver/path_config.ghul
@@ -134,6 +134,8 @@ namespace Driver is
                 // FIXME this works on Windows despite wrong path separator but should use path join
                 return "{match.value}/runtimes/{os}-{architecture}/native/ilasm{file_extension}";
             fi
+
+            return null;
         si
     si    
 si

--- a/src/ir/innate_operation_generator.ghul
+++ b/src/ir/innate_operation_generator.ghul
@@ -92,6 +92,7 @@ namespace IR is
                 handler(value, block);
                 return true;
             fi
+            return false;
         si
 
         gen_arithmetic(value: INNATE, block: BLOCK) is

--- a/src/ir/value_converter.ghul
+++ b/src/ir/value_converter.ghul
@@ -63,6 +63,7 @@ namespace IR is
             if _instructions.contains_key(name) then
                 return _instructions[name];
             fi
+            return null;
         si
     si    
 si

--- a/src/lexical/tokenizer.ghul
+++ b/src/lexical/tokenizer.ghul
@@ -263,7 +263,7 @@ namespace Lexical is
         si
 
         skip_white_space() -> char is
-            let c: char mut;
+            let c: char mut = default;
             do
                 c = next_char();
 
@@ -339,7 +339,7 @@ namespace Lexical is
                     od
                 else
                     let seen_dot mut = false;
-                    let pc: char mut;
+                    let pc: char mut = default;
 
                     while 
                         (c >= '0' /\ c <= '9') \/ c == '.' \/ c == '_'
@@ -439,7 +439,7 @@ namespace Lexical is
 
                 _buffer = System.Text.StringBuilder();
 
-                let prev_c: char mut;
+                let prev_c: char mut = default;
 
                 while (c>='a'/\c<='z') \/ (c>='A'/\c<='Z') \/ (c>='0'/\c<='9') \/ c=='_' \/ c == '`' do
                     _buffer.append(c);

--- a/src/logging/diagnostics_store.ghul
+++ b/src/logging/diagnostics_store.ghul
@@ -280,7 +280,7 @@ namespace Logging is
         si
 
         get_diagnostics_list(source_path: string) -> DIAGNOSTICS_LIST is
-            let diagnostics_for_path: DIAGNOSTICS_LIST mut;
+            let diagnostics_for_path: DIAGNOSTICS_LIST mut = default;
 
             if !_diagnostics_by_source_path.try_get_value(source_path, diagnostics_for_path ref) then
                 diagnostics_for_path = DIAGNOSTICS_LIST(source_path);

--- a/src/semantic/dotnet/ambiguous_method_checker.ghul
+++ b/src/semantic/dotnet/ambiguous_method_checker.ghul
@@ -34,7 +34,7 @@ namespace Semantic.DotNet is
             let map = MAP[(name: string, number_of_arguments: int), LIST[(function: Function, method_info: MethodInfo)]]();
 
             for f_mi in functions do
-                let list: LIST[(function: Function, method_info: MethodInfo)] mut;
+                let list: LIST[(function: Function, method_info: MethodInfo)] mut = default;
 
                 let name = f_mi.function.name;
                 let number_of_arguments = f_mi.function.argument_names.count;

--- a/src/semantic/dotnet/assemblies.ghul
+++ b/src/semantic/dotnet/assemblies.ghul
@@ -196,7 +196,7 @@ namespace Semantic.DotNet is
             let types_file = "{_paths.get_library_location(IO.Path.combine("dotnet", "refs"))}{assembly_name}.types";
         
             let any_succeeded mut = false;
-            let exported_ex: System.Exception mut;
+            let exported_ex: System.Exception mut = default;
             let forwarded_ex: System.Exception mut;
 
             try

--- a/src/semantic/dotnet/property_details.ghul
+++ b/src/semantic/dotnet/property_details.ghul
@@ -28,6 +28,7 @@ namespace Semantic.DotNet is
             if dotnet_set_method? then
                 result = "{result}set: {dotnet_set_method} {dotnet_set_method.get_hash_code()}";
             fi
+            return result;
         si
     si
 si

--- a/src/semantic/dotnet/symbol_factory.ghul
+++ b/src/semantic/dotnet/symbol_factory.ghul
@@ -108,6 +108,7 @@ namespace Semantic.DotNet is
                 throw ex;
             yrt
             
+            return null;
         si
 
         create_class(type_details: TYPE_DETAILS) -> Symbols.Scoped is
@@ -134,7 +135,7 @@ namespace Semantic.DotNet is
                 od
             fi
 
-            let result: Symbols.Classy mut;
+            let result: Symbols.Classy mut = default;
 
             if dotnet_type.is_enum then
                 result = Symbols.ENUM_STRUCT(Source.LOCATION.reflected, Source.LOCATION.reflected, owner, ghul_type_name, true, owner);
@@ -352,6 +353,7 @@ namespace Semantic.DotNet is
             elif member_type == MemberTypes.METHOD then
                 add_method(owner, type, properties, indexers, methods, cast MethodInfo(member));
             fi            
+            return null;
         si
 
         add_constructor(owner: Symbols.Scoped, method: ConstructorInfo) is
@@ -414,7 +416,7 @@ namespace Semantic.DotNet is
 
             let field_name = `field.name;
 
-            let name: string mut;
+            let name: string mut = default;
 
             if field_name.length == 5 /\ `field.name.starts_with("Item") /\ type.is_generic_type then
                 let unspecialized_type = type.get_generic_type_definition();
@@ -465,7 +467,7 @@ namespace Semantic.DotNet is
             // and stash it as unspecialized_type; gen_reference prefers it.
             if dt != type /\ dt.is_generic_type /\ !dt.is_generic_type_definition then
                 let open_type = dt.get_generic_type_definition();
-                let open_field: FieldInfo mut;
+                let open_field: FieldInfo mut = default;
 
                 for m in open_type.get_members(cast BindingFlags(2 + 4 + 8 + 16 + 32)) do
                     if m.member_type == MemberTypes.FIELD then
@@ -569,7 +571,7 @@ namespace Semantic.DotNet is
 
             let name: string mut;
 
-            let property_details: PROPERTY_DETAILS mut;
+            let property_details: PROPERTY_DETAILS mut = default;
 
             if properties.try_get_value(method, property_details ref) then
                 name = _type_name_map.get_member_name(owner.qualified_name, method.name, method.is_private, true);
@@ -658,7 +660,7 @@ namespace Semantic.DotNet is
             let dt = method.declaring_type;
             if dt != type /\ dt.is_generic_type /\ !dt.is_generic_type_definition then
                 let open_type = dt.get_generic_type_definition();
-                let open_method: MethodInfo mut;
+                let open_method: MethodInfo mut = default;
 
                 for m in open_type.get_members(cast BindingFlags(2 + 4 + 8 + 16 + 32)) do
                     if m.member_type == MemberTypes.METHOD then
@@ -698,7 +700,7 @@ namespace Semantic.DotNet is
         get_assembly_name(type: TYPE) -> string is
             let assembly = type.assembly;
 
-            let result: string mut;
+            let result: string mut = default;
 
             if _assembly_names.try_get_value(assembly, result ref) then
                 return result;

--- a/src/semantic/dotnet/symbol_store.ghul
+++ b/src/semantic/dotnet/symbol_store.ghul
@@ -19,7 +19,7 @@ namespace Semantic.DotNet is
         get_symbol(dotnet_type: TYPE) -> Symbols.Scoped is
             assert dotnet_type? else "get symbol .NET type is null";
 
-            let result: Symbols.Scoped;
+            let result: Symbols.Scoped mut = default;
 
             _symbols_by_dotnet_type.try_get_value(dotnet_type, result ref);
 
@@ -32,7 +32,7 @@ namespace Semantic.DotNet is
         get_symbol(ghul_name: string) -> Symbols.Scoped is
             assert ghul_name? else "get symbol ghul name is null";
 
-            let result: Symbols.Scoped;
+            let result: Symbols.Scoped mut = default;
 
             _symbols_by_ghul_name.try_get_value(ghul_name, result ref);
 

--- a/src/semantic/dotnet/symbol_table.ghul
+++ b/src/semantic/dotnet/symbol_table.ghul
@@ -86,7 +86,7 @@ namespace Semantic.DotNet is
         si
 
         get_symbol(ghul_name: string) -> Symbols.Scoped is
-            let result: Symbols.Scoped;
+            let result: Symbols.Scoped mut = default;
             
             if _symbol_store.try_get_symbol(ghul_name, result ref) then
                 return result;
@@ -103,6 +103,7 @@ namespace Semantic.DotNet is
             fi
             
             _symbol_store.cache_no_result(ghul_name);
+            return null;
         si
         
         get_symbol(type: TYPE) -> Symbols.Scoped is

--- a/src/semantic/dotnet/type_details_lookup.ghul
+++ b/src/semantic/dotnet/type_details_lookup.ghul
@@ -38,7 +38,7 @@ namespace Semantic.DotNet is
         si
 
         register_variant(union_full_name: string, variant_type: TYPE) is
-            let list: MutableList[TYPE] mut;
+            let list: MutableList[TYPE] mut = default;
 
             if !_variants_by_union_full_name.try_get_value(union_full_name, list ref) then
                 list = LIST[TYPE]();
@@ -50,7 +50,7 @@ namespace Semantic.DotNet is
         si
 
         get_variants_for_union(union_full_name: string) -> Iterable[TYPE] is
-            let result: MutableList[TYPE];
+            let result: MutableList[TYPE] mut = default;
 
             _variants_by_union_full_name.try_get_value(union_full_name, result ref);
 
@@ -105,7 +105,7 @@ namespace Semantic.DotNet is
 
             let ghul_namespace = type_details.ghul_namespace;
 
-            let list: MutableList[TYPE_DETAILS] mut;
+            let list: MutableList[TYPE_DETAILS] mut = default;
 
             if !_type_details_by_ghul_namespace.try_get_value(ghul_namespace, list ref) then
                 list = LIST[TYPE_DETAILS]();
@@ -127,7 +127,7 @@ namespace Semantic.DotNet is
         si
         
         get_type_details_by_dotnet_type(type: TYPE) -> TYPE_DETAILS is
-            let result: TYPE_DETAILS;
+            let result: TYPE_DETAILS mut = default;
 
             _type_details_by_dotnet_type.try_get_value(type, result ref);
 
@@ -135,7 +135,7 @@ namespace Semantic.DotNet is
         si
 
         get_all_type_details_in_ghul_namespace(namespace_name: string) -> Iterable[TYPE_DETAILS] is
-            let result: MutableList[TYPE_DETAILS];
+            let result: MutableList[TYPE_DETAILS] mut = default;
 
             _type_details_by_ghul_namespace.try_get_value(namespace_name, result ref);
 
@@ -154,6 +154,7 @@ namespace Semantic.DotNet is
                     return details;
                 fi                
             od
+            return null;
         si
     si
 si

--- a/src/semantic/dotnet/type_mapper.ghul
+++ b/src/semantic/dotnet/type_mapper.ghul
@@ -139,7 +139,7 @@ namespace Semantic.DotNet is
         si
 
         get_type(type: TYPE) -> Type is
-            let result: Type mut;
+            let result: Type mut = default;
             let unsafe_constraints mut = false;
 
             if !type? then
@@ -174,7 +174,7 @@ namespace Semantic.DotNet is
             if type.is_generic_type_definition \/ type.is_generic_type then
                 let b = type.get_generic_type_definition();
 
-                let creator: TypeCreator mut;
+                let creator: TypeCreator mut = default;
 
                 if !_type_creators.try_get_value(b, creator ref) then
                     creator = _generic_type_creator;
@@ -203,7 +203,7 @@ namespace Semantic.DotNet is
                 unsafe_constraints = true;
             fi
 
-            let creator: TypeCreator;
+            let creator: TypeCreator mut = default;
 
             if _type_creators.try_get_value(type, creator ref) then
                 return creator.create(_symbol_table.value, type);

--- a/src/semantic/dotnet/type_name.ghul
+++ b/src/semantic/dotnet/type_name.ghul
@@ -10,6 +10,8 @@ namespace Semantic.DotNet is
             if last_dot_index >= 0 then
                 return qualified_name.substring(0, last_dot_index);
             fi
+
+            return null;
         si
 
         name: string is

--- a/src/semantic/dotnet/type_name_map.ghul
+++ b/src/semantic/dotnet/type_name_map.ghul
@@ -191,14 +191,14 @@ namespace Semantic.DotNet is
         si
 
         get_type_details(type: TYPE) -> TYPE_DETAILS is
-            let result: TYPE_DETAILS;
+            let result: TYPE_DETAILS mut = default;
             _type_details_by_dotnet_type.try_get_value(type, result ref);
 
             return result;
         si
 
         get_namespace_details(type: TYPE) -> NAMESPACE_DETAILS is
-            let result: NAMESPACE_DETAILS;
+            let result: NAMESPACE_DETAILS mut = default;
 
             _namespace_details_by_dotnet_namespace.try_get_value(type.`namespace, result ref);
 
@@ -206,7 +206,7 @@ namespace Semantic.DotNet is
         si
 
         get_namespace_details(ghul_namespace_name: string) -> NAMESPACE_DETAILS is
-            let result: NAMESPACE_DETAILS;
+            let result: NAMESPACE_DETAILS mut = default;
             _namespace_details_by_ghul_name.try_get_value(ghul_namespace_name, result ref);
 
             return result;

--- a/src/semantic/least_upper_bound_map.ghul
+++ b/src/semantic/least_upper_bound_map.ghul
@@ -336,7 +336,7 @@ namespace Semantic is
         si
 
         _try_get_best_assignable() -> Type is
-            let best: Type mut;
+            let best: Type mut = default;
 
             for type in types do
                 if !best? then
@@ -392,7 +392,7 @@ namespace Semantic is
         si
 
         _get_best() -> Type is
-            let best: Type mut;
+            let best: Type mut = default;
             let is_ambiguous mut = false;
 
             for list in result.values do
@@ -418,6 +418,7 @@ namespace Semantic is
             if !is_ambiguous then
                 return _with_element_names(best);
             fi
+            return null;
         si
 
         _apply_intersection() is
@@ -430,7 +431,7 @@ namespace Semantic is
                 let rsf = kv.key;
                 let result_list = kv.value;
 
-                let current_list: LIST[Type];
+                let current_list: LIST[Type] mut = default;
 
                 if !current.try_get_value(rsf, current_list ref) then
                     continue;
@@ -526,7 +527,7 @@ namespace Semantic is
             // per unspecialized generic type. we then only need
             // to search under the matching root specialized from symbol
 
-            let list: LIST[Type] mut;
+            let list: LIST[Type] mut = default;
 
             if !result.try_get_value(rsf, list ref) then
                 list = LIST[Type]();
@@ -548,7 +549,7 @@ namespace Semantic is
                 return;
             fi
 
-            let list: LIST[Type] mut;
+            let list: LIST[Type] mut = default;
 
             if !current.try_get_value(rsf, list ref) then
                 list = LIST[Type]();

--- a/src/semantic/overload_resolver.ghul
+++ b/src/semantic/overload_resolver.ghul
@@ -107,9 +107,9 @@ namespace Semantic is
             let is_ambiguous mut = false;
 
             let best_score mut = cast int (Types.MATCH.DIFFERENT);
-            let result: Symbols.Function mut;
+            let result: Symbols.Function mut = default;
 
-            let ambiguous_matches: Collections.LIST[Symbols.Function] mut;
+            let ambiguous_matches: Collections.LIST[Symbols.Function] mut = default;
 
             let functions_to_search = group.functions | .filter(f => want_instance \/ !f.is_instance);
 

--- a/src/semantic/scope/namespace_scope.ghul
+++ b/src/semantic/scope/namespace_scope.ghul
@@ -201,7 +201,7 @@ namespace Semantic is
         contains_used_symbol(name: string) -> bool => _used_symbols.contains_key(name);
         
         get_used_symbol(name: string) -> Symbol is
-            let result: Symbol;
+            let result: Symbol mut = default;
 
             _used_symbols.try_get_value(name, result ref);
 

--- a/src/semantic/stable_symbols.ghul
+++ b/src/semantic/stable_symbols.ghul
@@ -21,7 +21,7 @@ namespace Semantic is
         _is_enabled: bool;
 
         [node: Node] -> Scope is
-            let result: STABLE_SYMBOL;
+            let result: STABLE_SYMBOL mut = default;
 
             _symbols.try_get_value(node, result ref);
 
@@ -37,7 +37,7 @@ namespace Semantic is
         si
 
         is_stable(node: Node) -> bool is
-            let symbol: STABLE_SYMBOL;
+            let symbol: STABLE_SYMBOL mut = default;
 
             if !_is_enabled then
                 return false;
@@ -46,6 +46,7 @@ namespace Semantic is
             if _symbols.try_get_value(node, symbol ref) then
                 return _generation > symbol.generation;
             fi
+            return false;
         si
         
         try_get_symbol(node: Node, result: STABLE_SYMBOL ref) -> bool is

--- a/src/semantic/symbol_map.ghul
+++ b/src/semantic/symbol_map.ghul
@@ -13,11 +13,7 @@ namespace Semantic is
         si
 
         [name: string]: Symbols.Symbol
-            is
-                if _map.contains_key(name) then
-                    return _map[name];                
-                fi            
-            si,
+            => if _map.contains_key(name) then _map[name] else null fi,
             = v is
                 _map[name] = v;
             si

--- a/src/semantic/symbol_table.ghul
+++ b/src/semantic/symbol_table.ghul
@@ -41,6 +41,7 @@ namespace Semantic is
                     return cast DeclarationContext(scope);
                 fi
             od
+            return null;
         si
 
         current_instance_context: Symbols.Classy is
@@ -49,6 +50,7 @@ namespace Semantic is
                     return cast Symbols.Classy(scope);
                 fi
             od
+            return null;
         si
 
         current_union_context: Symbols.UNION is
@@ -57,6 +59,7 @@ namespace Semantic is
                     return cast Symbols.UNION(scope);
                 fi
             od
+            return null;
         si
         
         current_function: Symbols.Function is
@@ -65,6 +68,7 @@ namespace Semantic is
                     return cast Symbols.Function(scope);
                 fi
             od
+            return null;
         si
 
         current_closure_context: ClosureContext is
@@ -83,6 +87,7 @@ namespace Semantic is
                     return cast Symbols.Symbol(scope);
                 fi
             od
+            return null;
         si
 
         current_closure: Symbols.Closure is
@@ -93,6 +98,7 @@ namespace Semantic is
                     return result;
                 fi
             od
+            return null;
         si
 
         current_function_group: Symbols.FUNCTION_GROUP is
@@ -101,6 +107,7 @@ namespace Semantic is
                     return cast Symbols.FUNCTION_GROUP(scope);
                 fi
             od
+            return null;
         si
 
         current_property: Symbols.Property is
@@ -109,6 +116,7 @@ namespace Semantic is
                     return cast Symbols.Property(scope);
                 fi
             od
+            return null;
         si
 
         all_classes: Collections.Iterable[Symbols.Classy] =>
@@ -138,6 +146,7 @@ namespace Semantic is
             if _scopes.contains_key(node) then
                 return _scopes[node];
             fi
+            return null;
         si
 
         associate_node_with_scope(node: Node, scope: Scope) is

--- a/src/semantic/symbol_use_locations.ghul
+++ b/src/semantic/symbol_use_locations.ghul
@@ -70,7 +70,7 @@ namespace Semantic is
             fi
 
             let shortest_length mut = 1_000_000_000;
-            let best_match: HOVER_USE mut;
+            let best_match: HOVER_USE mut = default;
 
             for m in matches do
                 let length = m.location.length;
@@ -97,7 +97,7 @@ namespace Semantic is
                 matches[0].value;
             else
                 let shortest_length mut = 1_000_000_000;
-                let best_match: Symbols.Symbol mut;
+                let best_match: Symbols.Symbol mut = default;
 
                 for m in matches do
                     let location = m.location;
@@ -365,7 +365,7 @@ namespace Semantic is
         si        
 
         _try_get_references_set(symbol: Symbols.Symbol) -> Collections.SET[LOCATION] is
-            let results: Collections.SET[LOCATION];                
+            let results: Collections.SET[LOCATION] mut = default;
 
             _symbol_reference_map.try_get_value(symbol, results ref);
 
@@ -375,7 +375,7 @@ namespace Semantic is
         _get_references_set(symbol: Symbols.Symbol mut) -> Collections.SET[LOCATION] is
             // FIXME: is this correct in all cases?
             symbol = symbol.root_specialized_from;
-            let results: Collections.SET[LOCATION] mut;                
+            let results: Collections.SET[LOCATION] mut = default;
 
             if !_symbol_reference_map.try_get_value(symbol, results ref) then
                 results = Collections.SET[LOCATION]();
@@ -447,11 +447,12 @@ namespace Semantic is
             return result;
         si
         
-        _get_file(file_name: string) -> Collections.MAP[int, Collections.LIST[Pair[LOCATION,T]]] is
+        _get_file(file_name: string) -> Collections.MAP[int, Collections.LIST[Pair[LOCATION,T]]] =>
             if _file_name_to_file.contains_key(file_name) then
-                return _file_name_to_file[file_name];
-            fi
-        si        
+                _file_name_to_file[file_name]
+            else
+                null
+            fi;        
     si
     
     struct LOCATION_SEARCH_RESULT[T] is

--- a/src/semantic/symbols/classy.ghul
+++ b/src/semantic/symbols/classy.ghul
@@ -1151,6 +1151,7 @@ namespace Semantic.Symbols is
                     return c;
                 fi
             od            
+            return null;
         si
                             
         declare_captured(name: string, type: Type, symbol_definition_listener: SymbolDefinitionListener) -> Field is           
@@ -1275,6 +1276,7 @@ namespace Semantic.Symbols is
             catch ex: System.Exception
                 CONTAINER.instance.logger.exception(self.location, ex, "trying to generate frame instance");
             yrt
+            return null;
         si
 
         gen_access(buffer: StringBuilder) is

--- a/src/semantic/symbols/closure.ghul
+++ b/src/semantic/symbols/closure.ghul
@@ -246,6 +246,7 @@ namespace Semantic.Symbols is
 
                 i = i - 1;
             od
+            return null;
         si
 
         type_updated(type: Semantic.Types.Type) is
@@ -658,6 +659,7 @@ namespace Semantic.Symbols is
                 // load self normally: 
                 return IR.Values.Load.REFERENCE_SELF(context, context.type);
             fi
+            return null;
         si
 
         load_self(location: Source.LOCATION, loader: SYMBOL_LOADER) -> Value is
@@ -711,6 +713,7 @@ namespace Semantic.Symbols is
 
                 index = index - 1;
             od
+            return null;
         si
 
         load_recurse(location: LOCATION, loader: SYMBOL_LOADER) -> Value is

--- a/src/semantic/symbols/generic_argument.ghul
+++ b/src/semantic/symbols/generic_argument.ghul
@@ -62,11 +62,12 @@ namespace Semantic.Symbols is
         get_ancestor(i: int) -> Type 
             => ancestors[i];
 
-        find_member(name: string) -> Symbol is
+        find_member(name: string) -> Symbol =>
             if _ancestor_type? then
-                return _ancestor_type.find_member(name);
-            fi
-        si
+                _ancestor_type.find_member(name)
+            else
+                null
+            fi;
 
         find_member_matches(prefix: string, matches: Collections.MAP[string, Symbol]) is
             if _ancestor_type? then

--- a/src/semantic/symbols/symbol.ghul
+++ b/src/semantic/symbols/symbol.ghul
@@ -262,6 +262,7 @@ namespace Semantic.Symbols is
             actual_type_arguments: Collections.List[Type]
         ) -> Symbol is
             logger.error(location, "cannot supply explicit type arguments here");
+            return null;
         si
 
         freeze() -> Symbol => null;
@@ -340,6 +341,7 @@ namespace Semantic.Symbols is
                     return result;
                 fi
             od        
+            return null;
         si
 
         find_ancestor(search_type: Type) -> Type is
@@ -354,6 +356,7 @@ namespace Semantic.Symbols is
                     return result;
                 fi                
             od
+            return null;
         si
 
         get_all_direct_ancestor_members() -> Collections.Iterable[Symbol] is

--- a/src/semantic/symbols/symbol_inheritance_resolver.ghul
+++ b/src/semantic/symbols/symbol_inheritance_resolver.ghul
@@ -101,7 +101,7 @@ namespace Semantic is
         is
             let is_stub = into.is_stub;
             let other_overridee_symbols_count = other_overridee_symbols | .count();
-            let overriding_method: Function mut;
+            let overriding_method: Function mut = default;
 
             if overriders? then
                 overriding_method = overriders.get_overrider(into);
@@ -222,8 +222,8 @@ namespace Semantic is
             logger: Logging.Logger
         )
         is
-            let concrete: Function mut;
-            let abstract: Function mut;
+            let concrete: Function mut = default;
+            let abstract: Function mut = default;
 
             let seen_multiple_concrete mut = false;
             let seen_multiple_abstract mut = false;
@@ -431,10 +431,10 @@ namespace Semantic is
             logger: Logging.Logger
         )
         is
-            let type: Type mut;
+            let type: Type mut = default;
             let inconsistent_types mut = false;
             let any_non_properties mut = false;
-            let property: Symbol mut;
+            let property: Symbol mut = default;
 
             for s in overridee_symbols do
                 if isa Symbols.Property(s) then

--- a/src/semantic/symbols/variable.ghul
+++ b/src/semantic/symbols/variable.ghul
@@ -142,7 +142,7 @@ namespace Semantic.Symbols is
         si
 
         try_get_inferred_type() -> Type is
-            let candidate: Type mut;
+            let candidate: Type mut = default;
 
             if _lub_map? then
                 candidate = _lub_map.get_result();

--- a/src/semantic/types/generic.ghul
+++ b/src/semantic/types/generic.ghul
@@ -101,6 +101,7 @@ namespace Semantic.Types is
                     return true;
                 fi
             od
+            return false;
         si
 
         init(
@@ -172,7 +173,7 @@ namespace Semantic.Types is
                 let argument_name
                     = generic_symbol.symbol.argument_names[i];
 
-                let mapped_type: Type;
+                let mapped_type: Type mut = default;
 
                 // FIXME: this seems to fix #118 but don't think this is the correct place to put this check:
                 if we_are_generic /\ type_map.try_get_value(argument_name, mapped_type ref) then

--- a/src/semantic/types/generic_argument.ghul
+++ b/src/semantic/types/generic_argument.ghul
@@ -27,7 +27,7 @@ namespace Semantic.Types is
         si
 
         specialize(type_map: Collections.Map[string,Type]) -> Type is
-            let result: Type;
+            let result: Type mut = default;
 
             if type_map.try_get_value(name, result ref) then
                 return result;

--- a/src/semantic/types/generic_argument_bind_results.ghul
+++ b/src/semantic/types/generic_argument_bind_results.ghul
@@ -51,7 +51,7 @@ namespace Semantic.Types is
         si
 
         bind(type_argument: GenericArgument, actual_type: Type mut) -> bool is
-            let existing: GENERIC_ARGUMENT_BINDING;
+            let existing: GENERIC_ARGUMENT_BINDING mut = default;
 
             actual_type =
                 if actual_type.get_type_arguments().count > 0 then

--- a/src/semantic/types/named.ghul
+++ b/src/semantic/types/named.ghul
@@ -108,7 +108,7 @@ namespace Semantic.Types is
                     return Types.MATCH.SAME;
                 fi
 
-                let result: Types.MATCH;
+                let result: Types.MATCH mut = default;
 
                 if _cache == null then
                     _cache = Collections.MAP[(int,int),Types.MATCH]();
@@ -142,11 +142,12 @@ namespace Semantic.Types is
             return Types.MATCH.DIFFERENT;            
         si
 
-        find_member(name: string) -> Symbols.Symbol is
+        find_member(name: string) -> Symbols.Symbol =>
             if symbol? then
-                return symbol.find_member(name);
-            fi
-        si
+                symbol.find_member(name)
+            else
+                null
+            fi;
 
         get_destructure_member_name(index: int) -> string =>
             if symbol? then
@@ -155,11 +156,12 @@ namespace Semantic.Types is
                 null
             fi;
 
-        find_ancestor(type: Type) -> Type is
+        find_ancestor(type: Type) -> Type =>
             if symbol? then
-                return symbol.find_ancestor(type);
-            fi            
-        si
+                symbol.find_ancestor(type)
+            else
+                null
+            fi;
 
         freeze() -> Type =>
             if symbol? then

--- a/src/semantic/types/type.ghul
+++ b/src/semantic/types/type.ghul
@@ -42,13 +42,13 @@ namespace Semantic.Types is
 
         short_description: string => to_string();
 
-        unspecialized_symbol: Symbols.Symbol is
-            let s = scope;
-
+        unspecialized_symbol: Symbols.Symbol =>
+            let s = scope in
             if s? then
-                return s.unspecialized_symbol;
-            fi
-        si
+                s.unspecialized_symbol
+            else
+                null
+            fi;
         
         // FIXME: better than isa XXXX, but still should not need these:
         is_none: bool => false;

--- a/src/syntax/parsers/base.ghul
+++ b/src/syntax/parsers/base.ghul
@@ -66,6 +66,7 @@ namespace Syntax.Parsers is
                     "{syntax_error_message}: expected {Lexical.TOKEN_NAMES[expected_tokens]} but found {context.current_token_name}"
                 );
             fi
+            return default;
         si
 
         populate_expected_tokens() private is

--- a/src/syntax/parsers/context.ghul
+++ b/src/syntax/parsers/context.ghul
@@ -209,6 +209,7 @@ namespace Syntax.Parsers is
                 next_token();
                 return true;
             fi
+            return false;
         si
 
         next_token(tokens: Collections.List[Lexical.TOKEN], message: string) -> bool is
@@ -216,6 +217,7 @@ namespace Syntax.Parsers is
                 next_token();
                 return true;
             fi
+            return false;
         si
 
         next_token(token: Lexical.TOKEN) -> bool is

--- a/src/syntax/parsers/definitions/class.ghul
+++ b/src/syntax/parsers/definitions/class.ghul
@@ -40,8 +40,8 @@ namespace Syntax.Parsers.Definitions is
                     return null;
                 fi            
     
-                let arguments: Trees.TypeExpressions.LIST mut;
-                let ancestors: Trees.TypeExpressions.LIST mut;
+                let arguments: Trees.TypeExpressions.LIST mut = default;
+                let ancestors: Trees.TypeExpressions.LIST mut = default;
     
                 if context.current.token == Lexical.TOKEN.SQUARE_OPEN then
                     context.next_token();

--- a/src/syntax/parsers/definitions/enum.ghul
+++ b/src/syntax/parsers/definitions/enum.ghul
@@ -46,7 +46,7 @@ namespace Syntax.Parsers.Definitions is
 
                         if member_name? then
                             let member_end mut = member_name.location;
-                            let member_initializer: Trees.Expressions.Expression mut;
+                            let member_initializer: Trees.Expressions.Expression mut = default;
                             if context.current.token == Lexical.TOKEN.ASSIGN then
                                 context.next_token();
 
@@ -68,7 +68,7 @@ namespace Syntax.Parsers.Definitions is
                 fi
             fi                    
 
-            let result: Trees.Definitions.ENUM mut;
+            let result: Trees.Definitions.ENUM mut = default;
 
             if name? then
                 result = Trees.Definitions.ENUM(start::context.location, name, modifiers, members);

--- a/src/syntax/parsers/definitions/function.ghul
+++ b/src/syntax/parsers/definitions/function.ghul
@@ -48,6 +48,7 @@ namespace Syntax.Parsers.Definitions is
 
                 return generic_arguments;
             fi
+            return null;
         si
 
         parse_formal_arguments(
@@ -66,8 +67,8 @@ namespace Syntax.Parsers.Definitions is
             let use arguments_tokenizer_snapshot = context.tokenizer_speculate_then_commit();
             let use arguments_logger_snaphot = context.logger_speculate_then_commit();
 
-            let arguments: Trees.Variables.LIST mut;
-            let function: Trees.Definitions.FUNCTION mut;
+            let arguments: Trees.Variables.LIST mut = default;
+            let function: Trees.Definitions.FUNCTION mut = default;
 
             let any_bad_arguments mut = false;
 
@@ -188,7 +189,7 @@ namespace Syntax.Parsers.Definitions is
         is
             let is_poisoned mut = false;
             let type_expression: Trees.TypeExpressions.TypeExpression mut;
-            let function: Trees.Definitions.FUNCTION mut;
+            let function: Trees.Definitions.FUNCTION mut = default;
 
             if context.current.token == Lexical.TOKEN.ARROW_THIN then
                 let arrow_location = context.location;
@@ -271,7 +272,7 @@ namespace Syntax.Parsers.Definitions is
                 let modifiers = modifier_list_parser.parse(context);
                 let expect_semicolon = context.current.token != Lexical.TOKEN.IS;
 
-                let body: Trees.Bodies.Body mut;
+                let body: Trees.Bodies.Body mut = default;
 
                 try 
                     body = body_parser.parse(context)

--- a/src/syntax/parsers/definitions/indexer.ghul
+++ b/src/syntax/parsers/definitions/indexer.ghul
@@ -29,7 +29,7 @@ namespace Syntax.Parsers.Definitions is
         si
 
         parse(context: CONTEXT) -> Trees.Definitions.INDEXER is
-            let name: Trees.Identifiers.Identifier mut;
+            let name: Trees.Identifiers.Identifier mut = default;
             let start = context.location;
 
             if context.current.token == Lexical.TOKEN.IDENTIFIER then
@@ -55,9 +55,9 @@ namespace Syntax.Parsers.Definitions is
             fi
 
             let modifiers = modifier_list_parser.parse(context);
-            let read_body: Trees.Bodies.Body mut;
-            let assign_body: Trees.Bodies.Body mut;
-            let setter_argument_name: Trees.Identifiers.Identifier mut;
+            let read_body: Trees.Bodies.Body mut = default;
+            let assign_body: Trees.Bodies.Body mut = default;
+            let setter_argument_name: Trees.Identifiers.Identifier mut = default;
             let expect_semicolon mut = true;
 
             let progress mut = false;
@@ -126,7 +126,7 @@ namespace Syntax.Parsers.Definitions is
                 read_body = Trees.Bodies.NULL(context.location);
             fi
 
-            let result: Trees.Definitions.INDEXER mut;
+            let result: Trees.Definitions.INDEXER mut = default;
             
             if index_argument? then
                 result = 

--- a/src/syntax/parsers/definitions/member.ghul
+++ b/src/syntax/parsers/definitions/member.ghul
@@ -56,7 +56,7 @@ namespace Syntax.Parsers.Definitions is
 
             tokenizer_snapshot.commit();
 
-            other_token(context);    
+            return other_token(context);
         si
     si
 si

--- a/src/syntax/parsers/definitions/namespace.ghul
+++ b/src/syntax/parsers/definitions/namespace.ghul
@@ -46,6 +46,7 @@ namespace Syntax.Parsers.Definitions is
 
                 return result;
             fi
+            return null;
         si
     si
 si

--- a/src/syntax/parsers/definitions/pragma.ghul
+++ b/src/syntax/parsers/definitions/pragma.ghul
@@ -59,8 +59,8 @@ namespace Syntax.Parsers.Definitions is
         
             // FIXME: factor this out
             if pragma? /\ !pragma.is_poisoned then
-                let operator_name: string mut;
-                let precedence_to_restore: PRECEDENCE;
+                let operator_name: string mut = default;
+                let precedence_to_restore: PRECEDENCE mut = default;
     
                 let restore_status mut = PRECEDENCE_RESTORE_STATUS.NO_RESTORE_NEEDED;
 
@@ -78,7 +78,7 @@ namespace Syntax.Parsers.Definitions is
                         is_precedence_valid = false;
                     fi
 
-                    let precedence_to_set: PRECEDENCE mut;
+                    let precedence_to_set: PRECEDENCE mut = default;
 
                     if !precedence_name? then
                         context.error(pragma.location, "expected operator precedence argument");
@@ -123,6 +123,8 @@ namespace Syntax.Parsers.Definitions is
                     return Trees.Definitions.PRAGMA(pragma.location::definition.location, pragma, definition);
                 fi
             fi
+
+            return null;
         si
     si
 si

--- a/src/syntax/parsers/definitions/property.ghul
+++ b/src/syntax/parsers/definitions/property.ghul
@@ -56,9 +56,9 @@ namespace Syntax.Parsers.Definitions is
                 fi
         
                 let modifiers = modifier_list_parser.parse(context);
-                let read_body: Trees.Bodies.Body mut;
-                let assign_body: Trees.Bodies.Body mut;
-                let setter_argument_name: Trees.Identifiers.Identifier mut;
+                let read_body: Trees.Bodies.Body mut = default;
+                let assign_body: Trees.Bodies.Body mut = default;
+                let setter_argument_name: Trees.Identifiers.Identifier mut = default;
                 let expect_semicolon mut = true;
     
                 do

--- a/src/syntax/parsers/definitions/struct.ghul
+++ b/src/syntax/parsers/definitions/struct.ghul
@@ -35,8 +35,8 @@ namespace Syntax.Parsers.Definitions is
 
                 let identifier = identifier_parser.parse(context);
                             
-                let arguments: Trees.TypeExpressions.LIST mut;
-                let ancestors: Trees.TypeExpressions.LIST mut;
+                let arguments: Trees.TypeExpressions.LIST mut = default;
+                let ancestors: Trees.TypeExpressions.LIST mut = default;
 
                 let is_poisoned mut = false;
 
@@ -90,6 +90,7 @@ namespace Syntax.Parsers.Definitions is
             finally
                 context.in_classy = false;
             yrt            
+            return null;
         si
     si
 si

--- a/src/syntax/parsers/definitions/trait.ghul
+++ b/src/syntax/parsers/definitions/trait.ghul
@@ -40,8 +40,8 @@ namespace Syntax.Parsers.Definitions is
                     return null;
                 fi            
 
-                let arguments: Trees.TypeExpressions.LIST mut;
-                let ancestors: Trees.TypeExpressions.LIST mut;
+                let arguments: Trees.TypeExpressions.LIST mut = default;
+                let ancestors: Trees.TypeExpressions.LIST mut = default;
 
                 if context.current.token == Lexical.TOKEN.SQUARE_OPEN then
                     context.next_token();

--- a/src/syntax/parsers/definitions/union.ghul
+++ b/src/syntax/parsers/definitions/union.ghul
@@ -58,7 +58,7 @@ namespace Syntax.Parsers.Definitions is
                     return null;
                 fi
     
-                let arguments: Trees.TypeExpressions.LIST mut;
+                let arguments: Trees.TypeExpressions.LIST mut = default;
     
                 if context.current.token == Lexical.TOKEN.SQUARE_OPEN then
                     context.next_token();

--- a/src/syntax/parsers/expressions/expression.ghul
+++ b/src/syntax/parsers/expressions/expression.ghul
@@ -100,7 +100,7 @@ namespace Syntax.Parsers.Expressions is
 
             let op = context.current.value_string;
 
-            let known: PRECEDENCE mut;
+            let known: PRECEDENCE mut = default;
             if _precedence.try_get_value(op, known ref) then
                 return known;
             fi

--- a/src/syntax/parsers/expressions/primary.ghul
+++ b/src/syntax/parsers/expressions/primary.ghul
@@ -47,8 +47,8 @@ namespace Syntax.Parsers.Expressions is
                     if context.allow_tuple_element /\ !identifier.is_qualified then
                         context.allow_tuple_element = false;
                         let end mut = identifier.location;
-                        let type_expression: Trees.TypeExpressions.TypeExpression mut;
-                        let initializer: Trees.Expressions.Expression mut;
+                        let type_expression: Trees.TypeExpressions.TypeExpression mut = default;
+                        let initializer: Trees.Expressions.Expression mut = default;
 
                         if context.current.token == Lexical.TOKEN.COLON then
                             context.next_token();
@@ -82,7 +82,7 @@ namespace Syntax.Parsers.Expressions is
                     let start = context.location;
                     context.next_token();
                     let elements = expression_list_parser.parse(context);
-                    let type_expression: Trees.TypeExpressions.TypeExpression mut;
+                    let type_expression: Trees.TypeExpressions.TypeExpression mut = default;
                     let end mut = context.location;
                     context.next_token(Lexical.TOKEN.SQUARE_CLOSE);
                     if context.current.token == Lexical.TOKEN.COLON then
@@ -117,13 +117,13 @@ namespace Syntax.Parsers.Expressions is
                     // call argument with a known formal type).
                     // Distinguished from `new TYPE(args)` by an
                     // immediately-following `(`.
-                    let type_expression: Trees.TypeExpressions.TypeExpression mut;
+                    let type_expression: Trees.TypeExpressions.TypeExpression mut = default;
 
                     if context.current.token != Lexical.TOKEN.PAREN_OPEN then
                         type_expression = type_parser.parse(context);
                     fi
 
-                    let arguments: Trees.Expressions.LIST mut;
+                    let arguments: Trees.Expressions.LIST mut = default;
 
                     if context.next_token(Lexical.TOKEN.PAREN_OPEN) then
                         if context.current.token != Lexical.TOKEN.PAREN_CLOSE then
@@ -254,7 +254,7 @@ namespace Syntax.Parsers.Expressions is
                     let start = context.location;
                     context.next_token(Lexical.TOKEN.DEFAULT);
 
-                    let type_expression: Trees.TypeExpressions.TypeExpression mut;
+                    let type_expression: Trees.TypeExpressions.TypeExpression mut = default;
 
                     if context.current_token == Lexical.TOKEN.SQUARE_OPEN then
                         context.next_token();
@@ -319,7 +319,7 @@ namespace Syntax.Parsers.Expressions is
 
                     let variable_list = variable_list_parser.parse(context);
 
-                    let expression: Trees.Expressions.Expression mut;
+                    let expression: Trees.Expressions.Expression mut = default;
 
                     if context.next_token(Lexical.TOKEN.IN) then
                         expression = expression_parser.parse(context);

--- a/src/syntax/parsers/expressions/secondary.ghul
+++ b/src/syntax/parsers/expressions/secondary.ghul
@@ -41,8 +41,8 @@ namespace Syntax.Parsers.Expressions is
             let start = context.location;
             let result: Trees.Expressions.Expression mut = expression_primary_parser.parse(context);
 
-            let previous_left: Trees.Expressions.Expression mut;
-            let previous_identifier: Trees.Identifiers.Identifier mut;
+            let previous_left: Trees.Expressions.Expression mut = default;
+            let previous_identifier: Trees.Identifiers.Identifier mut = default;
 
             do
                 case context.current.token
@@ -62,8 +62,8 @@ namespace Syntax.Parsers.Expressions is
 
                     let done mut = false;
 
-                    let left: Trees.Expressions.Expression mut;
-                    let identifier: Trees.Identifiers.Identifier mut;
+                    let left: Trees.Expressions.Expression mut = default;
+                    let identifier: Trees.Identifiers.Identifier mut = default;
 
                     if result.is_member then
                         left = previous_left;
@@ -81,7 +81,7 @@ namespace Syntax.Parsers.Expressions is
                         let type_arguments = type_list_parser.parse(context);
 
                         if type_arguments? /\ !type_arguments.is_poisoned /\ context.next_token(Lexical.TOKEN.SQUARE_CLOSE) then
-                            let index_expression: Trees.Expressions.Expression mut;
+                            let index_expression: Trees.Expressions.Expression mut = default;
 
                             if type_arguments.count == 1 then
                                 let index = type_arguments.elements[0].try_copy_as_value_expression();
@@ -315,8 +315,8 @@ namespace Syntax.Parsers.Expressions is
                     
                     let type_arguments = type_list_parser.parse(context);
 
-                    let left: Trees.Expressions.Expression mut;
-                    let identifier: Trees.Identifiers.Identifier mut;
+                    let left: Trees.Expressions.Expression mut = default;
+                    let identifier: Trees.Identifiers.Identifier mut = default;
 
                     if result.is_member then
                         left = previous_left;

--- a/src/syntax/parsers/expressions/tuple.ghul
+++ b/src/syntax/parsers/expressions/tuple.ghul
@@ -31,6 +31,7 @@ namespace Syntax.Parsers.Expressions is
                 
                 return Trees.Expressions.TUPLE(start::context.location, expressions, false);
             fi
+            return null;
         si
     si
 si

--- a/src/syntax/parsers/identifiers/qualified.ghul
+++ b/src/syntax/parsers/identifiers/qualified.ghul
@@ -53,6 +53,7 @@ namespace Syntax.Parsers.Identifiers is
 
                 return result;
             fi
+            return null;
         si
     si
 si

--- a/src/syntax/parsers/modifiers/list.ghul
+++ b/src/syntax/parsers/modifiers/list.ghul
@@ -14,8 +14,8 @@ namespace Syntax.Parsers.Modifiers is
             let start = context.location;
             let end mut = context.location;
             let modifier mut = modifier_parser.parse(context);
-            let access_modifier: Trees.Modifiers.AccessModifier mut;
-            let storage_class: Trees.Modifiers.StorageClass mut;
+            let access_modifier: Trees.Modifiers.AccessModifier mut = default;
+            let storage_class: Trees.Modifiers.StorageClass mut = default;
 
             if modifier? /\ isa Trees.Modifiers.AccessModifier(modifier) then
                 access_modifier = cast Trees.Modifiers.AccessModifier(modifier);

--- a/src/syntax/parsers/pragmas/pragma.ghul
+++ b/src/syntax/parsers/pragmas/pragma.ghul
@@ -35,7 +35,7 @@ namespace Syntax.Parsers.Pragmas is
             fi
 
             if context.next_token(Lexical.TOKEN.PAREN_OPEN) then
-                let arguments: Trees.Expressions.LIST mut;
+                let arguments: Trees.Expressions.LIST mut = default;
                 
                 if context.current.token != Lexical.TOKEN.PAREN_CLOSE then
                     arguments = expression_list_parser.parse(context);

--- a/src/syntax/parsers/statements/node.ghul
+++ b/src/syntax/parsers/statements/node.ghul
@@ -109,7 +109,7 @@ namespace Syntax.Parsers.Statements is
                     let end mut = context.location;
 
                     if context.next_token(Lexical.TOKEN.RETURN, syntax_error_message) then
-                        let expression: Trees.Expressions.Expression mut;
+                        let expression: Trees.Expressions.Expression mut = default;
                         if 
                             context.current.token != Lexical.TOKEN.SEMICOLON /\
                             primary_expression_tokens | .any(t => t == context.current.token)
@@ -129,7 +129,7 @@ namespace Syntax.Parsers.Statements is
                     let start = context.location;
                     let end mut = context.location;
                     if context.next_token(Lexical.TOKEN.THROW, syntax_error_message) then
-                        let expression: Trees.Expressions.Expression mut;
+                        let expression: Trees.Expressions.Expression mut = default;
                         if context.current.token != Lexical.TOKEN.SEMICOLON then
                             expression = expression_parser.parse(context);
                             end = expression.location;
@@ -152,7 +152,7 @@ namespace Syntax.Parsers.Statements is
                         let expression = expression_parser.parse(context);
                         end = expression.location;
                         
-                        let message: Trees.Expressions.Expression mut;
+                        let message: Trees.Expressions.Expression mut = default;
 
                         if context.current_token == Lexical.TOKEN.ELSE then
                             context.next_token();
@@ -235,7 +235,7 @@ namespace Syntax.Parsers.Statements is
                         catches.add(Trees.Statements.CATCH(catch_start::catch_body.location, catch_variable, catch_body));
                     od
 
-                    let `finally: Trees.Statements.LIST mut;
+                    let `finally: Trees.Statements.LIST mut = default;
 
                     if context.current.token == Lexical.TOKEN.FINALLY then
                         context.next_token();
@@ -261,14 +261,14 @@ namespace Syntax.Parsers.Statements is
             add_parser(
                 (context) is
                     let start = context.location;
-                    let condition: Trees.Expressions.Expression mut;
+                    let condition: Trees.Expressions.Expression mut = default;
 
                     if context.current.token == Lexical.TOKEN.WHILE then
                         context.next_token();
                         condition = expression_parser.parse(context);
                     fi
 
-                    let body: Trees.Statements.LIST mut;
+                    let body: Trees.Statements.LIST mut = default;
 
                     if context.next_token(Lexical.TOKEN.DO, syntax_error_message) then                        
                         body = statement_list_parser.parse(context);
@@ -295,8 +295,8 @@ namespace Syntax.Parsers.Statements is
                     context.next_token(Lexical.TOKEN.FOR);
 
                     let variable = variable_parser.parse(context);
-                    let expression: Trees.Expressions.Expression mut;
-                    let body: Trees.Statements.LIST mut;
+                    let expression: Trees.Expressions.Expression mut = default;
+                    let body: Trees.Statements.LIST mut = default;
 
                     if (variable? /\ !variable.is_poisoned) \/ context.current_token == Lexical.TOKEN.IN then
                         if context.next_token(Lexical.TOKEN.IN, "in for statement") then
@@ -328,7 +328,7 @@ namespace Syntax.Parsers.Statements is
                     let start = context.location;
                     let end mut = context.location;
                     context.next_token();
-                    let label: Trees.Identifiers.Identifier mut;
+                    let label: Trees.Identifiers.Identifier mut = default;
                     if context.current.token == Lexical.TOKEN.IDENTIFIER then
                         label = identifier_parser.parse(context);
                         end = label.location;
@@ -345,7 +345,7 @@ namespace Syntax.Parsers.Statements is
                     let start = context.location;
                     let end mut = context.location;
                     context.next_token();
-                    let label: Trees.Identifiers.Identifier mut;
+                    let label: Trees.Identifiers.Identifier mut = default;
                     if context.current.token == Lexical.TOKEN.IDENTIFIER then
                         label = identifier_parser.parse(context);
                         end = label.location;

--- a/src/syntax/parsers/statements/pragma.ghul
+++ b/src/syntax/parsers/statements/pragma.ghul
@@ -25,6 +25,7 @@ namespace Syntax.Parsers.Statements is
                     return Trees.Statements.PRAGMA(pragma.location::statement.location, pragma, statement);
                 fi
             fi
+            return null;
         si
     si
 si

--- a/src/syntax/parsers/type_expressions/type_expression.ghul
+++ b/src/syntax/parsers/type_expressions/type_expression.ghul
@@ -111,7 +111,7 @@ namespace Syntax.Parsers.TypeExpressions is
                 (context: CONTEXT) -> Trees.TypeExpressions.TypeExpression is
                     let start = context.location;
                     context.next_token();
-                    let types: Trees.TypeExpressions.LIST mut;
+                    let types: Trees.TypeExpressions.LIST mut = default;
                     if context.current.token != Lexical.TOKEN.PAREN_CLOSE then
                         types = type_list_parser.parse(context);
                     else

--- a/src/syntax/parsers/variables/variable.ghul
+++ b/src/syntax/parsers/variables/variable.ghul
@@ -42,7 +42,7 @@ namespace Syntax.Parsers.Variables is
                 
             let end mut = variable_left.location;
             let type_expression: Trees.TypeExpressions.TypeExpression mut = Trees.TypeExpressions.INFER(start::context.location);
-            let initializer: Trees.Expressions.Expression mut;
+            let initializer: Trees.Expressions.Expression mut = default;
             let is_explicit_type mut = false;
 
             if context.current.token == Lexical.TOKEN.COLON then

--- a/src/syntax/process/README.md
+++ b/src/syntax/process/README.md
@@ -15,7 +15,7 @@ The `COMPILER` class (see `src/compiler/compiler.ghul`) runs these in order:
 5. **resolve_uses.ghul** – binds identifier uses to symbols within the current scope.
 6. **resolve_type_expressions.ghul** – resolves references inside type expressions.
 7. **resolve_ancestors.ghul** – attaches base classes and trait implementations.
-8. **resolve_explicit_variable_types\ copy.ghul** – checks variables with explicit types against their initialisers.
+8. **resolve_explicit_variable_types.ghul** – checks variables with explicit types against their initialisers.
 9. **resolve_overrides.ghul** – verifies override methods match inherited signatures.
 10. **record_type_argument_uses.ghul** – records generic type argument usage for later IL generation.
 11. **compile_expressions.ghul** – translates expressions into the intermediate representation.

--- a/src/syntax/process/add_accessors_for_properties.ghul
+++ b/src/syntax/process/add_accessors_for_properties.ghul
@@ -37,6 +37,7 @@ namespace Syntax.Process is
             if name =~ "IL.stub" then
                 _stub_depth = _stub_depth + 1;
             fi
+            return false;
         si
 
         visit(pragma: Definitions.PRAGMA) is
@@ -436,6 +437,7 @@ namespace Syntax.Process is
         pre(variant: Trees.Definitions.VARIANT) -> bool is
             super.pre(variant);
             _stack.push(variant.body);
+            return false;
         si
 
         visit(variant: Trees.Definitions.VARIANT) is

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -326,6 +326,7 @@ namespace Syntax.Process is
                     fi
                 od
             fi
+            return null;
         si
 
         get_reference_has_value(
@@ -442,6 +443,7 @@ namespace Syntax.Process is
             elif name =~ "KEEP" then
                 _keep_depth = _keep_depth + 1;
             fi
+            return false;
         si
 
         visit(pragma: Trees.Definitions.PRAGMA) is
@@ -727,6 +729,7 @@ namespace Syntax.Process is
                 `for.body.walk(self);
                 _flow.set_env(kept);
             fi
+            return false;
         si
 
         pre(left: Trees.Expressions.SIMPLE_LEFT_EXPRESSION) -> bool is
@@ -1022,7 +1025,7 @@ namespace Syntax.Process is
             fi
 
             let mark = _logger.mark();
-            let type: Type mut;
+            let type: Type mut = default;
 
             try
                 _logger.speculate();
@@ -1627,8 +1630,8 @@ namespace Syntax.Process is
             closure.map_type_arguments();
 
             let implied_type: Type;
-            let implied_argument_types: Collections.List[Type] mut;
-            let constraint_return_type: Type mut;
+            let implied_argument_types: Collections.List[Type] mut = default;
+            let constraint_return_type: Type mut = default;
 
             // have we been passed expected arguments types? If so we'll use them
             // to argument types of any anonymous function literal arguments.
@@ -1980,7 +1983,7 @@ namespace Syntax.Process is
                 // aware element types (notably function literals) use
                 // it to infer their argument types; element types that
                 // ignore constraint (most literals) are unaffected.
-                let element_constraint: Type mut;
+                let element_constraint: Type mut = default;
 
                 if sequence.type_expression? /\ !isa Trees.TypeExpressions.INFER(sequence.type_expression) /\ sequence.type_expression.type? then
                     element_constraint = sequence.type_expression.type.get_element_type();
@@ -2010,12 +2013,12 @@ namespace Syntax.Process is
         si
 
         _visit(sequence: Trees.Expressions.SEQUENCE) is
-            let type: Type mut;
-            let have_explicit_type: bool mut;
+            let type: Type mut = default;
+            let have_explicit_type: bool mut = default;
 
             let elements = Collections.LIST[Trees.Expressions.Expression](sequence.elements);
 
-            let constraint_type: Type mut;
+            let constraint_type: Type mut = default;
             if sequence.constraint? then
                 constraint_type = sequence.constraint.get_element_type();
             fi
@@ -2185,7 +2188,7 @@ namespace Syntax.Process is
         visit(`self: Trees.Expressions.SELF) is
             let s = current_instance_context;
 
-            let type: Type mut;
+            let type: Type mut = default;
 
             if s? then
                 let f = current_function;
@@ -2518,7 +2521,7 @@ namespace Syntax.Process is
             arg_count: int,
             want_instance: bool
         ) -> Semantic.Symbols.Function is
-            let result: Semantic.Symbols.Function mut;
+            let result: Semantic.Symbols.Function mut = default;
             let count mut = 0;
 
             for f in group.functions do
@@ -2833,8 +2836,8 @@ namespace Syntax.Process is
             let right_is_consumable = binary.right.value.check_is_consumable(_logger, binary.right.location);
             
             let binary_function_group: Semantic.Symbols.FUNCTION_GROUP mut;
-            let binary_overload_result: Semantic.OVERLOAD_RESOLVE_RESULT mut;
-            let binary_errors: Logging.DIAGNOSTICS_STATE mut;
+            let binary_overload_result: Semantic.OVERLOAD_RESOLVE_RESULT mut = default;
+            let binary_errors: Logging.DIAGNOSTICS_STATE mut = default;
 
             let binary_name = binary.operation.name.to_string();
 
@@ -2859,9 +2862,9 @@ namespace Syntax.Process is
                 binary_errors = logger_snapshot.backtrack();
             fi
 
-            let member_overload_result: Semantic.OVERLOAD_RESOLVE_RESULT mut;
+            let member_overload_result: Semantic.OVERLOAD_RESOLVE_RESULT mut = default;
             let member_function_group: Semantic.Symbols.FUNCTION_GROUP mut;
-            let member_errors: Logging.DIAGNOSTICS_STATE mut;
+            let member_errors: Logging.DIAGNOSTICS_STATE mut = default;
 
             if binary.left.value.type? then
                 let member_function_symbol = 
@@ -2887,7 +2890,7 @@ namespace Syntax.Process is
                 fi
             fi
 
-            let function: Semantic.Symbols.Function mut;
+            let function: Semantic.Symbols.Function mut = default;
 
             if member_overload_result? /\ binary_overload_result? then
                 if cast int(member_overload_result.score) <= cast int(binary_overload_result.score) then
@@ -2904,7 +2907,7 @@ namespace Syntax.Process is
             if function? then
                 _symbol_use_locations.add_symbol_use(binary.operation.location, function);
 
-                let force_type: Type mut;
+                let force_type: Type mut = default;
                 let want_not mut = false;
 
                 if binary.operation.name =~ "<>" then
@@ -3229,7 +3232,7 @@ namespace Syntax.Process is
                         return result;
                     si;
 
-                let value: Value mut;
+                let value: Value mut = default;
 
                 if need_store then
                     let store_value = cast Need.STORE(member.value).value;
@@ -3324,7 +3327,7 @@ namespace Syntax.Process is
                         .map(t => t.type).collect()
                 );
 
-            let from: IR.Values.Value mut;
+            let from: IR.Values.Value mut = default;
 
             if isa IR.Values.Load.SYMBOL(explicit_specialization.left.value) then
                 let load = cast IR.Values.Load.SYMBOL(explicit_specialization.left.value);
@@ -3357,7 +3360,7 @@ namespace Syntax.Process is
 
             arg.walk(self);
 
-            let symbol: Semantic.Symbols.Symbol mut;
+            let symbol: Semantic.Symbols.Symbol mut = default;
 
             if ambiguous_expression.left? then
                 ambiguous_expression.left.walk(self);
@@ -3380,8 +3383,8 @@ namespace Syntax.Process is
 
             _symbol_use_locations.add_symbol_use(ambiguous_expression.identifier.location, symbol);
 
-            let result_type: Semantic.Types.Type mut;
-            let result_symbol: Semantic.Symbols.Symbol mut;
+            let result_type: Semantic.Types.Type mut = default;
+            let result_symbol: Semantic.Symbols.Symbol mut = default;
 
             if symbol.is_type then
                 ambiguous_expression.result = Trees.Expressions.AMBIGUOUS_EXPRESSION_RESULT.TYPE;
@@ -3441,7 +3444,7 @@ namespace Syntax.Process is
         pre(generic_application: Trees.Expressions.GENERIC_APPLICATION) -> bool is
             generic_application.type_arguments.walk(self);
 
-            let symbol: Semantic.Symbols.Symbol mut;
+            let symbol: Semantic.Symbols.Symbol mut = default;
 
             if generic_application.left? then
                 generic_application.left.walk(self);
@@ -3465,8 +3468,8 @@ namespace Syntax.Process is
 
             _symbol_use_locations.add_symbol_use(generic_application.identifier.location, symbol);
 
-            let result_type: Semantic.Types.Type mut;
-            let result_symbol: Semantic.Symbols.Symbol mut;
+            let result_type: Semantic.Types.Type mut = default;
+            let result_symbol: Semantic.Symbols.Symbol mut = default;
 
             if symbol.is_type then
                 generic_application.result = Trees.Expressions.AMBIGUOUS_EXPRESSION_RESULT.TYPE;
@@ -4267,7 +4270,7 @@ namespace Syntax.Process is
             // we could also treat consuming a bare type as a constructor call
             // this would be done in the symbol loader
 
-            let load_symbol: Semantic.Symbols.Symbol mut;
+            let load_symbol: Semantic.Symbols.Symbol mut = default;
 
             if isa Load.SYMBOL(call.function.value) then
                 let load = cast Load.SYMBOL(call.function.value);
@@ -4875,7 +4878,7 @@ namespace Syntax.Process is
             // takes the type pushed in by the parent context
             // (assignment RHS, return position, typed `let`
             // initializer, call argument) via set_constraint.
-            let type: Semantic.Types.Type mut;
+            let type: Semantic.Types.Type mut = default;
 
             if `default.type_expression? then
                 type = `default.type_expression.type;

--- a/src/syntax/process/condition_analysis.ghul
+++ b/src/syntax/process/condition_analysis.ghul
@@ -99,7 +99,7 @@ namespace Syntax.Process is
 
             let suffix = member_name.substring(3);
 
-            let one_of: Semantic.Types.ONE_OF mut;
+            let one_of: Semantic.Types.ONE_OF mut = default;
             if isa Semantic.Types.ONE_OF(receiver_type) then
                 one_of = cast Semantic.Types.ONE_OF(receiver_type);
             fi

--- a/src/syntax/process/declare_symbols.ghul
+++ b/src/syntax/process/declare_symbols.ghul
@@ -80,6 +80,7 @@ namespace Syntax.Process is
             elif name =~ "KEEP" then
                 _keep_depth = _keep_depth + 1;
             fi
+            return false;
         si
 
         visit(pragma: Definitions.PRAGMA) is
@@ -161,6 +162,7 @@ namespace Syntax.Process is
 
         pre(`namespace: Definitions.NAMESPACE) -> bool is
             declare_and_enter_namespace(`namespace.name, _symbol_definition_listener, `namespace.is_compiler_generated);
+            return false;
         si
 
         visit(`namespace: Definitions.NAMESPACE) is
@@ -206,8 +208,8 @@ namespace Syntax.Process is
                 let names = Collections.LIST[string]();
 
                 for a in arguments do
-                    let s: Semantic.Symbols.Symbol mut;
-                    let name: string mut;
+                    let s: Semantic.Symbols.Symbol mut = default;
+                    let name: string mut = default;
 
                     if isa Trees.TypeExpressions.NAMED(a) then
                         let named = cast Trees.TypeExpressions.NAMED(a);
@@ -243,6 +245,7 @@ namespace Syntax.Process is
 
                 return (names, types);
             fi
+            return default;
         si
 
         _pre(
@@ -250,7 +253,7 @@ namespace Syntax.Process is
             declare_symbol: (Semantic.DeclarationContext, LOCATION, LOCATION, string, Collections.List[string], bool, Semantic.Scope, Semantic.SymbolDefinitionListener) -> Semantic.Symbols.Symbol    
         ) -> bool is
             let symbol: Semantic.Scope mut;
-            let stable_symbol: Semantic.STABLE_SYMBOL;
+            let stable_symbol: Semantic.STABLE_SYMBOL mut = default;
 
             if _keep_depth > 0 /\ _stable_symbols.try_get_symbol(classy, stable_symbol ref) then
                 symbol = stable_symbol.symbol;
@@ -289,6 +292,7 @@ namespace Syntax.Process is
             fi
             
             declare_generic_arguments(classy.arguments);
+            return false;
         si
 
         pre(`class: Definitions.CLASS) -> bool =>
@@ -354,7 +358,7 @@ namespace Syntax.Process is
         si
 
         pre(enum_member: Definitions.ENUM_MEMBER) -> bool is
-            let value: string mut;
+            let value: string mut = default;
 
             if enum_member.initializer? then
                 let i = enum_member.initializer;
@@ -372,6 +376,7 @@ namespace Syntax.Process is
                 value,
                 _symbol_definition_listener
             );
+            return false;
         si
 
         pre(function: Definitions.FUNCTION) -> bool is
@@ -380,7 +385,7 @@ namespace Syntax.Process is
 
             let is_private = function.modifiers.is_private;
 
-            let property: Semantic.Symbols.Property mut;
+            let property: Semantic.Symbols.Property mut = default;
 
             _local_id_generator.enter_function();
 
@@ -559,6 +564,7 @@ namespace Syntax.Process is
 
         pre(if_branch: Statements.IF_BRANCH) -> bool is
             create_and_enter_block_scope(if_branch);
+            return false;
         si
 
         visit(if_branch: Statements.IF_BRANCH) is
@@ -567,6 +573,7 @@ namespace Syntax.Process is
 
         pre(`case: Statements.CASE) -> bool is
             create_and_enter_block_scope(`case);
+            return false;
         si
 
         visit(`case: Statements.CASE) is
@@ -575,6 +582,7 @@ namespace Syntax.Process is
 
         pre(case_match: Statements.CASE_MATCH) -> bool is
             create_and_enter_block_scope(case_match);
+            return false;
         si
 
         visit(case_match: Statements.CASE_MATCH) is
@@ -583,6 +591,7 @@ namespace Syntax.Process is
 
         pre(`try: Statements.TRY) -> bool is
             create_and_enter_block_scope(`try);
+            return false;
         si
 
         visit(`try: Statements.TRY) is
@@ -591,6 +600,7 @@ namespace Syntax.Process is
 
         pre(`catch: Statements.CATCH) -> bool is
             create_and_enter_block_scope(`catch);
+            return false;
         si
 
         visit(`catch: Statements.CATCH) is
@@ -599,6 +609,7 @@ namespace Syntax.Process is
 
         pre(`do: Statements.DO) -> bool is
             create_and_enter_block_scope(`do);
+            return false;
         si
 
         visit(`do: Statements.DO) is
@@ -607,6 +618,7 @@ namespace Syntax.Process is
 
         pre(`for: Statements.FOR) -> bool is
             create_and_enter_block_scope(`for);
+            return false;
         si
 
         visit(`for: Statements.FOR) is
@@ -615,6 +627,7 @@ namespace Syntax.Process is
 
         pre(labelled: Statements.LABELLED) -> bool is
             current_declaration_context.declare_label(labelled.label.location, labelled.label.name, _symbol_definition_listener);
+            return false;
         si
 
         visit(labelled: Statements.LABELLED) is
@@ -622,6 +635,7 @@ namespace Syntax.Process is
 
         pre(body: Bodies.Body) -> bool is
             create_and_enter_block_scope(body);
+            return false;
         si
 
         visit(body: Bodies.Body) is
@@ -634,6 +648,7 @@ namespace Syntax.Process is
             fi
 
             current_declaration_context.declare_variable(variable.name.location, variable.name.name, false, _symbol_definition_listener);
+            return false;
         si
 
         pre(function: Expressions.FUNCTION) -> bool is
@@ -694,6 +709,7 @@ namespace Syntax.Process is
         
         pre(let_in: Expressions.LET_IN) -> bool is
             create_and_enter_block_scope(let_in);
+            return false;
         si
 
         visit(let_in: Expressions.LET_IN) is
@@ -702,6 +718,7 @@ namespace Syntax.Process is
 
         pre(expression: Bodies.EXPRESSION) -> bool is
             create_and_enter_block_scope(expression);
+            return false;
         si
 
         visit(expression: Bodies.EXPRESSION) is
@@ -710,6 +727,7 @@ namespace Syntax.Process is
 
         pre(block: Bodies.BLOCK) -> bool is
             create_and_enter_block_scope(block);
+            return false;
         si
 
         visit(block: Bodies.BLOCK) is

--- a/src/syntax/process/expand_namespaces.ghul
+++ b/src/syntax/process/expand_namespaces.ghul
@@ -96,7 +96,7 @@ namespace Syntax.Process is
 
         get_namespace_name(path: string) -> string is
             let local_path: string mut;
-            let uri: Uri mut;
+            let uri: Uri mut = default;
 
             if Uri.is_well_formed_uri_string(path, UriKind.ABSOLUTE) then
                 uri = Uri(path);
@@ -153,6 +153,7 @@ namespace Syntax.Process is
 
         pre(`namespace: Definitions.NAMESPACE) -> bool is
             _depth = _depth + 1;
+            return false;
         si
 
         visit(`namespace: Definitions.NAMESPACE) is

--- a/src/syntax/process/generate_il.ghul
+++ b/src/syntax/process/generate_il.ghul
@@ -223,9 +223,7 @@ namespace Syntax.Process is
             println("}}");
         si
 
-        pre(`namespace: Definitions.NAMESPACE) -> bool is
-            super.pre(`namespace);
-        si
+        pre(`namespace: Definitions.NAMESPACE) -> bool => super.pre(`namespace);
 
         visit(`namespace: Definitions.NAMESPACE) is
             let context = _symbol_table.current_closure_context;
@@ -248,6 +246,7 @@ namespace Syntax.Process is
             enter_scope(`class);
 
             _context.indent();
+            return false;
         si
         
         visit(`class: Definitions.CLASS) is
@@ -282,6 +281,7 @@ namespace Syntax.Process is
             enter_scope(`trait);
 
             _context.indent();
+            return false;
         si
 
         visit(`trait: Definitions.TRAIT) is
@@ -306,6 +306,7 @@ namespace Syntax.Process is
             _context.indent();
 
             enter_scope(`struct);            
+            return false;
         si
 
         visit(`struct: Definitions.STRUCT) is
@@ -396,6 +397,7 @@ namespace Syntax.Process is
             _context.indent();
 
             println(".custom instance void ['ghul-runtime']Ghul.Internal.VARIANT_ATTRIBUTE::.ctor() = ( 01 00 00 00 )");
+            return false;
         si
         
         visit(variant: Definitions.VARIANT) is
@@ -490,6 +492,7 @@ namespace Syntax.Process is
             _context.indent();
 
             _context.write_line(".field public specialname rtspecialname int32 value__ ");
+            return false;
         si
 
         visit(`enum: Definitions.ENUM) is
@@ -505,6 +508,7 @@ namespace Syntax.Process is
             let buffer = System.Text.StringBuilder();
             symbol.gen_definition_header(buffer);
             println(buffer);
+            return false;
         si
 
         pre(function: Definitions.FUNCTION) -> bool is
@@ -530,6 +534,7 @@ namespace Syntax.Process is
             symbol.gen_body_header(_context);
 
             enter_block();
+            return false;
         si
 
         visit(function: Definitions.FUNCTION) is
@@ -608,7 +613,7 @@ namespace Syntax.Process is
             // Property AST node carries either a Property symbol or a Variable
             // symbol (declare_symbols collapses `_name: T;` to a variable). Both
             // need wrapping when at namespace scope.
-            let globals_namespace: Semantic.Symbols.NAMESPACE mut;
+            let globals_namespace: Semantic.Symbols.NAMESPACE mut = default;
 
             let global_property = cast Semantic.Symbols.GLOBAL_PROPERTY(symbol);
 
@@ -640,6 +645,7 @@ namespace Syntax.Process is
         // FIXME: #500 Pragma handling code is duplicated across multiple visitors
         pre(pragma: Definitions.PRAGMA) -> bool is
             process_pragma(pragma.pragma, true);
+            return false;
         si
 
         visit(pragma: Definitions.PRAGMA) is
@@ -851,7 +857,7 @@ namespace Syntax.Process is
             fi
 
             let buffer = System.Text.StringBuilder();
-            let globals_namespace: Semantic.Symbols.NAMESPACE mut;
+            let globals_namespace: Semantic.Symbols.NAMESPACE mut = default;
 
             for name in variable.names do
                 let symbol = find(name);
@@ -884,6 +890,7 @@ namespace Syntax.Process is
                     fi
                 fi
             fi
+            return false;
         si
         
         visit(v: Variables.VARIABLE) is
@@ -962,7 +969,7 @@ namespace Syntax.Process is
             super.visit(r);
 
             let function = current_function;
-            let value: Value mut;
+            let value: Value mut = default;
 
             if
                 r.expression? /\
@@ -1076,10 +1083,10 @@ namespace Syntax.Process is
             let return_type = current_function.return_type;
 
             let return_needed: TEMP mut;
-            let return_value: TEMP mut;
-            let label: LOOP_LABELS mut;
+            let return_value: TEMP mut = default;
+            let label: LOOP_LABELS mut = default;
 
-            let outer_try: LOOP_LABELS mut;
+            let outer_try: LOOP_LABELS mut = default;
 
             let brancher = get_brancher_for_block();
 
@@ -1301,7 +1308,7 @@ namespace Syntax.Process is
             let return_type = current_function.return_type;
 
             let return_needed: TEMP mut;
-            let return_value: TEMP mut;
+            let return_value: TEMP mut = default;
 
             let outer_try = _loops.get_current_try();
 
@@ -1522,6 +1529,7 @@ namespace Syntax.Process is
 
         pre(pragma: Statements.PRAGMA) -> bool is
             process_pragma(pragma.pragma, true);
+            return false;
         si
 
         visit(pragma: Statements.PRAGMA) is
@@ -1702,6 +1710,7 @@ namespace Syntax.Process is
 
                 index = index - 1;
             od
+            return null;
         si
 
         get_current_loop() -> LOOP_LABELS is
@@ -1716,6 +1725,7 @@ namespace Syntax.Process is
 
                 index = index - 1;
             od
+            return null;
         si
 
         init() is
@@ -1736,6 +1746,7 @@ namespace Syntax.Process is
                     return loop;
                 fi
             od         
+            return null;
         si
 
         enter_try(return_needed: TEMP, return_value: TEMP) -> LOOP_LABELS is

--- a/src/syntax/process/narrow_env.ghul
+++ b/src/syntax/process/narrow_env.ghul
@@ -46,7 +46,7 @@ namespace Syntax.Process is
         // The narrowed type recorded for `v`, or null when `v` is
         // not narrowed in this environment.
         narrowed_type_of(v: Variable) -> Type is
-            let result: Type;
+            let result: Type mut = default;
 
             if _narrows.try_get_value(v, result ref) then
                 return result;

--- a/src/syntax/process/narrowing_flow.ghul
+++ b/src/syntax/process/narrowing_flow.ghul
@@ -89,7 +89,7 @@ namespace Syntax.Process is
         // declared type (without emptying the environment).
         restore_all() is
             for v in _current_env.variables do
-                let declared: Type;
+                let declared: Type mut = default;
 
                 if _declared.try_get_value(v, declared ref) /\ declared? then
                     v.set_type(declared);
@@ -104,7 +104,7 @@ namespace Syntax.Process is
                 return null;
             fi
 
-            let declared: Type;
+            let declared: Type mut = default;
 
             if _declared.try_get_value(v, declared ref) /\ declared? then
                 return declared;

--- a/src/syntax/process/numeric_literal_classifier.ghul
+++ b/src/syntax/process/numeric_literal_classifier.ghul
@@ -36,7 +36,7 @@ namespace Syntax.Process is
         classify_integer(location: LOCATION, value_string: string) -> Literal.NUMBER is
             let type: Type mut;
             let suffix mut = "i4";
-            let conv: string mut;
+            let conv: string mut = default;
             let working mut = value_string;
 
             let last_char = working.get_chars(working.length - 1);
@@ -155,7 +155,7 @@ namespace Syntax.Process is
                 if value_string.starts_with("0x") \/ value_string.starts_with("0X") then
                     parse_hex(value_string.substring(2, value_string.length - 2));
                 else
-                    let v: ulong;
+                    let v: ulong mut = default;
                     let parsed_ok = ulong.try_parse(value_string, v ref);
                     (parsed_ok, v);
                 fi;

--- a/src/syntax/process/resolve_ancestors.ghul
+++ b/src/syntax/process/resolve_ancestors.ghul
@@ -151,9 +151,7 @@ namespace Syntax.Process is
             struct_symbol.push_ancestor(_innate_symbol_lookup.get_value_type());
         si
 
-        pre(`union: Trees.Definitions.UNION) -> bool is
-            super.pre(`union);
-        si
+        pre(`union: Trees.Definitions.UNION) -> bool => super.pre(`union);
 
         visit(`union: Trees.Definitions.UNION) is
             if is_stable(`union) then

--- a/src/syntax/process/resolve_explicit_variable_types.ghul
+++ b/src/syntax/process/resolve_explicit_variable_types.ghul
@@ -55,6 +55,7 @@ namespace Syntax.Process is
         pre(function: Trees.Definitions.FUNCTION) -> bool is
             super.pre(function);
             set_generic_argument_types(function.generic_arguments);            
+            return false;
         si
 
         visit(function: Trees.Definitions.FUNCTION) is

--- a/src/syntax/process/resolve_type_expressions.ghul
+++ b/src/syntax/process/resolve_type_expressions.ghul
@@ -135,7 +135,7 @@ namespace Syntax.Process is
                     type_arguments
                 );
 
-            let from: IR.Values.Value mut;
+            let from: IR.Values.Value mut = default;
 
             if isa IR.Values.Load.SYMBOL(left_value) then
                 let load = cast IR.Values.Load.SYMBOL(left_value);
@@ -182,9 +182,7 @@ namespace Syntax.Process is
                     get_type_or_any(reference.element.type));                        
         si
 
-        pre(member: Trees.TypeExpressions.MEMBER) -> bool is
-            super.pre(member);
-        si
+        pre(member: Trees.TypeExpressions.MEMBER) -> bool => super.pre(member);
 
         visit(member: Trees.TypeExpressions.MEMBER) is
             // we have something like

--- a/src/syntax/process/resolve_uses.ghul
+++ b/src/syntax/process/resolve_uses.ghul
@@ -102,6 +102,7 @@ namespace Syntax.Process is
                     _logger.error(u.`use.location, "cannot use instance member");
                 fi
             od
+            return false;
         si
 
         visit(`namespace: Definitions.NAMESPACE) is

--- a/src/syntax/process/scopedvisitor.ghul
+++ b/src/syntax/process/scopedvisitor.ghul
@@ -69,6 +69,7 @@ namespace Syntax.Process is
         pre(`namespace: Definitions.NAMESPACE) -> bool is
             enter_namespace(`namespace.name);
             enter_uses(`namespace);
+            return false;
         si
 
         visit(`namespace: Definitions.NAMESPACE) is
@@ -78,6 +79,7 @@ namespace Syntax.Process is
 
         pre(`class: Definitions.CLASS) -> bool is
             enter_scope(`class);
+            return false;
         si
 
         visit(`class: Definitions.CLASS) is
@@ -86,6 +88,7 @@ namespace Syntax.Process is
 
         pre(`trait: Definitions.TRAIT) -> bool is
             enter_scope(`trait);
+            return false;
         si
 
         visit(`trait: Definitions.TRAIT) is
@@ -94,10 +97,12 @@ namespace Syntax.Process is
 
         pre(`struct: Definitions.STRUCT) -> bool is
             enter_scope(`struct);
+            return false;
         si
 
         pre(`union: Definitions.UNION) -> bool is
             enter_scope(`union);
+            return false;
         si
 
         visit(`union: Definitions.UNION) is
@@ -106,6 +111,7 @@ namespace Syntax.Process is
         
         pre(variant: Definitions.VARIANT) -> bool is
             enter_scope(variant);
+            return false;
         si
 
         visit(variant: Definitions.VARIANT) is
@@ -118,6 +124,7 @@ namespace Syntax.Process is
 
         pre(`enum: Definitions.ENUM) -> bool is
             enter_scope(`enum);
+            return false;
         si
 
         visit(`enum: Definitions.ENUM) is
@@ -126,6 +133,7 @@ namespace Syntax.Process is
 
         pre(function: Definitions.FUNCTION) -> bool is
             enter_scope(function);
+            return false;
         si
 
         visit(function: Definitions.FUNCTION) is
@@ -135,6 +143,7 @@ namespace Syntax.Process is
         pre(property: Definitions.PROPERTY) -> bool is
             // enter_scope(property);
             // return true;
+            return false;
         si
 
         visit(property: Definitions.PROPERTY) is
@@ -152,6 +161,7 @@ namespace Syntax.Process is
 
         pre(if_branch: Statements.IF_BRANCH) -> bool is
             enter_scope(if_branch);
+            return false;
         si
 
         visit(if_branch: Statements.IF_BRANCH) is
@@ -160,6 +170,7 @@ namespace Syntax.Process is
 
         pre(`case: Statements.CASE) -> bool is
             enter_scope(`case);
+            return false;
         si
 
         visit(`case: Statements.CASE) is
@@ -168,6 +179,7 @@ namespace Syntax.Process is
 
         pre(case_match: Statements.CASE_MATCH) -> bool is
             enter_scope(case_match);
+            return false;
         si
 
         visit(case_match: Statements.CASE_MATCH) is
@@ -176,6 +188,7 @@ namespace Syntax.Process is
 
         pre(`try: Statements.TRY) -> bool is
             enter_scope(`try);
+            return false;
         si
 
         visit(`try: Statements.TRY) is
@@ -184,6 +197,7 @@ namespace Syntax.Process is
 
         pre(`catch: Statements.CATCH) -> bool is
             enter_scope(`catch);
+            return false;
         si
 
         visit(`catch: Statements.CATCH) is
@@ -192,6 +206,7 @@ namespace Syntax.Process is
 
         pre(`do: Statements.DO) -> bool is
             enter_scope(`do);
+            return false;
         si
 
         visit(`do: Statements.DO) is
@@ -200,6 +215,7 @@ namespace Syntax.Process is
 
         pre(`for: Statements.FOR) -> bool is
             enter_scope(`for);
+            return false;
         si
 
         visit(`for: Statements.FOR) is
@@ -208,6 +224,7 @@ namespace Syntax.Process is
 
         pre(labelled: Statements.LABELLED) -> bool is
             enter_scope(labelled);
+            return false;
         si
 
         visit(labelled: Statements.LABELLED) is
@@ -216,6 +233,7 @@ namespace Syntax.Process is
 
         pre(function: Expressions.FUNCTION) -> bool is
             enter_scope(function);
+            return false;
         si
 
         visit(function: Expressions.FUNCTION) is
@@ -224,6 +242,7 @@ namespace Syntax.Process is
 
         pre(let_in: Expressions.LET_IN) -> bool is
             enter_scope(let_in);
+            return false;
         si
 
         visit(let_in: Expressions.LET_IN) is
@@ -232,6 +251,7 @@ namespace Syntax.Process is
 
         pre(expression: Bodies.EXPRESSION) -> bool is
             enter_scope(expression);
+            return false;
         si
 
         visit(expression: Bodies.EXPRESSION) is
@@ -240,6 +260,7 @@ namespace Syntax.Process is
 
         pre(block: Bodies.BLOCK) -> bool is
             enter_scope(block);
+            return false;
         si
 
         visit(block: Bodies.BLOCK) is

--- a/src/syntax/process/strictvisitor.ghul
+++ b/src/syntax/process/strictvisitor.ghul
@@ -314,6 +314,7 @@ namespace Syntax is
 
         pre(statement: Expressions.STATEMENT) -> bool is
             throwNotImplemented("statement expression", statement);
+            return false;
         si
 
         visit(statement: Expressions.STATEMENT) is

--- a/src/syntax/trees/definitions/pragma.ghul
+++ b/src/syntax/trees/definitions/pragma.ghul
@@ -20,11 +20,12 @@ namespace Syntax.Trees.Definitions is
 
         is_name_equal_to(name: string) -> bool => pragma? /\ pragma.is_name_equal_to(name);
 
-        try_get_string_literal_at(index: int) -> string is
+        try_get_string_literal_at(index: int) -> string =>
             if pragma? then
-                return pragma.try_get_string_literal_at(index);
-            fi
-        si
+                pragma.try_get_string_literal_at(index)
+            else
+                null
+            fi;
 
         accept(visitor: Visitor) is
             visitor.visit(self);

--- a/src/syntax/trees/expressions/list.ghul
+++ b/src/syntax/trees/expressions/list.ghul
@@ -13,11 +13,12 @@ namespace Syntax.Trees.Expressions is
 
         iterator: Collections.Iterator[Expression] => expressions.iterator;
 
-        try_get_string_literal_at(index: int) -> string is
+        try_get_string_literal_at(index: int) -> string =>
             if expressions? /\ index < expressions.count then
-                return expressions[index].try_get_string_literal();
-            fi
-        si
+                expressions[index].try_get_string_literal()
+            else
+                null
+            fi;
 
         replace_element(index: int, value: Expression) is
             expressions[index] = value;

--- a/src/syntax/trees/expressions/literals/string.ghul
+++ b/src/syntax/trees/expressions/literals/string.ghul
@@ -11,10 +11,11 @@ namespace Syntax.Trees.Expressions.Literals is
             visitor.visit(self);
         si
 
-        try_get_string_literal() -> string is
+        try_get_string_literal() -> string =>
             if value_string? /\ value_string.length > 0 then
-                return value_string;
-            fi
-        si
+                value_string
+            else
+                null
+            fi;
     si
 si

--- a/src/syntax/trees/identifiers/identifier.ghul
+++ b/src/syntax/trees/identifiers/identifier.ghul
@@ -116,7 +116,7 @@ namespace Syntax.Trees.Identifiers is
         si
 
         copy() -> Identifier is
-            let np: Identifier mut;
+            let np: Identifier mut = default;
 
             if qualifier? then
                 np = qualifier.copy();

--- a/src/syntax/trees/modifiers/list.ghul
+++ b/src/syntax/trees/modifiers/list.ghul
@@ -25,8 +25,8 @@ namespace Syntax.Trees.Modifiers is
         si
 
         copy() -> LIST is
-            let nam: AccessModifier mut;
-            let nsc: StorageClass mut;
+            let nam: AccessModifier mut = default;
+            let nsc: StorageClass mut = default;
 
             if access_modifier? then
                 nam = access_modifier.copy();


### PR DESCRIPTION
Bugs fixed:
- `PROPERTY_DETAILS.to_string()` built its description string but never returned it, so it always returned null.

Technical:
- Initialise locals flagged by the new definite-assignment warning with the `default` value expression; ref-out locals become `mut = default`.
- Give functions flagged by the new definite-return warning an explicit return, an expression body, or a `let … in` body where that reads better.
- Rename `resolve_explicit_variable_types copy.ghul`, dropping the stray " copy" from the filename.