### PR TITLE
Dogfood flow narrowing and `if let` in the compiler source

### DIFF
--- a/src/semantic/back_feed.ghul
+++ b/src/semantic/back_feed.ghul
@@ -52,7 +52,7 @@ namespace Semantic is
                 isa Types.INFERRED_VARIABLE_TYPE(actual) /\
                 !formal.is_sentinel /\ !formal.is_type_variable
             then
-                let placeholder = cast Types.INFERRED_VARIABLE_TYPE(actual);
+                let placeholder = actual;
                 // Upper-bound, not lower: formal here is the slot the
                 // placeholder must fit INTO. Treating it as a peer
                 // LUB candidate widens spuriously when the slot is
@@ -69,7 +69,7 @@ namespace Semantic is
                 isa Types.INFERRED_VARIABLE_TYPE(formal) /\
                 !actual.is_sentinel /\ !actual.is_type_variable
             then
-                let placeholder = cast Types.INFERRED_VARIABLE_TYPE(formal);
+                let placeholder = formal;
                 if placeholder.origin.add_constraint(actual) then
                     _logger.mark_consumed_any();
                 fi
@@ -111,7 +111,7 @@ namespace Semantic is
                         let ancestor = actual_symbol.get_ancestor(i);
 
                         if ancestor? /\ isa Types.GENERIC(ancestor) then
-                            let ancestor_generic = cast Types.GENERIC(ancestor);
+                            let ancestor_generic = ancestor;
                             let ancestor_symbol = cast Symbols.GENERIC(ancestor_generic.symbol);
 
                             if

--- a/src/semantic/closure_arg_resolver.ghul
+++ b/src/semantic/closure_arg_resolver.ghul
@@ -67,7 +67,7 @@ namespace Semantic is
                     return false;
                 fi
 
-                let argument = cast Syntax.Trees.Expressions.VARIABLE(a);
+                let argument = a;
 
                 argument_names.add(argument.name.name);
 

--- a/src/semantic/constraint.ghul
+++ b/src/semantic/constraint.ghul
@@ -110,8 +110,7 @@ namespace Semantic is
             fi
 
             let symbol mut = named.symbol;
-            let generic = cast Symbols.GENERIC(symbol);
-            if generic? then
+            if let generic: Symbols.GENERIC = symbol then
                 symbol = generic.symbol;
             fi
 
@@ -153,8 +152,7 @@ namespace Semantic is
                 return function.arguments.count == call_arity;
             fi
 
-            let group = cast Symbols.FUNCTION_GROUP(member);
-            if group? then
+            if let group: Symbols.FUNCTION_GROUP = member then
                 for f in group.functions do
                     if f? /\ f.arguments? /\ f.arguments.count == call_arity then
                         return true;
@@ -175,7 +173,7 @@ namespace Semantic is
                 return false;
             fi
 
-            let m = cast MEMBER_CONSTRAINT(other);
+            let m = other;
             return member_name == m.member_name /\ call_arity == m.call_arity;
         si
 
@@ -266,7 +264,7 @@ namespace Semantic is
             // argument prefix.
             let candidate_args =
                 if isa Types.NAMED(candidate) then
-                    (cast Types.NAMED(candidate)).arguments
+                    candidate.arguments
                 else
                     null
                 fi;
@@ -303,7 +301,7 @@ namespace Semantic is
                 return false;
             fi
 
-            let c = cast CALL_CONSTRAINT(other);
+            let c = other;
 
             if !argument_types? /\ !c.argument_types? then return true; fi
             if !argument_types? \/ !c.argument_types? then return false; fi
@@ -399,8 +397,7 @@ namespace Semantic is
             fi
 
             let symbol mut = named.symbol;
-            let generic = cast Symbols.GENERIC(symbol);
-            if generic? then
+            if let generic: Symbols.GENERIC = symbol then
                 symbol = generic.symbol;
             fi
 
@@ -449,7 +446,7 @@ namespace Semantic is
                 return false;
             fi
 
-            let d = cast DESTRUCTURE_CONSTRAINT(other);
+            let d = other;
             return member_count == d.member_count;
         si
 
@@ -496,8 +493,7 @@ namespace Semantic is
             fi
 
             let symbol mut = named.symbol;
-            let generic = cast Symbols.GENERIC(symbol);
-            if generic? then
+            if let generic: Symbols.GENERIC = symbol then
                 symbol = generic.symbol;
             fi
 
@@ -579,8 +575,7 @@ namespace Semantic is
             fi
 
             let symbol mut = named.symbol;
-            let generic = cast Symbols.GENERIC(symbol);
-            if generic? then
+            if let generic: Symbols.GENERIC = symbol then
                 symbol = generic.symbol;
             fi
 
@@ -618,13 +613,11 @@ namespace Semantic is
                 return false;
             fi
 
-            let function = cast Symbols.Function(member);
-            if function? then
+            if let function: Symbols.Function = member then
                 return accepts_index(function);
             fi
 
-            let group = cast Symbols.FUNCTION_GROUP(member);
-            if group? then
+            if let group: Symbols.FUNCTION_GROUP = member then
                 for f in group.functions do
                     if f? /\ accepts_index(f) then
                         return true;
@@ -654,7 +647,7 @@ namespace Semantic is
                 return false;
             fi
 
-            let i = cast INDEX_CONSTRAINT(other);
+            let i = other;
             if !index_type? /\ !i.index_type? then return true; fi
             if !index_type? \/ !i.index_type? then return false; fi
             return index_type =~ i.index_type;

--- a/src/semantic/dotnet/symbol_factory.ghul
+++ b/src/semantic/dotnet/symbol_factory.ghul
@@ -197,7 +197,7 @@ namespace Semantic.DotNet is
                 return;
             fi
 
-            let result = cast Symbols.Classy(symbol);
+            let result = symbol;
 
             if type.base_type? then
                 result.add_ancestor(_type_mapper.get_type(type.base_type));
@@ -316,7 +316,7 @@ namespace Semantic.DotNet is
                 return;
             fi
 
-            let classy = cast Symbols.Classy(result);
+            let classy = result;
 
             for i in 0..classy.ancestors.count do
                 let ancestor = classy.get_ancestor(i);
@@ -333,7 +333,7 @@ namespace Semantic.DotNet is
 
         inherit_default_trait_member(into: Symbols.Classy, member: Symbols.Symbol) is
             if isa Symbols.FUNCTION_GROUP(member) then
-                let group = cast Symbols.FUNCTION_GROUP(member);
+                let group = member;
 
                 for function in group.functions do
                     if function.is_default_trait_method then
@@ -341,7 +341,7 @@ namespace Semantic.DotNet is
                     fi
                 od
             elif isa Symbols.Function(member) then
-                let function = cast Symbols.Function(member);
+                let function = member;
 
                 if function.is_default_trait_method then
                     into.add_member(function);

--- a/src/semantic/dotnet/symbol_table.ghul
+++ b/src/semantic/dotnet/symbol_table.ghul
@@ -134,9 +134,9 @@ namespace Semantic.DotNet is
                 let union_symbol = get_symbol(parent_type);
 
                 if isa Symbols.Classy(union_symbol) then
