### PR TITLE
Add a non-null presence domain to the flow analysis

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.12.4",
+      "version": "0.12.7",
       "commands": [
         "ghul-compiler"
       ],

--- a/src/syntax/process/condition_analysis.ghul
+++ b/src/syntax/process/condition_analysis.ghul
@@ -18,12 +18,14 @@ namespace Syntax.Process is
     // environment in force before the condition, produce the
     // environments in force along its true and false edges.
     //
-    // `isa T(x)` and `x.is_<variant>` leaves contribute a narrow on
-    // their target; `/\` `\/` `!` compose the leaves; anything else
-    // is opaque (no narrowing either way). Narrowing targets are
-    // resolved through the `resolve_target` delegate supplied at
-    // construction — in the compiler it is the visitor's
-    // scope-aware lookup; in tests it is a stub.
+    // `isa T(x)` and `x.is_<variant>` leaves contribute a type narrow
+    // on their target; an `x?` (has-value) leaf contributes a
+    // presence fact (`x` known to hold a value on the true edge);
+    // `/\` `\/` `!` compose the leaves; anything else is opaque (no
+    // narrowing either way). Narrowing targets are resolved through
+    // the `resolve_target` delegate supplied at construction — in the
+    // compiler it is the visitor's scope-aware lookup; in tests it is
+    // a stub.
     //
     // See `docs/claude/flow-sensitive-narrowing.md`.
     class CONDITION_ANALYZER is
@@ -229,6 +231,8 @@ namespace Syntax.Process is
                 return _analyze_isa(cast Trees.Expressions.ISA(cond), in_env);
             elif isa Trees.Expressions.MEMBER(cond) then
                 return _analyze_member(cast Trees.Expressions.MEMBER(cond), in_env);
+            elif isa Trees.Expressions.HAS_VALUE(cond) then
+                return _analyze_has_value(cast Trees.Expressions.HAS_VALUE(cond), in_env);
             fi
 
             return _opaque(in_env);
@@ -247,11 +251,33 @@ namespace Syntax.Process is
             let isa_type =
                 if `isa.type_expression? then `isa.type_expression.type else null fi;
 
-            if
-                target? /\ isa_type? /\
-                !isa_type.is_error /\ !isa_type.is_inferred
-            then
-                then_env.set_narrow(target, isa_type);
+            if target? then
+                // `isa T(x)` is true only for a non-null `x` of a
+                // matching type — so the true edge knows both.
+                then_env.set_non_null(target);
+
+                if isa_type? /\ !isa_type.is_error /\ !isa_type.is_inferred then
+                    then_env.set_narrow(target, isa_type);
+                fi
+            fi
+
+            return CONDITION_FACTS(then_env, else_env);
+        si
+
+        // `x?` — the has-value test. On the true edge `x` is known to
+        // hold a value; the false edge learns nothing (no narrowing
+        // the other way). Applies uniformly to a nullable reference
+        // and to an OPTION[T] value type.
+        _analyze_has_value(has_value: Trees.Expressions.HAS_VALUE, in_env: NARROW_ENV) -> CONDITION_FACTS is
+            let then_env = in_env.copy();
+            let else_env = in_env.copy();
+
+            if has_value.left? then
+                let target = _resolve_target(has_value.left);
+
+                if target? then
+                    then_env.set_non_null(target);
+                fi
             fi
 
             return CONDITION_FACTS(then_env, else_env);
@@ -270,6 +296,10 @@ namespace Syntax.Process is
                 let target = _resolve_target(member.left);
 
                 if target? then
+                    // A variant test discriminates a non-null union
+                    // value — the matched edge knows it holds a value.
+                    then_env.set_non_null(target);
+
                     let variant_type = try_get_variant_type_for_is_accessor(receiver_type, name);
 
                     if variant_type? then

--- a/src/syntax/process/narrow_env.ghul
+++ b/src/syntax/process/narrow_env.ghul
@@ -5,20 +5,28 @@ namespace Syntax.Process is
     // The flow-analysis facts in force at one program point: the
     // local variables observed at a type narrower than their
     // declaration, the local variables known to be definitely
