### PR TITLE
Bind if let names with ERROR type on an impossible match

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.12.1",
+      "version": "0.12.2",
       "commands": [
         "ghul-compiler"
       ],

--- a/integration-tests/semantic/if-let-errors/err.expected
+++ b/integration-tests/semantic/if-let-errors/err.expected
@@ -1,3 +1,3 @@
-test.ghul: 17,35..17,36: error: symbol not found: s
-test.ghul: 20,31..20,32: error: symbol not found: s
-test.ghul: 9,20..9,30: error: if let binding must have a reference type, not value type Ghul.int
+test.ghul: 12,20..12,30: error: if let binding must have a reference type, not value type Ghul.int
+test.ghul: 20,35..20,36: error: symbol not found: s
+test.ghul: 23,31..23,32: error: symbol not found: s

--- a/integration-tests/semantic/if-let-errors/test.ghul
+++ b/integration-tests/semantic/if-let-errors/test.ghul
@@ -5,9 +5,12 @@ namespace Test is
         si
 
         check(o: object) static is
-            // a value type is always present: cannot be tested with if let
+            // `int` is a value type, so this is an impossible match.
+            // The one error for that must not be followed by a cascade:
+            // `i` is still bound, with ERROR type, so the member access
+            // below is absorbed rather than producing a spurious error.
             if let i: int = o then
-                IO.Std.write_line("got {i}");
+                IO.Std.write_line("got {i.no_such_member}");
             fi
 
             // the binding is scoped to its own then-arm

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -1501,6 +1501,20 @@ namespace Syntax.Process is
                         `if.binding.location,
                         "if let binding must have a reference type, not value type {`if.binding.initializer.value.type}"
                     );
+
+                    // Error recovery: an impossible match still binds its
+                    // names — typed ERROR — so the one diagnostic above is
+                    // not followed by a cascade of spurious errors on uses
+                    // of the binding within the then-arm.
+                    for name in `if.binding.left.names do
+                        let symbol = find(name);
+
+                        if symbol? /\ isa Semantic.Types.SettableTyped(symbol) then
+                            symbol.define();
+
+                            (cast Semantic.Types.SettableTyped(symbol)).set_type(Semantic.Types.ERROR());
+                        fi
+                    od
                 fi
 
                 if `if.body? then


### PR DESCRIPTION
Bugs fixed:

- An impossible `if let` match (a value-type initializer — `if let i: int = obj`) reported the impossibility but could then produce a cascade of spurious follow-on errors on uses of the binding within the then-arm. The binding's names are now bound with `ERROR` type, so the one root-cause diagnostic stands alone.

Follows #1301.