-                    let variant_member = cast Symbols.Classy(union_symbol).find_member(type.name);
+                    let variant_member = union_symbol.find_member(type.name);
                     if isa Symbols.Scoped(variant_member) then
-                        return cast Symbols.Scoped(variant_member);
+                        return variant_member;
                     fi
                 fi
             fi
@@ -185,8 +185,7 @@ namespace Semantic.DotNet is
             // full name and would clash with the union as a
             // namespace) — assemblies.ghul stashed them keyed by
             // the union's full name in TYPE_DETAILS_LOOKUP.
-            let union_result = cast Symbols.UNION(result);
-            if union_result? then
+            if let union_result: Symbols.UNION = result then
                 _symbol_factory.materialize_variants(union_result, dotnet_type);
             fi
 

--- a/src/semantic/least_upper_bound_map.ghul
+++ b/src/semantic/least_upper_bound_map.ghul
@@ -114,8 +114,8 @@ namespace Semantic is
                 return null;
             fi
 
-            let ga = cast Types.GENERIC(a);
-            let gb = cast Types.GENERIC(b);
+            let ga = a;
+            let gb = b;
 
             let sa = cast Symbols.GENERIC(ga.symbol);
             let sb = cast Symbols.GENERIC(gb.symbol);
@@ -209,7 +209,7 @@ namespace Semantic is
                     continue;
                 fi
 
-                let a_anc_gen = cast Types.GENERIC(a_anc);
+                let a_anc_gen = a_anc;
                 let a_anc_sym = cast Symbols.GENERIC(a_anc_gen.symbol);
 
                 if !a_anc_sym? then
@@ -223,7 +223,7 @@ namespace Semantic is
                         continue;
                     fi
 
-                    let b_anc_gen = cast Types.GENERIC(b_anc);
+                    let b_anc_gen = b_anc;
                     let b_anc_sym = cast Symbols.GENERIC(b_anc_gen.symbol);
 
                     if !b_anc_sym? then
@@ -460,9 +460,7 @@ namespace Semantic is
         // which is the only way the trait-walk can find them
         // intersecting.
         _specialised_ancestor(type: Type, i: int) -> Type is
-            let symbol = cast Symbols.GENERIC(type.symbol);
-
-            if symbol? then
+            if let symbol: Symbols.GENERIC = type.symbol then
                 return symbol.get_ancestor(i);
             fi
 

--- a/src/semantic/owner_constraint_specializer.ghul
+++ b/src/semantic/owner_constraint_specializer.ghul
@@ -132,7 +132,7 @@ namespace Semantic is
                     continue;
                 fi
 
-                let ancestor_generic = cast Types.GENERIC(ancestor);
+                let ancestor_generic = ancestor;
                 let ancestor_symbol = cast Symbols.GENERIC(ancestor_generic.symbol);
 
                 if
@@ -154,7 +154,7 @@ namespace Semantic is
                         break;
                     fi
 
-                    let arg = cast Types.GenericArgument(slot);
+                    let arg = slot;
 
                     candidate[arg.name] = constraint_generic.arguments[j];
                 od

--- a/src/semantic/scope/namespace_search_result.ghul
+++ b/src/semantic/scope/namespace_search_result.ghul
@@ -93,8 +93,8 @@ namespace Semantic is
                 // we've not found any non-method symbol, yet, and we've just found a function. We need to
                 // merge this function into the override map we're building:
 
-                let function = cast Symbols.Function(symbol);
-                
+                let function = symbol;
+
                 add_function(function);
 
                 // continue searching, as there could be other overloads with the same name in outer scopes:
@@ -103,7 +103,7 @@ namespace Semantic is
                 // we've not found any non-method symbol, yet, and we've just found a function group. We need to
                 // merge every function in this group into the override map we're building:
 
-                let fg = cast Symbols.FUNCTION_GROUP(symbol);
+                let fg = symbol;
 
                 add_function_group(fg);
 

--- a/src/semantic/symbol_table.ghul
+++ b/src/semantic/symbol_table.ghul
@@ -56,7 +56,7 @@ namespace Semantic is
         current_union_context: Symbols.UNION is
             for scope in Collections.LIST_REVERSE_ITERATOR[Scope](_stack) do
                 if isa Symbols.UNION(scope) then
-                    return cast Symbols.UNION(scope);
+                    return scope;
                 fi
             od
             return null;
@@ -65,7 +65,7 @@ namespace Semantic is
         current_function: Symbols.Function is
             for scope in Collections.LIST_REVERSE_ITERATOR[Scope](_stack) do
                 if isa Symbols.Function(scope) then
-                    return cast Symbols.Function(scope);
+                    return scope;
                 fi
             od
             return null;
@@ -92,9 +92,7 @@ namespace Semantic is
 
         current_closure: Symbols.Closure is
             for scope in Collections.LIST_REVERSE_ITERATOR[Scope](_stack) do
-                let result = cast Symbols.Closure(scope);
-
-                if result? then
+                if let result: Symbols.Closure = scope then
                     return result;
                 fi
             od
@@ -104,7 +102,7 @@ namespace Semantic is
         current_function_group: Symbols.FUNCTION_GROUP is
             for scope in Collections.LIST_REVERSE_ITERATOR[Scope](_stack) do
                 if isa Symbols.FUNCTION_GROUP(scope) then
-                    return cast Symbols.FUNCTION_GROUP(scope);
+                    return scope;
                 fi
             od
             return null;
@@ -113,7 +111,7 @@ namespace Semantic is
         current_property: Symbols.Property is
             for scope in Collections.LIST_REVERSE_ITERATOR[Scope](_stack) do
                 if isa Symbols.Property(scope) then
-                    return cast Symbols.Property(scope);
+                    return scope;
                 fi
             od
             return null;

--- a/src/semantic/symbol_use_locations.ghul
+++ b/src/semantic/symbol_use_locations.ghul
@@ -498,7 +498,7 @@ namespace Semantic is
                 // completed — is then the better answer. Narrowed
                 // types are always concrete, so this keeps them.
                 if observed? /\ observed.is_settled then
-                    return cast Symbols.Variable(s).describe_with_type(observed);
+                    return s.describe_with_type(observed);
                 fi
             fi
 

--- a/src/semantic/symbols/classy.ghul
+++ b/src/semantic/symbols/classy.ghul
@@ -148,12 +148,12 @@ namespace Semantic.Symbols is
 
                 let seen = Collections.SET[METHOD_OVERRIDE_CLASS]();
 
-                for f in cast FUNCTION_GROUP(result).functions do
+                for f in result.functions do
                     seen.add(f.override_class);
                     combined.add(f);
                 od
 
-                for f in cast FUNCTION_GROUP(outer).functions do
+                for f in outer.functions do
                     if !seen.contains(f.override_class) then
                         combined.add(f);                        
                     fi                    
@@ -1067,7 +1067,7 @@ namespace Semantic.Symbols is
             let owner_owner: Scope mut;
 
             if isa Symbol(owner) then