-    // assigned, and a `bottom` marker for points reached only via a
-    // diverging path (return / throw / break / continue).
+    // assigned, the local variables known to hold a value, and a
+    // `bottom` marker for points reached only via a diverging path
+    // (return / throw / break / continue).
     //
     // The flow pass threads a NARROW_ENV forward through a method,
     // copies it at branch points, and merges divergent copies with
     // `join`. A variable absent from `_narrows` is at its declared
     // type; a variable absent from `_assigned` is not known to be
-    // definitely assigned. See `docs/claude/flow-sensitive-narrowing.md`.
+    // definitely assigned; a variable absent from `_non_null` is not
+    // known to hold a value. See `docs/claude/flow-sensitive-narrowing.md`.
     class NARROW_ENV is
         _narrows: Collections.MAP[Variable, Type];
 
         // Locals definitely assigned on every path reaching this
         // point — the definite-assignment domain.
         _assigned: Collections.SET[Variable];
+
+        // Locals known to hold a value at this point — non-null for a
+        // reference type, has-a-value for an OPTION[T] (`T?`) value
+        // type. The presence domain; a possible-null-dereference
+        // check (a later phase) consumes it.
+        _non_null: Collections.SET[Variable];
 
         // True for an unreachable program point. A bottom env is the
         // identity element of `join` and carries no facts.
@@ -27,6 +35,7 @@ namespace Syntax.Process is
         init() is
             _narrows = Collections.MAP[Variable, Type]();
             _assigned = Collections.SET[Variable]();
+            _non_null = Collections.SET[Variable]();
         si
 
         // The unreachable environment.
@@ -89,6 +98,30 @@ namespace Syntax.Process is
             _assigned.add(v);
         si
 
+        // The locals known to hold a value at this point.
+        non_null_variables: Collections.Iterable[Variable] => _non_null;
+
+        // True iff `v` is known to hold a value at this point.
+        is_non_null(v: Variable) -> bool => v? /\ _non_null.contains(v);
+
+        // Record `v` as known to hold a value (mutating). A bottom
+        // env ignores it — it stays unreachable.
+        set_non_null(v: Variable) is
+            if is_bottom \/ !v? then
+                return;
+            fi
+
+            _non_null.add(v);
+        si
+
+        // Forget that `v` is known to hold a value (mutating) — used
+        // by the assignment transfer function.
+        drop_non_null(v: Variable) is
+            if v? /\ _non_null.contains(v) then
+                _non_null.remove(v);
+            fi
+        si
+
         copy() -> NARROW_ENV is
             let e = NARROW_ENV();
             e.is_bottom = is_bottom;
@@ -99,6 +132,10 @@ namespace Syntax.Process is
 
             for v in _assigned do
                 e._assigned.add(v);
+            od
+
+            for v in _non_null do
+                e._non_null.add(v);
             od
 
             return e;
@@ -120,11 +157,11 @@ namespace Syntax.Process is
 
         // Merge two environments at a control-flow merge point.
         // `bottom` is the identity (a diverging branch contributes
-        // nothing). Both domains merge by intersection: a variable
+        // nothing). Every domain merges by intersection: a variable
         // survives the narrowing merge only when narrowed in BOTH
         // inputs (merged type = least upper bound); a variable is
         // definitely assigned after the merge only when assigned in
-        // BOTH inputs.
+        // BOTH inputs; likewise known-non-null only when in both.
         join(a: NARROW_ENV, b: NARROW_ENV) -> NARROW_ENV static is
             if !a? \/ a.is_bottom then
                 return if b? then b.copy() else NARROW_ENV() fi;
@@ -157,6 +194,12 @@ namespace Syntax.Process is
             for v in a.assigned_variables do
                 if b.is_assigned(v) then
                     result.set_assigned(v);
+                fi
+            od
+
+            for v in a.non_null_variables do
+                if b.is_non_null(v) then
+                    result.set_non_null(v);
                 fi
             od
 

--- a/src/syntax/process/narrowing_flow.ghul
+++ b/src/syntax/process/narrowing_flow.ghul
@@ -140,6 +140,10 @@ namespace Syntax.Process is
                 for v in target.assigned_variables do
                     applied.set_assigned(v);
                 od
+
+                for v in target.non_null_variables do
+                    applied.set_non_null(v);
+                od
             fi
 
             _current_env = applied;
@@ -152,9 +156,16 @@ namespace Syntax.Process is
         si
 
         // Assignment transfer: a write to `v` invalidates any narrow
-        // on it — subsequent reads must observe the declared type.
+        // on it — subsequent reads must observe the declared type —
+        // and any presence fact, since the new value may be null.
         on_assignment(v: Variable) is
-            if !v? \/ !_current_env.contains(v) then
+            if !v? then
+                return;
+            fi
+
+            _current_env.drop_non_null(v);
+
+            if !_current_env.contains(v) then
                 return;
             fi
 

--- a/unit-tests/src/syntax/process/condition_analysis_tests.ghul
+++ b/unit-tests/src/syntax/process/condition_analysis_tests.ghul
@@ -68,6 +68,9 @@ namespace Syntax.Process.UnitTests is
         make_not(operand: Expression) -> Trees.Expressions.UNARY =>
             Trees.Expressions.UNARY(loc(), Trees.Identifiers.Identifier(loc(), "!"), operand);
 
+        make_has_value(operand: Expression) -> Trees.Expressions.HAS_VALUE =>
+            Trees.Expressions.HAS_VALUE(loc(), operand);
+
         // A resolver backed by an explicit expression->variable map.
         make_analyzer(targets: MAP[Expression, Variable]) -> CONDITION_ANALYZER =>
             CONDITION_ANALYZER(
@@ -205,6 +208,79 @@ namespace Syntax.Process.UnitTests is
 
             Assert.is_false(facts.then_env.contains(x));
             Assert.is_false(facts.then_env.contains(y));
+        si
+
+        analyze_has_value_should_mark_non_null_on_then_edge() is
+            @test()
+
+            let owner = make_owner();
+            let v = make_var(owner, "v", make_class_type("T"));
+
+            let operand = id_expr("v");
+            let targets = MAP[Expression, Variable]();
+            targets[operand] = v;
+
+            let facts = make_analyzer(targets).analyze_condition(make_has_value(operand), NARROW_ENV());
+
+            Assert.is_true(facts.then_env.is_non_null(v));
+            Assert.is_false(facts.else_env.is_non_null(v));
+        si
+
+        analyze_not_has_value_should_mark_non_null_on_else_edge() is
+            @test()
+
+            // `!x?` — the false edge (x holds a value) carries the fact.
+            let owner = make_owner();
+            let v = make_var(owner, "v", make_class_type("T"));
+
+            let operand = id_expr("v");
+            let targets = MAP[Expression, Variable]();
+            targets[operand] = v;
+
+            let facts = make_analyzer(targets).analyze_condition(make_not(make_has_value(operand)), NARROW_ENV());
+
+            Assert.is_false(facts.then_env.is_non_null(v));
+            Assert.is_true(facts.else_env.is_non_null(v));
+        si
+
+        analyze_isa_should_mark_target_non_null_on_then_edge() is
+            @test()
+
+            // `isa T(x)` is true only for a non-null `x`.
+            let owner = make_owner();
+            let t = make_class_type("T");
+            let v = make_var(owner, "v", t);
+
+            let right = id_expr("v");
+            let targets = MAP[Expression, Variable]();
+            targets[right] = v;
+
+            let facts = make_analyzer(targets).analyze_condition(make_isa(right, t), NARROW_ENV());
+
+            Assert.is_true(facts.then_env.is_non_null(v));
+            Assert.is_false(facts.else_env.is_non_null(v));
+        si
+
+        analyze_and_of_has_value_should_mark_both_non_null_on_then_edge() is
+            @test()
+
+            let owner = make_owner();
+            let x = make_var(owner, "x", make_class_type("Tx"));
+            let y = make_var(owner, "y", make_class_type("Ty"));
+
+            let rx = id_expr("x");
+            let ry = id_expr("y");
+            let targets = MAP[Expression, Variable]();
+            targets[rx] = x;
+            targets[ry] = y;
+
+            let cond = make_and(make_has_value(rx), make_has_value(ry));
+            let facts = make_analyzer(targets).analyze_condition(cond, NARROW_ENV());
+
+            Assert.is_true(facts.then_env.is_non_null(x));
+            Assert.is_true(facts.then_env.is_non_null(y));
+            Assert.is_false(facts.else_env.is_non_null(x));
+            Assert.is_false(facts.else_env.is_non_null(y));
         si
     si
 si

--- a/unit-tests/src/syntax/process/narrow_env_tests.ghul
+++ b/unit-tests/src/syntax/process/narrow_env_tests.ghul
@@ -231,5 +231,99 @@ namespace Syntax.Process.UnitTests is
             Assert.is_false(merged.contains(y));
             Assert.is_true(merged.is_empty);
         si
+
+        set_non_null_should_record_and_be_readable() is
+            @test()
+
+            let owner = make_owner();
+            let v = make_var(owner, "v", make_class_type("T"));
+
+            let e = NARROW_ENV();
+            e.set_non_null(v);
+
+            Assert.is_true(e.is_non_null(v));
+        si
+
+        is_non_null_should_be_false_for_unrecorded() is
+            @test()
+
+            let owner = make_owner();
+            let v = make_var(owner, "v", make_class_type("T"));
+
+            Assert.is_false(NARROW_ENV().is_non_null(v));
+        si
+
+        drop_non_null_should_remove_entry() is
+            @test()
+
+            let owner = make_owner();
+            let v = make_var(owner, "v", make_class_type("T"));
+
+            let e = NARROW_ENV();
+            e.set_non_null(v);
+            e.drop_non_null(v);
+
+            Assert.is_false(e.is_non_null(v));
+        si
+
+        set_non_null_on_bottom_should_be_no_op() is
+            @test()
+
+            let owner = make_owner();
+            let v = make_var(owner, "v", make_class_type("T"));
+
+            let e = NARROW_ENV.bottom();
+            e.set_non_null(v);
+
+            Assert.is_false(e.is_non_null(v));
+        si
+
+        copy_should_carry_non_null_independently() is
+            @test()
+
+            let owner = make_owner();
+            let a = make_var(owner, "a", make_class_type("T"));
+            let b = make_var(owner, "b", make_class_type("T"));
+
+            let original = NARROW_ENV();
+            original.set_non_null(a);
+
+            let clone = original.copy();
+            clone.set_non_null(b);
+            clone.drop_non_null(a);
+
+            Assert.is_true(original.is_non_null(a));
+            Assert.is_false(original.is_non_null(b));
+            Assert.is_false(clone.is_non_null(a));
+            Assert.is_true(clone.is_non_null(b));
+        si
+
+        join_should_keep_non_null_in_both_sides() is
+            @test()
+
+            let owner = make_owner();
+            let v = make_var(owner, "v", make_class_type("T"));
+
+            let a = NARROW_ENV();
+            a.set_non_null(v);
+            let b = NARROW_ENV();
+            b.set_non_null(v);
+
+            Assert.is_true(NARROW_ENV.join(a, b).is_non_null(v));
+        si
+
+        join_should_drop_non_null_in_only_one_side() is
+            @test()
+
+            let owner = make_owner();
+            let v = make_var(owner, "v", make_class_type("T"));
+
+            let a = NARROW_ENV();
+            a.set_non_null(v);
+            let b = NARROW_ENV();
+
+            Assert.is_false(NARROW_ENV.join(a, b).is_non_null(v));
+            Assert.is_false(NARROW_ENV.join(b, a).is_non_null(v));
+        si
     si
 si


### PR DESCRIPTION
Technical:
- `NARROW_ENV` gains a third domain alongside narrowing and definite
  assignment: the locals known to hold a value at a program point —
  non-null for a reference type, has-a-value for an `OPTION[T]` (`T?`)
  value type. `analyze_condition` populates it — an `x?` test, and
  `isa` / variant tests, mark the target present on their true edge;
  the assignment transfer drops it. No diagnostic consumes the domain
  yet; the possible-null-dereference check is a later phase.