-                let owner_symbol = cast Symbol(owner);
+                let owner_symbol = owner;
 
                 owner_owner = owner_symbol.owner;
             else

--- a/src/semantic/symbols/closure.ghul
+++ b/src/semantic/symbols/closure.ghul
@@ -237,7 +237,7 @@ namespace Semantic.Symbols is
                 let scope = stack[i];
 
                 if seen_self /\ isa Closure(scope) then
-                    return cast Closure(scope);
+                    return scope;
                 fi
 
                 if scope == self then
@@ -391,7 +391,7 @@ namespace Semantic.Symbols is
                         outer_self.type.walk(capture_type_argument);
                     fi
                 elif isa Closure(c) then
-                    let outer = cast Closure(c);
+                    let outer = c;
 
                     if !enclosing? then
                         enclosing = _find_enclosing_closure();

--- a/src/semantic/symbols/function_wrapper.ghul
+++ b/src/semantic/symbols/function_wrapper.ghul
@@ -16,7 +16,7 @@ namespace Semantic is
                 return false;
             fi
 
-            return self =~ cast FUNCTION_WRAPPER(other);
+            return self =~ other;
         si
 
         =~(other: FUNCTION_WRAPPER) -> bool =>

--- a/src/semantic/symbols/generic.ghul
+++ b/src/semantic/symbols/generic.ghul
@@ -192,7 +192,7 @@ namespace Semantic.Symbols is
                 return false;
             fi
 
-            let other_generic = cast GENERIC(other);
+            let other_generic = other;
 
             if other_generic.symbol != symbol then
                 return false;

--- a/src/semantic/symbols/ineffective_trait_override_checker.ghul
+++ b/src/semantic/symbols/ineffective_trait_override_checker.ghul
@@ -94,7 +94,7 @@ namespace Semantic.Symbols is
             let classy_unspec = classy.unspecialized_symbol;
 
             if isa FUNCTION_GROUP(direct) then
-                for f in cast FUNCTION_GROUP(direct).functions do
+                for f in direct.functions do
                     if f.is_default_trait_method \/ f.is_abstract then
                         continue;
                     fi
@@ -108,7 +108,7 @@ namespace Semantic.Symbols is
             fi
 
             if isa Property(direct) then
-                let prop = cast Property(direct);
+                let prop = direct;
                 let read_is_default = prop.read_function? /\ prop.read_function.is_default_trait_method;
                 let assign_is_default = prop.assign_function? /\ prop.assign_function.is_default_trait_method;
 

--- a/src/semantic/symbols/method_override_class.ghul
+++ b/src/semantic/symbols/method_override_class.ghul
@@ -47,7 +47,7 @@ namespace Semantic is
                 return false;
             fi
 
-            return self =~ cast METHOD_OVERRIDE_CLASS(other);
+            return self =~ other;
         si
         
         get_hash_code() -> int is

--- a/src/semantic/symbols/namespace.ghul
+++ b/src/semantic/symbols/namespace.ghul
@@ -95,7 +95,7 @@ namespace Semantic.Symbols is
             let globals_class = dotnet_symbol_table.get_symbol("{qn}.$globals");
 
             if globals_class? /\ isa Classy(globals_class) then
-                return cast Classy(globals_class).find_member(name);
+                return globals_class.find_member(name);
             fi
 
             return null;

--- a/src/semantic/symbols/symbol.ghul
+++ b/src/semantic/symbols/symbol.ghul
@@ -368,7 +368,7 @@ namespace Semantic.Symbols is
                 if a? /\ a.scope? then
                     for member in a.scope.symbols do
                         if isa FUNCTION_GROUP(member) then
-                            for function in cast FUNCTION_GROUP(member).functions do
+                            for function in member.functions do
                                 if
                                     function.is_abstract \/
                                     function.is_default_trait_method \/
@@ -378,7 +378,7 @@ namespace Semantic.Symbols is
                                 fi
                             od
                         elif isa Function(member) then
-                            let function = cast Function(member);
+                            let function = member;
 
                             if
                                 function.is_abstract \/
@@ -597,7 +597,7 @@ namespace Semantic.Symbols is
                     return;
                 fi
 
-                function_group = cast Symbols.FUNCTION_GROUP(existing);
+                function_group = existing;
             else
                 function_group = Symbols.FUNCTION_GROUP(location, self, function.name);
                 _symbols[function.name] = function_group;
@@ -619,7 +619,7 @@ namespace Semantic.Symbols is
                 
                 if isa FUNCTION_GROUP(existing) then
                     if isa Function(member) then
-                        cast FUNCTION_GROUP(existing).add(cast Function(member));
+                        existing.add(member);
                     elif !member.is_reflected \/ !existing.is_reflected then                        
                         throw Exception("cannot add function {member} over the top of non function member {existing}");
                     fi
@@ -629,8 +629,8 @@ namespace Semantic.Symbols is
                     if isa Function(member) then
                         let fg = FUNCTION_GROUP(location, self, member.name);
 
-                        fg.add(cast Function(existing));
-                        fg.add(cast Function(member));
+                        fg.add(existing);
+                        fg.add(member);
 
                         _symbols[member.name] = fg;
                     elif !member.is_reflected \/ !existing.is_reflected then
@@ -650,8 +650,8 @@ namespace Semantic.Symbols is
             if isa Function(member) then
                 let fg = FUNCTION_GROUP(location, self, member.name);
 
-                fg.add(cast Function(member));
-    
+                fg.add(member);
+
                 _symbols[member.name] = fg;
             else
                 _symbols[member.name] = member;                                    

--- a/src/semantic/symbols/symbol_inheritance_resolver.ghul
+++ b/src/semantic/symbols/symbol_inheritance_resolver.ghul
@@ -301,7 +301,7 @@ namespace Semantic is
             if overrider_symbol? then
                 if isa Symbols.Property(overrider_symbol) then
                     handle_property_overrider(
-                        cast Symbols.Property(overrider_symbol), overridee_symbols, logger);
+                        overrider_symbol, overridee_symbols, logger);
                 else
                     handle_non_property_overrider(overrider_symbol, overridee_symbols, logger);
                 fi
@@ -329,7 +329,7 @@ namespace Semantic is
             for overridee in overridee_symbols do
                 if isa Symbols.Property(overridee) then
                     handle_property_overridee(
-                        overrider_symbol, cast Symbols.Property(overridee), logger);
+                        overrider_symbol, overridee, logger);
                 elif !(isa Symbols.Variable(overridee)) then
                     logger.warn(overrider_symbol.location, "{overrider_symbol} hides non-property {overridee}");
                 fi
@@ -499,7 +499,7 @@ namespace Semantic is
             if !symbol? then
                 // do nothing
             elif isa FUNCTION_GROUP(symbol) then
-                for f in cast FUNCTION_GROUP(symbol).functions do
+                for f in symbol.functions do
                     result.add(f);
                 od
             elif !symbol.is_type_variable then

--- a/src/semantic/symbols/symbol_wrapper.ghul
+++ b/src/semantic/symbols/symbol_wrapper.ghul
@@ -15,7 +15,7 @@ namespace Semantic is
             elif !isa SYMBOL_WRAPPER(other) then
                 false;
             else
-                self =~ cast SYMBOL_WRAPPER(other);
+                self =~ other;
             fi;
 
         =~(other: SYMBOL_WRAPPER) -> bool =>

--- a/src/semantic/types/function_group.ghul
+++ b/src/semantic/types/function_group.ghul
@@ -15,7 +15,7 @@ namespace Semantic.Types is
 
         =~(other: Type) -> bool =>
             isa FUNCTION_GROUP(other) /\
-                function_group == cast FUNCTION_GROUP(other).function_group;
+                function_group == other.function_group;
 
         to_string() -> string =>
             "{name}(...)";

--- a/src/semantic/types/generic.ghul
+++ b/src/semantic/types/generic.ghul
@@ -129,8 +129,8 @@ namespace Semantic.Types is
             if !isa GENERIC(other) then
                 return false;
             fi
-            
-            let other_generic = cast GENERIC(other);
+
+            let other_generic = other;
 
             let generic_symbol = cast Symbols.GENERIC(symbol);
             let generic_other_symbol = cast Symbols.GENERIC(other_generic.symbol);
@@ -213,7 +213,7 @@ namespace Semantic.Types is
                 return false;
             fi
 
-            let generic_other = cast GENERIC(other);
+            let generic_other = other;
 
             if symbol == generic_other.symbol then
                 return true;
@@ -249,7 +249,7 @@ namespace Semantic.Types is
                 return Types.MATCH.DIFFERENT;
             fi
 
-            let generic_other = cast GENERIC(other);
+            let generic_other = other;
 
             if symbol == generic_other.symbol then
                 return Types.MATCH.SAME;
@@ -299,7 +299,7 @@ namespace Semantic.Types is
                 // is_assignable_from check sees the same identity it
                 // would for the plain union. NAMED.compare already
                 // does the right thing for ONE_OF via symbol-match.
-                let one_of = cast ONE_OF(other);
+                let one_of = other;
                 return self.compare(one_of.underlying_type);
             fi
 
@@ -341,8 +341,7 @@ namespace Semantic.Types is
                 return true;
             fi
 
-            let other_generic = cast GENERIC(other);
-            if other_generic? then
+            if let other_generic: GENERIC = other then
                 let generic_symbol = cast Symbols.GENERIC(symbol);
                 let generic_other_symbol = cast Symbols.GENERIC(other_generic.symbol);
     

--- a/src/semantic/types/generic_argument_bind_results.ghul
+++ b/src/semantic/types/generic_argument_bind_results.ghul
@@ -113,7 +113,7 @@ namespace Semantic.Types is
                 // is_any-actual vs concrete-existing the right way:
                 // skip the overwrite, keep the concrete existing).
                 if isa INFERRED_VARIABLE_TYPE(actual_type) then
-                    let placeholder = cast INFERRED_VARIABLE_TYPE(actual_type);
+                    let placeholder = actual_type;
                     let resolved = placeholder.origin.try_get_inferred_type();
 
                     if resolved? /\ resolved.is_settled then

--- a/src/semantic/types/named.ghul
+++ b/src/semantic/types/named.ghul
@@ -62,7 +62,7 @@ namespace Semantic.Types is
                 // override handles the ONE_OF =~ ONE_OF case.
                 false;
             elif isa NAMED(other) then
-                let other_symbol = cast NAMED(other);
+                let other_symbol = other;
                 symbol == other_symbol.symbol;
             else
                 false;

--- a/src/semantic/types/one_of.ghul
+++ b/src/semantic/types/one_of.ghul
@@ -75,7 +75,7 @@ namespace Semantic.Types is
             variant: Symbols.Classy
         ) -> NAMED static is
             if isa GENERIC(underlying_type) then
-                let generic = cast GENERIC(underlying_type);
+                let generic = underlying_type;
                 return GENERIC(variant.location, variant, generic.arguments);
             fi
 
@@ -101,7 +101,7 @@ namespace Semantic.Types is
                 return false;
             fi
 
-            let o = cast ONE_OF(other);
+            let o = other;
 
             if _underlying_type !~ o._underlying_type then
                 return false;

--- a/src/syntax/parsers/definitions/union.ghul
+++ b/src/syntax/parsers/definitions/union.ghul
@@ -108,7 +108,7 @@ namespace Syntax.Parsers.Definitions is
                 if arguments? then
                     for member in body do
                         if isa Trees.Definitions.VARIANT(member) then
-                            let variant = cast Trees.Definitions.VARIANT(member);
+                            let variant = member;
 
                             variant.set_arguments(arguments.deep_copy());
                         fi

--- a/src/syntax/parsers/expressions/secondary.ghul
+++ b/src/syntax/parsers/expressions/secondary.ghul
@@ -226,7 +226,7 @@ namespace Syntax.Parsers.Expressions is
                             // error already reported
                             arguments = Trees.Expressions.LIST(start::result.location, Collections.LIST[Trees.Expressions.Expression]());                                
                         elif isa Trees.Expressions.TUPLE(result) then
-                            arguments = cast Trees.Expressions.TUPLE(result).elements;
+                            arguments = result.elements;
                             arguments.rewrite_as_variables();
                         else
                             let elements = Collections.LIST[Trees.Expressions.Expression]();

--- a/src/syntax/parsers/modifiers/list.ghul
+++ b/src/syntax/parsers/modifiers/list.ghul
@@ -18,7 +18,7 @@ namespace Syntax.Parsers.Modifiers is
             let storage_class: Trees.Modifiers.StorageClass mut = default;
 
             if modifier? /\ isa Trees.Modifiers.AccessModifier(modifier) then
-                access_modifier = cast Trees.Modifiers.AccessModifier(modifier);
+                access_modifier = modifier;
                 modifier = modifier_parser.parse(context);
                 if modifier? then
                     end = modifier.location;
@@ -27,7 +27,7 @@ namespace Syntax.Parsers.Modifiers is
 
             if modifier? then
                 if isa Trees.Modifiers.StorageClass(modifier) then
-                    storage_class = cast Trees.Modifiers.StorageClass(modifier);
+                    storage_class = modifier;
                     end = modifier.location;
                 else
                     context.error(modifier.location, "unexpected modifier {modifier} is a storage class: {isa Trees.Modifiers.StorageClass(modifier)}");

--- a/src/syntax/process/add_accessors_for_properties.ghul
+++ b/src/syntax/process/add_accessors_for_properties.ghul
@@ -330,8 +330,8 @@ namespace Syntax.Process is
 
             for definition in `union.body do
                 if isa Definitions.VARIANT(definition) then
-                    let variant = cast Definitions.VARIANT(definition);
-                
+                    let variant = definition;
+
                     if variant.fields.count > 0 then
                         non_unit_variant_count = non_unit_variant_count + 1;
                     else
@@ -349,7 +349,7 @@ namespace Syntax.Process is
 
             for definition in `union.body do
                 if isa Definitions.VARIANT(definition) then
-                    let variant = cast Definitions.VARIANT(definition);
+                    let variant = definition;
 
                     if variant.fields.count > 0 then
                         // this variant has fields so it is not a unit variant
@@ -420,7 +420,7 @@ namespace Syntax.Process is
 
             for definition in `union.body do
                 if isa Definitions.VARIANT(definition) then
-                    let variant = cast Definitions.VARIANT(definition);
+                    let variant = definition;
 
                     variant.body.add(get_typed_equals_method_for_variant(variant, `union));
                     variant.body.add(get_hash_code_method_for_variant(variant));

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -128,7 +128,7 @@ namespace Syntax.Process is
                 return null;
             fi
 
-            let identifier_expr = cast Trees.Expressions.IDENTIFIER(expr);
+            let identifier_expr = expr;
 
             if !identifier_expr.identifier? \/ identifier_expr.identifier.is_qualified then
                 return null;
@@ -140,7 +140,7 @@ namespace Syntax.Process is
                 return null;
             fi
 
-            return cast Semantic.Symbols.Variable(symbol);
+            return symbol;
         si
 
         // Warn when a value is dereferenced through a `T?` receiver —
@@ -227,7 +227,7 @@ namespace Syntax.Process is
                 return false;
             fi
 
-            let one_of = cast Semantic.Types.ONE_OF(receiver_type);
+            let one_of = receiver_type;
             let classy = _condition_analyzer.get_classy_for_narrowing(receiver_type);
 
             if !classy? \/ !classy.is_union then
@@ -268,7 +268,7 @@ namespace Syntax.Process is
                 return null;
             fi
 
-            let one_of = cast Semantic.Types.ONE_OF(receiver_type);
+            let one_of = receiver_type;
 
             let any_variant mut = false;
             for variant in one_of.variants do
@@ -349,7 +349,7 @@ namespace Syntax.Process is
             let symbol = type.find_member(name);
 
             if symbol? /\ isa Semantic.Symbols.FUNCTION_GROUP(symbol) then
-                let function_group = cast Semantic.Symbols.FUNCTION_GROUP(symbol);
+                let function_group = symbol;
 
                 for f in function_group.functions do
                     if f.arguments.count == 0 then
@@ -384,7 +384,7 @@ namespace Syntax.Process is
                     let overload_result =
                         _overload_resolver.resolve(
                             location,
-                            cast Semantic.Symbols.FUNCTION_GROUP(and_symbol),
+                            and_symbol,
                             argument_types,
                             false,
                             false,
@@ -637,7 +637,7 @@ namespace Syntax.Process is
                         for name in v.names do
                             let symbol = find(name);
                             if symbol? /\ isa Semantic.Symbols.Variable(symbol) then
-                                let variable = cast Semantic.Symbols.Variable(symbol);
+                                let variable = symbol;
                                 variable.is_defined = false;
                             fi
                         od
@@ -661,7 +661,7 @@ namespace Syntax.Process is
                             let symbol = find(name);
 
                             if symbol? /\ isa Semantic.Symbols.Variable(symbol) then
-                                _flow.track_deferred(cast Semantic.Symbols.Variable(symbol));
+                                _flow.track_deferred(symbol);
                             fi
                         od
                     fi
@@ -676,7 +676,7 @@ namespace Syntax.Process is
                         let symbol = find(v.name);
 
                         if symbol? /\ isa Semantic.Symbols.Variable(symbol) then
-                            let variable = cast Semantic.Symbols.Variable(symbol); 
+                            let variable = symbol;
                             variable.is_disposed = true;
 
                             let type = variable.type;
@@ -1077,7 +1077,7 @@ namespace Syntax.Process is
                 return false;
             fi
 
-            let variable = cast Semantic.Symbols.Variable(symbol);
+            let variable = symbol;
 
             return variable.add_constraint(rhs_type);
         si
@@ -2015,7 +2015,7 @@ namespace Syntax.Process is
                     fi;
 
                 if isa Trees.Expressions.TUPLE_ELEMENT(v) then
-                    let element = cast Trees.Expressions.TUPLE_ELEMENT(v);
+                    let element = v;
 
                     seen_any_named = true;
                     names.add(element.name.name);
@@ -2533,7 +2533,7 @@ namespace Syntax.Process is
                 `new.type_expression.check_is_not_void(_logger, "cannot use void type here");
             fi
 
-            let named_type = cast Semantic.Types.NAMED(type);
+            let named_type = type;
             let type_symbol mut = named_type.symbol;
 
             let symbol = named_type.scope.find_direct("init");
@@ -2596,7 +2596,7 @@ namespace Syntax.Process is
             let is_directly_owned mut = false;
 
             if isa Semantic.Symbols.GENERIC(type_symbol) /\ isa Semantic.Symbols.Symbol(function.owner) then
-                is_directly_owned = cast Semantic.Symbols.GENERIC(type_symbol) =~ cast Semantic.Symbols.Symbol(function.owner);
+                is_directly_owned = type_symbol =~ cast Semantic.Symbols.Symbol(function.owner);
             else
                 is_directly_owned = type_symbol == function.owner;
             fi
@@ -2845,7 +2845,7 @@ namespace Syntax.Process is
             let is_directly_owned mut = false;
 
             if isa Semantic.Symbols.GENERIC(type_symbol) /\ isa Semantic.Symbols.Symbol(function.owner) then
-                is_directly_owned = cast Semantic.Symbols.GENERIC(type_symbol) =~ cast Semantic.Symbols.Symbol(function.owner);
+                is_directly_owned = type_symbol =~ cast Semantic.Symbols.Symbol(function.owner);
             else
                 is_directly_owned = type_symbol == function.owner;
             fi
@@ -2858,15 +2858,9 @@ namespace Syntax.Process is
             _symbol_use_locations.add_symbol_use(right_location, type_symbol.root_unspecialized_symbol);
 
             if !was_generic_on_entry then
-                let constructed = cast Semantic.Types.GENERIC(type);
-
-                if constructed? then
-                    let generic_symbol = cast Semantic.Symbols.GENERIC(constructed.symbol);
-
-                    if generic_symbol? then
-                        let classy = cast Semantic.Symbols.Classy(generic_symbol.symbol);
-
-                        if classy? then
+                if let constructed: Semantic.Types.GENERIC = type then
+                    if let generic_symbol: Semantic.Symbols.GENERIC = constructed.symbol then
+                        if let classy: Semantic.Symbols.Classy = generic_symbol.symbol then
                             classy.check_argument_constraints(location, _logger, constructed.arguments);
                         fi
                     fi
@@ -2897,7 +2891,7 @@ namespace Syntax.Process is
                 let overload_result =
                     _overload_resolver.resolve(
                         unary.location,
-                        cast Semantic.Symbols.FUNCTION_GROUP(function_group),
+                        function_group,
                         arguments,
                         false,
                         unary.right.value.is_consumable, // FIXME: this doesn't seem right
@@ -2986,7 +2980,7 @@ namespace Syntax.Process is
             let binary_function_symbol = find(binary.operation.name);
 
             if binary_function_symbol? /\ isa Semantic.Symbols.FUNCTION_GROUP(binary_function_symbol) then
-                binary_function_group = cast Semantic.Symbols.FUNCTION_GROUP(binary_function_symbol);
+                binary_function_group = binary_function_symbol;
 
                 let use logger_snapshot = _logger.speculate_then_backtrack();
 
@@ -3013,7 +3007,7 @@ namespace Syntax.Process is
                     binary.left.value.type.find_member(binary.operation.name);
 
                 if member_function_symbol? /\ isa Semantic.Symbols.FUNCTION_GROUP(member_function_symbol) then
-                    member_function_group = cast Semantic.Symbols.FUNCTION_GROUP(member_function_symbol);
+                    member_function_group = member_function_symbol;
     
                     let use logger_snapshot = _logger.speculate_then_backtrack();
 
@@ -3087,7 +3081,7 @@ namespace Syntax.Process is
                     value = function.call(binary.location, null, Collections.LIST[Value]([binary.left.value, binary.right.value]), force_type,_function_caller);
 
                     if isa Call.INNATE(value) then
-                        let innate_value = cast Call.INNATE(value);
+                        let innate_value = value;
 
                         innate_value.actual_operation = binary.actual_operation;
 
@@ -3159,7 +3153,7 @@ namespace Syntax.Process is
                     index.index.value? /\
                     index.index.value.type?
                 then
-                    let placeholder = cast Semantic.Types.INFERRED_VARIABLE_TYPE(type);
+                    let placeholder = type;
                     let constraint = Semantic.INDEX_CONSTRAINT(index.index.value.type);
 
                     if placeholder.origin.add_constraint(constraint) then
@@ -3177,7 +3171,7 @@ namespace Syntax.Process is
                     return;
                 fi
 
-                let named_type = cast Semantic.Types.NAMED(type);
+                let named_type = type;
 
                 let function_name: string mut;
                 let arguments: Collections.LIST[Value] mut;
@@ -3311,7 +3305,7 @@ namespace Syntax.Process is
                 // mark_consumed_any drives the retry loop to re-walk
                 // the body with the resolved type (if any).
                 if isa Semantic.Types.INFERRED_VARIABLE_TYPE(type) then
-                    let placeholder = cast Semantic.Types.INFERRED_VARIABLE_TYPE(type);
+                    let placeholder = type;
 
                     if placeholder.origin.add_constraint(Semantic.MEMBER_CONSTRAINT(member.identifier.name)) then
                         _logger.mark_consumed_any();
@@ -3339,7 +3333,7 @@ namespace Syntax.Process is
                     return;
                 fi
 
-                let named_type = cast Semantic.Types.NAMED(type);
+                let named_type = type;
 
                 if named_type.scope == null then
                     _logger.poison(member.left.location, "member left type has no type: {type}");
@@ -3722,7 +3716,7 @@ namespace Syntax.Process is
                         // for not re-deriving the LUB every iter
                         // while it's stable.
                         if isa Semantic.Symbols.Variable(symbol) then
-                            let variable = cast Semantic.Symbols.Variable(symbol);
+                            let variable = symbol;
                             let inferred = variable.try_get_inferred_type();
 
                             if inferred? /\ !inferred.is_sentinel then
@@ -3784,7 +3778,7 @@ namespace Syntax.Process is
             // type is fixed and the lambda's RHS placeholder is
             // forced to resolve via some other use.
             if isa Semantic.Types.INFERRED_VARIABLE_TYPE(from_type) then
-                let placeholder = cast Semantic.Types.INFERRED_VARIABLE_TYPE(from_type);
+                let placeholder = from_type;
                 let constraint = Semantic.DESTRUCTURE_CONSTRAINT(left.elements.count);
 
                 if placeholder.origin.add_constraint(constraint) then
@@ -4265,7 +4259,7 @@ namespace Syntax.Process is
                 if arg_expr? /\ arg_expr.value? /\ arg_expr.value.type? then
                     actual = arg_expr.value.type;
                 elif isa Trees.Expressions.IDENTIFIER(arg_expr) then
-                    let id_expr = cast Trees.Expressions.IDENTIFIER(arg_expr);
+                    let id_expr = arg_expr;
                     let sym = find(id_expr.identifier);
                     if sym? then
                         actual = sym.type;
@@ -4633,7 +4627,7 @@ namespace Syntax.Process is
             // type's is_error). The next iteration resolves x and
             // x.length cleanly.
             if isa Semantic.Types.NAMED(function_type) then
-                let ft_named = cast Semantic.Types.NAMED(function_type);
+                let ft_named = function_type;
                 let ft_args = ft_named.arguments;
                 let formal_count =
                     if function_type.is_function then
@@ -4648,7 +4642,7 @@ namespace Syntax.Process is
                         let actual = argument_types[i];
 
                         if formal? /\ actual? /\ isa Semantic.Types.INFERRED_VARIABLE_TYPE(formal) then
-                            let placeholder = cast Semantic.Types.INFERRED_VARIABLE_TYPE(formal);
+                            let placeholder = formal;
                             if placeholder.origin.add_constraint(actual) then
                                 _logger.mark_consumed_any();
                             fi
@@ -4669,7 +4663,7 @@ namespace Syntax.Process is
                 // resolved to a function type and the call can be compiled.
                 // Required for mutually-recursive lambdas where each side's
                 // signature depends on the other.
-                let placeholder = cast Semantic.Types.INFERRED_VARIABLE_TYPE(function_type);
+                let placeholder = function_type;
 
                 // Skip the speculative function-shape constraint
                 // when the LUB already has a candidate (typically
@@ -4719,7 +4713,7 @@ namespace Syntax.Process is
                 return;
             fi
 
-            let function_generic_type = cast Semantic.Types.NAMED(function_type);
+            let function_generic_type = function_type;
 
             let function_type_arguments = function_generic_type.arguments;
 
@@ -4842,7 +4836,7 @@ namespace Syntax.Process is
                         // deferred-init local before it is assigned
                         // on every path reaching here.
                         if _warn_definite_assignment /\ isa Semantic.Symbols.Variable(symbol) then
-                            let variable = cast Semantic.Symbols.Variable(symbol);
+                            let variable = symbol;
 
                             if _flow.is_tracked(variable) /\ !_flow.is_assigned(variable) then
                                 _logger.warn(identifier.location, "{variable.name} may be used before it is assigned");
@@ -5305,7 +5299,7 @@ namespace Syntax.Process is
                 fi
             od
 
-            let classy = cast Semantic.Symbols.Classy(symbol);
+            let classy = symbol;
 
             let actual_arguments = arguments | .map(
                 // FIXME type inference issue

--- a/src/syntax/process/completer.ghul
+++ b/src/syntax/process/completer.ghul
@@ -81,7 +81,7 @@ namespace Syntax.Process is
             let identifier = `use.`use;
 
             if identifier? /\ identifier.location.contains(_target_line, _target_column) /\ isa Trees.Identifiers.QUALIFIED(identifier) then                
-                add_qualified_identifier_matches(cast Trees.Identifiers.QUALIFIED(identifier));
+                add_qualified_identifier_matches(identifier);
             else
                 add_scope_matches();
             fi
@@ -156,7 +156,7 @@ namespace Syntax.Process is
                 return;
             fi
 
-            cast Semantic.Symbols.Scoped(symbol).find_member_matches("", _results);
+            symbol.find_member_matches("", _results);
 
             _namespaces.find_namespace_matches(namespace_name, _results);
 

--- a/src/syntax/process/condition_analysis.ghul
+++ b/src/syntax/process/condition_analysis.ghul
@@ -48,17 +48,17 @@ namespace Syntax.Process is
                 return null;
             fi
 
-            let symbol mut = (cast Semantic.Types.NAMED(type)).symbol;
+            let symbol mut = type.symbol;
 
             if isa Semantic.Symbols.GENERIC(symbol) then
-                symbol = (cast Semantic.Symbols.GENERIC(symbol)).symbol;
+                symbol = symbol.symbol;
             fi
 
             if !isa Semantic.Symbols.Classy(symbol) then
                 return null;
             fi
 
-            return cast Semantic.Symbols.Classy(symbol);
+            return symbol;
         si
 
         // Pick the type that carries the receiver's generic args for
@@ -71,11 +71,11 @@ namespace Syntax.Process is
             fi
 
             if isa Semantic.Types.ONE_OF(receiver_type) then
-                return (cast Semantic.Types.ONE_OF(receiver_type)).underlying_type;
+                return receiver_type.underlying_type;
             fi
 
             if isa Semantic.Types.NAMED(receiver_type) then
-                return cast Semantic.Types.NAMED(receiver_type);
+                return receiver_type;
             fi
 
             return null;
@@ -103,7 +103,7 @@ namespace Syntax.Process is
 
             let one_of: Semantic.Types.ONE_OF mut = default;
             if isa Semantic.Types.ONE_OF(receiver_type) then
-                one_of = cast Semantic.Types.ONE_OF(receiver_type);
+                one_of = receiver_type;
             fi
 
             for s in classy.symbols do
@@ -195,7 +195,7 @@ namespace Syntax.Process is
             fi
 
             if isa Trees.Expressions.BINARY(cond) then
-                let binary = cast Trees.Expressions.BINARY(cond);
+                let binary = cond;
 
                 if binary.operation? /\ binary.left? /\ binary.right? then
                     let op = binary.operation.name;
@@ -219,7 +219,7 @@ namespace Syntax.Process is
                     fi
                 fi
             elif isa Trees.Expressions.UNARY(cond) then
-                let unary = cast Trees.Expressions.UNARY(cond);
+                let unary = cond;
 
                 if unary.operation? /\ unary.operation.name =~ "!" /\ unary.right? then
                     let inner = analyze_condition(unary.right, in_env);
@@ -228,11 +228,11 @@ namespace Syntax.Process is
                     return CONDITION_FACTS(inner.else_env, inner.then_env);
                 fi
             elif isa Trees.Expressions.ISA(cond) then
-                return _analyze_isa(cast Trees.Expressions.ISA(cond), in_env);
+                return _analyze_isa(cond, in_env);
             elif isa Trees.Expressions.MEMBER(cond) then
-                return _analyze_member(cast Trees.Expressions.MEMBER(cond), in_env);
+                return _analyze_member(cond, in_env);
             elif isa Trees.Expressions.HAS_VALUE(cond) then
-                return _analyze_has_value(cast Trees.Expressions.HAS_VALUE(cond), in_env);
+                return _analyze_has_value(cond, in_env);
             fi
 
             return _opaque(in_env);

--- a/src/syntax/process/declare_symbols.ghul
+++ b/src/syntax/process/declare_symbols.ghul
@@ -113,7 +113,7 @@ namespace Syntax.Process is
                     return;
                 fi
 
-                let il_name = cast Expressions.Literals.STRING(argument).value_string;
+                let il_name = argument.value_string;
 
                 let definition mut = pragma.definition;
 
@@ -126,7 +126,7 @@ namespace Syntax.Process is
                 // FIXME: IL name pragmas not consistently applied to properties and fields 552
                 if symbol? then
                     if isa Semantic.Symbols.Property(symbol) then
-                        let property = cast Semantic.Symbols.Property(symbol);
+                        let property = symbol;
 
                         if name =~ "IL.name.read" then
                             property.read_function_il_name_override = il_name;
@@ -178,11 +178,11 @@ namespace Syntax.Process is
                 // node classes to represent them:
                 for a in arguments do                    
                     if isa Trees.TypeExpressions.NAMED(a) then
-                        let named = cast Trees.TypeExpressions.NAMED(a);
+                        let named = a;
 
                         result.add(named.name.name);
                     elif isa Trees.TypeExpressions.NAMED_TUPLE_ELEMENT(a) then
-                        let named = cast Trees.TypeExpressions.NAMED_TUPLE_ELEMENT(a);
+                        let named = a;
 
                         result.add(named.name.name);
                     elif !a.is_poisoned then
@@ -212,12 +212,12 @@ namespace Syntax.Process is
                     let name: string mut = default;
 
                     if isa Trees.TypeExpressions.NAMED(a) then
-                        let named = cast Trees.TypeExpressions.NAMED(a);
+                        let named = a;
                         name = named.name.name;
 
                         s = current_declaration_context.declare_type(named.name.location, name, index, _symbol_definition_listener);
                     elif isa Trees.TypeExpressions.NAMED_TUPLE_ELEMENT(a) then
-                        let named = cast Trees.TypeExpressions.NAMED_TUPLE_ELEMENT(a);
+                        let named = a;
                         name = named.name.name;
 
                         s = current_declaration_context.declare_type(named.name.location, named.name.name, index, _symbol_definition_listener);
@@ -364,7 +364,7 @@ namespace Syntax.Process is
                 let i = enum_member.initializer;
 
                 if isa Trees.Expressions.Literals.Literal(i) then
-                    value = cast Trees.Expressions.Literals.Literal(i).value_string;
+                    value = i.value_string;
                 else
                     _logger.error(i.location, "enum member initializer must be an integer literal");
                 fi
@@ -427,7 +427,7 @@ namespace Syntax.Process is
             let symbol = symbol_for(function);
 
             if symbol? /\ isa Semantic.Symbols.Function(symbol) then
-                let function_symbol = cast Semantic.Symbols.Function(symbol);
+                let function_symbol = symbol;
 
                 if property? then
                     if function.arguments.variables.count == 0 then
@@ -550,9 +550,7 @@ namespace Syntax.Process is
                 let declared = current_declaration_context.declare_variable(name.location, name.name, variable.is_static, _symbol_definition_listener);
 
                 if variable.is_mutable_marked then
-                    let v = cast Semantic.Symbols.Variable(declared);
-
-                    if v? then
+                    if let v: Semantic.Symbols.Variable = declared then
                         v.is_mutable_marked = true;
                     fi
                 fi
@@ -674,7 +672,7 @@ namespace Syntax.Process is
             let symbol = symbol_for(function);
 
             if symbol? /\ isa Semantic.Symbols.Function(symbol) then
-                let function_symbol = cast Semantic.Symbols.Function(symbol);
+                let function_symbol = symbol;
 
                 let arguments = function.arguments.expressions;
 

--- a/src/syntax/process/generate_il.ghul
+++ b/src/syntax/process/generate_il.ghul
@@ -514,9 +514,7 @@ namespace Syntax.Process is
         pre(function: Definitions.FUNCTION) -> bool is
             let symbol = function_for(function);
 
-            let global_function = cast Semantic.Symbols.GLOBAL_FUNCTION(symbol);
-
-            if global_function? then
+            if let global_function: Semantic.Symbols.GLOBAL_FUNCTION = symbol then
                 gen_globals_class_open(cast Semantic.Symbols.NAMESPACE(global_function.owner));
             fi
 
@@ -544,7 +542,7 @@ namespace Syntax.Process is
             leave_block();
 
             if symbol? /\ isa Semantic.Symbols.Function(symbol) then
-                let function_symbol = cast Semantic.Symbols.Function(symbol);
+                let function_symbol = symbol;
 
                 if !function_symbol.is_abstract then
                     if function.body? /\ isa Bodies.NULL(function.body) then
@@ -615,14 +613,10 @@ namespace Syntax.Process is
             // need wrapping when at namespace scope.
             let globals_namespace: Semantic.Symbols.NAMESPACE mut = default;
 
-            let global_property = cast Semantic.Symbols.GLOBAL_PROPERTY(symbol);
-
-            if global_property? then
+            if let global_property: Semantic.Symbols.GLOBAL_PROPERTY = symbol then
                 globals_namespace = cast Semantic.Symbols.NAMESPACE(global_property.owner);
             else
-                let global_variable = cast Semantic.Symbols.GLOBAL_VARIABLE(symbol);
-
-                if global_variable? then
+                if let global_variable: Semantic.Symbols.GLOBAL_VARIABLE = symbol then
                     globals_namespace = cast Semantic.Symbols.NAMESPACE(global_variable.owner);
                 fi
             fi
@@ -673,7 +667,7 @@ namespace Syntax.Process is
                     return;
                 fi
 
-                let file_name = cast Expressions.Literals.STRING(argument).value_string;
+                let file_name = argument.value_string;
 
                 if is_enter then
                     _il_output_depth = _il_output_depth + 1;
@@ -1682,7 +1676,7 @@ namespace Syntax.Process is
                 args.add(expression.value);
 
                 if isa Expressions.Literals.STRING(expression) then
-                    if cast Expressions.Literals.STRING(expression).value_string.length == 0 then
+                    if expression.value_string.length == 0 then
                         continue;
                     fi
 

--- a/src/syntax/process/loop_assignment_collector.ghul
+++ b/src/syntax/process/loop_assignment_collector.ghul
@@ -40,7 +40,7 @@ namespace Syntax.Process is
                 return;
             fi
 
-            let identifier = cast Trees.Expressions.IDENTIFIER(expr);
+            let identifier = expr;
 
             if identifier.identifier? /\ identifier.identifier.name? then
                 names.add(identifier.identifier.name);

--- a/src/syntax/process/printer/base.ghul
+++ b/src/syntax/process/printer/base.ghul
@@ -137,7 +137,7 @@ namespace Syntax.Process.Printer is
 
                 // yuck...
                 if isa Variables.VARIABLE(d) then
-                    let variable = cast Variables.VARIABLE(d);
+                    let variable = d;
                     if variable.name? /\ variable.name.name? /\ variable.name.name.starts_with("$") then
                         write_line(";");
                     fi

--- a/src/syntax/process/resolve_ancestors.ghul
+++ b/src/syntax/process/resolve_ancestors.ghul
@@ -93,7 +93,7 @@ namespace Syntax.Process is
 
                     if ancestor_type? then
                         if isa Semantic.Types.NAMED(ancestor_type) then
-                            let ancestor_named_type = cast Semantic.Types.NAMED(ancestor_type);                            
+                            let ancestor_named_type = ancestor_type;
 
                             if ancestor_named_type.symbol? /\ ancestor_named_type.symbol.is_trait then
                                 trait_symbol.add_ancestor(ancestor_named_type);
@@ -132,7 +132,7 @@ namespace Syntax.Process is
 
                     if ancestor_type? then
                         if isa Semantic.Types.NAMED(ancestor_type) then
-                            let ancestor_named_type = cast Semantic.Types.NAMED(ancestor_type);
+                            let ancestor_named_type = ancestor_type;
 
                             if ancestor_named_type.symbol? /\ ancestor_named_type.symbol.is_trait then
                                 struct_symbol.add_ancestor(ancestor_named_type);

--- a/src/syntax/process/resolve_type_expressions.ghul
+++ b/src/syntax/process/resolve_type_expressions.ghul
@@ -104,7 +104,7 @@ namespace Syntax.Process is
                     fi
                 od
 
-                let classy = cast Semantic.Symbols.Classy(symbol);
+                let classy = symbol;
 
                 generic.type = Semantic.Types.GENERIC(
                     generic.location,
@@ -138,7 +138,7 @@ namespace Syntax.Process is
             let from: IR.Values.Value mut = default;
 
             if isa IR.Values.Load.SYMBOL(left_value) then
-                let load = cast IR.Values.Load.SYMBOL(left_value);
+                let load = left_value;
 
                 from = load.from;
             fi

--- a/src/syntax/process/resolve_uses.ghul
+++ b/src/syntax/process/resolve_uses.ghul
@@ -58,9 +58,9 @@ namespace Syntax.Process is
                             _logger.error(u.`use.location, "duplicate use");                        
                         fi
                     elif u.name? then
-                        namespace_scope.add(u.name.name, cast Semantic.Symbols.NAMESPACE(used_symbol));
+                        namespace_scope.add(u.name.name, used_symbol);
                     else
-                        namespace_scope.add(cast Semantic.Symbols.NAMESPACE(used_symbol));
+                        namespace_scope.add(used_symbol);
                     fi
                 elif used_symbol.is_function_group then
                     let fg = cast Semantic.Symbols.FUNCTION_GROUP(used_symbol);

--- a/src/syntax/trees/definitions/list.ghul
+++ b/src/syntax/trees/definitions/list.ghul
@@ -14,7 +14,7 @@ namespace Syntax.Trees.Definitions is
                 let d_without_pragmas = d.without_pragmas;
 
                 if isa USE(d_without_pragmas) then
-                    result.add(cast USE(d_without_pragmas));
+                    result.add(d_without_pragmas);
                 fi
             od
             


### PR DESCRIPTION
Technical:

- Drop explicit `cast T(x)` calls made redundant by flow-sensitive type narrowing — where an `isa` test or a divergent guard already establishes a class type for a local, parameter or loop variable, the bare identifier now suffices (~130 sites across 40 files).
- Collapse the `let v = cast T(e); if v? then …` idiom to `if let v: T = e then …` (18 sites).