### PR TITLE
Annotate the compiler source with nullable types

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.12.13",
+      "version": "0.12.14",
       "commands": [
         "ghul-compiler"
       ],

--- a/src/analysis/command_despatcher.ghul
+++ b/src/analysis/command_despatcher.ghul
@@ -102,7 +102,7 @@ namespace Analysis is
             return false;
         si
 
-        read_command() -> string is
+        read_command() -> string? is
             let desynchronized mut = false;
 
             do

--- a/src/analysis/command_handlers.ghul
+++ b/src/analysis/command_handlers.ghul
@@ -277,7 +277,7 @@ namespace Analysis is
         _timers: TIMERS;
         _compiler: COMPILER;
         _build_flags: BUILD_FLAGS;
-        _library_files: Iterable[string];
+        _library_files: Iterable[string]?;
         _symbol_table: Semantic.SYMBOL_TABLE;
         
         _source_files_by_path: Collections.MutableMap[string,SOURCE_FILE];
@@ -305,7 +305,7 @@ namespace Analysis is
             _source_files_by_path = Collections.MAP[string,SOURCE_FILE]();
         si
 
-        find_source_file(path: string) -> SOURCE_FILE =>
+        find_source_file(path: string) -> SOURCE_FILE? =>
             if _source_files_by_path.contains_key(path) then
                 _source_files_by_path[path]
             else

--- a/src/compiler/source_file.ghul
+++ b/src/compiler/source_file.ghul
@@ -10,7 +10,7 @@ namespace Compiler is
         // this file against the current symbol table. Reset to null by
         // COMPILER.clear_symbols when the table is reallocated; advanced by
         // the build loop after each successful pass.apply.
-        compiled_through: Pass public;
+        compiled_through: Pass? public;
 
         init(
             build_flags: BUILD_FLAGS,

--- a/src/driver/path_config.ghul
+++ b/src/driver/path_config.ghul
@@ -30,11 +30,11 @@ namespace Driver is
             fi
         si
 
-        _ilasm_path: string;        
+        _ilasm_path: string?;        
 
         ilasm_path: string is
             if _ilasm_path? then
-                return _ilasm_path;
+                return _ilasm_path!;
             fi
             
             let os: string mut;
@@ -76,7 +76,7 @@ namespace Driver is
                 System.Environment.exit(1);
             fi
 
-            return _ilasm_path;
+            return _ilasm_path!;
         si
 
         init() is
@@ -127,7 +127,7 @@ namespace Driver is
             return directory;
         si
         
-        _try_find_ilasm_package(os: string, architecture: string, file_extension: string) -> string is
+        _try_find_ilasm_package(os: string, architecture: string, file_extension: string) -> string? is
             let match = _ilasm_package_paths | .find(p => p.contains("{os}-{architecture}"));
 
             if match.has_value then

--- a/src/ir/value_converter.ghul
+++ b/src/ir/value_converter.ghul
@@ -51,7 +51,7 @@ namespace IR is
             _instructions[type.symbol.qualified_name] = instruction;
         si        
 
-        get_instruction(type: Type) -> string is
+        get_instruction(type: Type) -> string? is
             complete_initialization();
 
             if !type? \/ !type.symbol? then

--- a/src/ir/values/wrapper.ghul
+++ b/src/ir/values/wrapper.ghul
@@ -4,7 +4,7 @@ namespace IR.Values is
     class WRAPPER: Value is
         has_type: bool => type?;
         has_address: bool => value.has_address;
-        type: Type => if value? then value.type else null fi;
+        type: Type? => if value? then value.type else null fi;
         value: Value public;
 
         init(

--- a/src/lexical/tokenizer.ghul
+++ b/src/lexical/tokenizer.ghul
@@ -293,7 +293,7 @@ namespace Lexical is
 
             _cursor.start();
 
-            let _buffer: System.Text.StringBuilder mut = null;
+            let _buffer mut = System.Text.StringBuilder();
 
             if _expect_format_string then
                 _expect_format_string = false;

--- a/src/logging/diagnostics_store.ghul
+++ b/src/logging/diagnostics_store.ghul
@@ -51,7 +51,7 @@ namespace Logging is
         init() is
         si
 
-        format(diagnostic: DIAGNOSTIC_MESSAGE) -> string is
+        format(diagnostic: DIAGNOSTIC_MESSAGE) -> string? is
             let location = diagnostic.location;
             let severity = 
                 if diagnostic.is_fatal then
@@ -83,7 +83,7 @@ namespace Logging is
         init() is
         si
 
-        format(diagnostic: DIAGNOSTIC_MESSAGE) -> string is
+        format(diagnostic: DIAGNOSTIC_MESSAGE) -> string? is
             if diagnostic.is_hint then
                 return null;
             fi

--- a/src/logging/logger.ghul
+++ b/src/logging/logger.ghul
@@ -156,27 +156,27 @@ namespace Logging is
     si
 
     struct LOGGER_SPECULATE_THEN_COMMIT: Disposable is
-        _logger: Logger;
+        _logger: Logger?;
 
-        has_consumed_any: bool => _logger.has_consumed_any;
-        has_consumed_error: bool => _logger.has_consumed_error;
+        has_consumed_any: bool => _logger!.has_consumed_any;
+        has_consumed_error: bool => _logger!.has_consumed_error;
 
-        any_errors: bool => _logger.any_errors;
+        any_errors: bool => _logger!.any_errors;
 
         is_speculating: bool => _logger != null;
 
         init(logger: Logger) is
             _logger = logger;
-            _logger.speculate();
+            _logger!.speculate();
         si
 
         backtrack() -> DIAGNOSTICS_STATE is
-            let result = _logger.roll_back();
+            let result = _logger!.roll_back();
             _logger = null;
             return result;
         si
 
-        backtrack_if_speculating() -> DIAGNOSTICS_STATE is
+        backtrack_if_speculating() -> DIAGNOSTICS_STATE? is
             if _logger != null then
                 return backtrack();
             else
@@ -185,13 +185,13 @@ namespace Logging is
         si
 
         backtrack_and_restart() -> DIAGNOSTICS_STATE is
-            let result = _logger.roll_back();
-            _logger.speculate();
+            let result = _logger!.roll_back();
+            _logger!.speculate();
             return result;
         si
 
         commit() is
-            _logger.commit();
+            _logger!.commit();
             _logger = null;
         si
 
@@ -208,34 +208,34 @@ namespace Logging is
     si
     
     struct LOGGER_SPECULATE_THEN_BACKTRACK: Disposable is
-        _logger: Logger;
+        _logger: Logger?;
 
-        has_consumed_any: bool => _logger.has_consumed_any;
-        has_consumed_error: bool => _logger.has_consumed_error;
+        has_consumed_any: bool => _logger!.has_consumed_any;
+        has_consumed_error: bool => _logger!.has_consumed_error;
 
-        any_errors: bool => _logger.any_errors;
+        any_errors: bool => _logger!.any_errors;
 
         is_speculating: bool => _logger != null;
 
         init(logger: Logger) is
             _logger = logger;
-            _logger.speculate();
+            _logger!.speculate();
         si
 
         backtrack() -> DIAGNOSTICS_STATE is
-            let result = _logger.roll_back();
+            let result = _logger!.roll_back();
             _logger = null;
             return result;
         si
 
         backtrack_and_restart() -> DIAGNOSTICS_STATE is
-            let result = _logger.roll_back();
-            _logger.speculate();
+            let result = _logger!.roll_back();
+            _logger!.speculate();
             return result;
         si
 
         commit() is
-            _logger.commit();
+            _logger!.commit();
             _logger = null;
         si
 

--- a/src/logging/logger.ghul
+++ b/src/logging/logger.ghul
@@ -201,7 +201,7 @@ namespace Logging is
 
         dispose() is
             if _logger != null then
-                _logger.commit();
+                _logger!.commit();
                 _logger = null;
             fi
         si
@@ -245,7 +245,7 @@ namespace Logging is
 
         dispose() is
             if _logger != null then
-                _logger.roll_back();
+                _logger!.roll_back();
                 _logger = null;
             fi
         si

--- a/src/semantic/closure_arg_resolver.ghul
+++ b/src/semantic/closure_arg_resolver.ghul
@@ -141,8 +141,8 @@ namespace Semantic is
             let inferred = symbol.try_get_inferred_type();
 
             if inferred? /\ !inferred.is_sentinel then
-                symbol.set_type(inferred);
-                return inferred;
+                symbol.set_type(inferred!);
+                return inferred!;
             fi
 
             _logger.error(a.location, "cannot infer type here");

--- a/src/semantic/dotnet/symbol_factory.ghul
+++ b/src/semantic/dotnet/symbol_factory.ghul
@@ -95,7 +95,7 @@ namespace Semantic.DotNet is
             _symbol_table = symbol_table;
         si
 
-        create_symbol(type_details: TYPE_DETAILS) -> Symbols.Scoped is
+        create_symbol(type_details: TYPE_DETAILS) -> Symbols.Scoped? is
             try
                 let dotnet_type = type_details.dotnet_type;
 
@@ -356,7 +356,7 @@ namespace Semantic.DotNet is
             indexers: SET[System.Reflection.MethodInfo],
             methods: LIST[(function: Symbols.Function, method_info: MethodInfo)],
             member: MemberInfo
-        ) -> Symbols.Symbol
+        ) -> Symbols.Symbol?
         is
             let member_type = member.member_type;
 

--- a/src/semantic/dotnet/symbol_table.ghul
+++ b/src/semantic/dotnet/symbol_table.ghul
@@ -85,7 +85,7 @@ namespace Semantic.DotNet is
             od
         si
 
-        get_symbol(ghul_name: string) -> Symbols.Scoped is
+        get_symbol(ghul_name: string) -> Symbols.Scoped? is
             let result: Symbols.Scoped mut = default;
             
             if _symbol_store.try_get_symbol(ghul_name, result ref) then
@@ -106,7 +106,7 @@ namespace Semantic.DotNet is
             return null;
         si
         
-        get_symbol(type: TYPE) -> Symbols.Scoped is
+        get_symbol(type: TYPE) -> Symbols.Scoped? is
             let result mut = _symbol_store.get_symbol(type);
 
             if result? then
@@ -161,7 +161,7 @@ namespace Semantic.DotNet is
             return create_symbol(type_details);
         si
 
-        create_symbol(type_details: TYPE_DETAILS) -> Symbols.Scoped is
+        create_symbol(type_details: TYPE_DETAILS) -> Symbols.Scoped? is
             let result = _symbol_factory.create_symbol(type_details);
 
             if !result? then

--- a/src/semantic/dotnet/tuple_element_names.ghul
+++ b/src/semantic/dotnet/tuple_element_names.ghul
@@ -14,7 +14,7 @@ namespace Semantic.DotNet is
         // The flattened element-name array declared by a
         // TupleElementNamesAttribute among `attributes`, or null when
         // there is none. A null entry marks an unnamed element.
-        read(attributes: Iterable[ATTRIBUTE_DATA]) -> List[string] static is
+        read(attributes: Iterable[ATTRIBUTE_DATA]) -> List[string]? static is
             if !attributes? then
                 return null;
             fi
@@ -40,7 +40,7 @@ namespace Semantic.DotNet is
 
         // The single `string[]` constructor argument surfaces as a
         // collection of CustomAttributeTypedArgument, one per element.
-        _read_names(argument: TYPED_ARGUMENT) -> List[string] static is
+        _read_names(argument: TYPED_ARGUMENT) -> List[string]? static is
             let elements = cast Iterable[TYPED_ARGUMENT](argument.value);
 
             if !elements? then

--- a/src/semantic/dotnet/type_details_lookup.ghul
+++ b/src/semantic/dotnet/type_details_lookup.ghul
@@ -142,7 +142,7 @@ namespace Semantic.DotNet is
             return result;
         si
 
-        get_type_details_by_ghul_namespace_and_symbol_name(namespace_name: string, name: string) -> TYPE_DETAILS is
+        get_type_details_by_ghul_namespace_and_symbol_name(namespace_name: string, name: string) -> TYPE_DETAILS? is
             let search_list = get_all_type_details_in_ghul_namespace(namespace_name);
 
             if !search_list? then

--- a/src/semantic/dotnet/type_name.ghul
+++ b/src/semantic/dotnet/type_name.ghul
@@ -4,7 +4,7 @@ namespace Semantic.DotNet is
     struct TYPE_NAME is
         qualified_name: string;
 
-        namespace_name: string is
+        namespace_name: string? is
             let last_dot_index = qualified_name.last_index_of('.');
 
             if last_dot_index >= 0 then

--- a/src/semantic/least_upper_bound_map.ghul
+++ b/src/semantic/least_upper_bound_map.ghul
@@ -18,8 +18,8 @@ namespace Semantic is
         types: LIST[Type];
         element_names: LIST[string];
 
-        result: MAP[Symbol,LIST[Type]];
-        current: MAP[Symbol,LIST[Type]];
+        result: MAP[Symbol,LIST[Type]]?;
+        current: MAP[Symbol,LIST[Type]]?;
 
         init() is
             types = LIST[Type]();
@@ -90,7 +90,7 @@ namespace Semantic is
         // null if the two aren't shape-compatible. At each position the
         // non-placeholder side wins; recurses through generic args to
         // handle nested cases like Function[Function[?, int], bool].
-        _try_merge_per_position(a: Type, b: Type) -> Type is
+        _try_merge_per_position(a: Type, b: Type) -> Type? is
             if !a? then return b; fi
             if !b? then return a; fi
 
@@ -197,7 +197,7 @@ namespace Semantic is
         _try_merge_through_shared_ancestor(
             ga: Types.GENERIC, gb: Types.GENERIC,
             sa: Symbols.GENERIC, sb: Symbols.GENERIC
-        ) -> Types.Type is
+        ) -> Types.Type? is
             if !sa.ancestors? \/ !sb.ancestors? then
                 return null;
             fi
@@ -246,7 +246,7 @@ namespace Semantic is
             return null;
         si
 
-        _try_merge_element_name(name_a: string mut, name_b: string mut, arg_a: Types.Type, arg_b: Types.Type) -> string is
+        _try_merge_element_name(name_a: string? mut, name_b: string? mut, arg_a: Types.Type, arg_b: Types.Type) -> string? is
             // Auto-generated positional names like `0 / `1 don't carry
             // user intent; treat them as absent.
             if name_a? /\ name_a.starts_with('`') then name_a = null; fi
@@ -279,7 +279,7 @@ namespace Semantic is
             fi
         si
 
-        get_result() -> Type is
+        get_result() -> Type? is
             if types.count == 0 then
                 return null;
             fi
@@ -335,7 +335,7 @@ namespace Semantic is
             fi
         si
 
-        _try_get_best_assignable() -> Type is
+        _try_get_best_assignable() -> Type? is
             let best: Type mut = default;
 
             for type in types do
@@ -351,7 +351,7 @@ namespace Semantic is
             return _with_element_names(best);
         si
 
-        _try_get_best_element_type() -> Type is
+        _try_get_best_element_type() -> Type? is
             _mode = LUB_MODE.ONLY_ELEMENT_TYPES;
 
             for type in types do
@@ -367,7 +367,7 @@ namespace Semantic is
                 fi
         si
 
-        _try_get_best_concrete() -> Type is
+        _try_get_best_concrete() -> Type? is
             result = null;
             current = null;
             _mode = LUB_MODE.ANY_CONCRETE;
@@ -379,7 +379,7 @@ namespace Semantic is
             return _get_best();
         si
 
-        _try_get_best_trait() -> Type is
+        _try_get_best_trait() -> Type? is
             result = null;
             current = null;
             _mode = LUB_MODE.ANY_TRAIT;
@@ -391,7 +391,7 @@ namespace Semantic is
             return _get_best();
         si
 
-        _get_best() -> Type is
+        _get_best() -> Type? is
             let best: Type mut = default;
             let is_ambiguous mut = false;
 
@@ -579,7 +579,7 @@ namespace Semantic is
             fi
         si
 
-        _with_element_names(type: Type) -> Type =>
+        _with_element_names(type: Type?) -> Type? =>
             if !type? then
                 null
             elif type.is_value_tuple /\ element_names? /\ element_names.count == type.arguments.count then

--- a/src/semantic/lookups/stubs_innate_symbol_lookup.ghul
+++ b/src/semantic/lookups/stubs_innate_symbol_lookup.ghul
@@ -191,7 +191,7 @@ namespace Semantic.Lookups is
             else
                 "could not find innate symbol {name}";
 
-            return result;
+            return result!;
         si
     si
 

--- a/src/semantic/namespaces.ghul
+++ b/src/semantic/namespaces.ghul
@@ -97,8 +97,8 @@ namespace Semantic is
 
                 _symbol_table.current_namespace_context.declare_namespace(location, name, ns, symbol_definition_listener);
             elif existing != ns then
-                _logger.error(location, "redefining symbol {name} as a namespace, originally defined at {existing.location}");
-                _logger.error(existing.location, "symbol {name} is redefined as namespace at {location}");
+                _logger.error(location, "redefining symbol {name} as a namespace, originally defined at {existing!.location}");
+                _logger.error(existing!.location, "symbol {name} is redefined as namespace at {location}");
             fi
 
             _prefixes.push(qualified_name);                

--- a/src/semantic/overload_resolver.ghul
+++ b/src/semantic/overload_resolver.ghul
@@ -51,7 +51,7 @@ namespace Semantic is
             want_infer: bool,
             want_instance: bool,
             is_constructor_call: bool
-        ) -> OVERLOAD_RESOLVE_RESULT
+        ) -> OVERLOAD_RESOLVE_RESULT?
         is
             let mark = _logger.mark();
 
@@ -71,7 +71,7 @@ namespace Semantic is
         find_matches(
             group: Symbols.FUNCTION_GROUP,
             arguments: Collections.List[Type]
-        ) -> OVERLOAD_MATCHES_RESULT
+        ) -> OVERLOAD_MATCHES_RESULT?
         is
             let mark = _logger.mark();
 
@@ -95,7 +95,7 @@ namespace Semantic is
             want_infer: bool,
             want_instance: bool,
             is_constructor_call: bool
-        ) -> OVERLOAD_RESOLVE_RESULT
+        ) -> OVERLOAD_RESOLVE_RESULT?
         is
             if group == null \/ group.functions == null \/ arguments == null then
                 return null;
@@ -456,7 +456,7 @@ namespace Semantic is
         _find_matches(
             group: Symbols.FUNCTION_GROUP,
             arguments: Collections.List[Type]
-        ) -> OVERLOAD_MATCHES_RESULT
+        ) -> OVERLOAD_MATCHES_RESULT?
         is
             if group == null \/ group.functions == null \/ arguments == null then
                 return null;

--- a/src/semantic/owner_constraint_specializer.ghul
+++ b/src/semantic/owner_constraint_specializer.ghul
@@ -101,7 +101,7 @@ namespace Semantic is
                 return candidate;
             fi
 
-            return specialized;
+            return specialized!;
         si
 
         // Walk owner_classy's ancestor types looking for a generic
@@ -120,7 +120,7 @@ namespace Semantic is
         try_unify_via_ancestor(
             owner_classy: Symbols.Classy,
             constraint_generic: Symbols.GENERIC
-        ) -> Collections.Map[string,Type] is
+        ) -> Collections.Map[string,Type]? is
             if !owner_classy.ancestors? then
                 return null;
             fi

--- a/src/semantic/owner_type_arg_specializer.ghul
+++ b/src/semantic/owner_type_arg_specializer.ghul
@@ -27,7 +27,7 @@ namespace Semantic is
         bind_owner_type_args_from_concrete_siblings(
             candidate: Symbols.Function,
             argument_types: Collections.List[Type]
-        ) -> Collections.MAP[string,Type] is
+        ) -> Collections.MAP[string,Type]? is
             let owner_classy = _generic_owner_classy_of(candidate);
 
             if !owner_classy? \/ !candidate.arguments? \/ !argument_types? then
@@ -116,10 +116,10 @@ namespace Semantic is
                 return candidate;
             fi
 
-            return specialized;
+            return specialized!;
         si
 
-        _generic_owner_classy_of(candidate: Symbols.Function) -> Symbols.Classy is
+        _generic_owner_classy_of(candidate: Symbols.Function) -> Symbols.Classy? is
             if !candidate? then
                 return null;
             fi
@@ -196,7 +196,7 @@ namespace Semantic is
                 specialized.is_generic = false;
             fi
 
-            return specialized;
+            return specialized!;
         si
 
         // Bind candidate's own generic_argument_names from sibling
@@ -206,7 +206,7 @@ namespace Semantic is
         bind_function_own_type_args_from_concrete_siblings(
             candidate: Symbols.Function,
             argument_types: Collections.List[Type]
-        ) -> Collections.MAP[string,Type] is
+        ) -> Collections.MAP[string,Type]? is
             if !candidate? \/ !candidate.arguments? \/ !argument_types? then
                 return null;
             fi

--- a/src/semantic/scope/block_scope.ghul
+++ b/src/semantic/scope/block_scope.ghul
@@ -19,7 +19,7 @@ namespace Semantic is
 
         type: Type => Types.NONE.instance;
 
-        unspecialized_symbol: Symbols.Symbol => null;
+        unspecialized_symbol: Symbols.Symbol? => null;
 
         init() is
             init(null);
@@ -32,14 +32,14 @@ namespace Semantic is
 
         qualify(name: string) -> string => _enclosing.qualify(name);
 
-        find_direct(name: string) -> Symbols.Symbol =>
+        find_direct(name: string) -> Symbols.Symbol? =>
             _symbols[name];
 
         find_direct_matches(prefix: string, matches: Collections.MutableMap[string,Semantic.Symbols.Symbol]) is
             _symbols.find_matches(prefix, matches);
         si            
 
-        find_member(name: string) -> Symbols.Symbol is
+        find_member(name: string) -> Symbols.Symbol? is
             throw NotImplementedException("cannot search for member {name} in block scope");
         si
 
@@ -47,7 +47,7 @@ namespace Semantic is
             throw NotImplementedException("cannot search for member matches {prefix} in block scope");
         si        
 
-        find_enclosing(name: string) -> Symbols.Symbol is
+        find_enclosing(name: string) -> Symbols.Symbol? is
             let result = find_direct(name);
 
             if result? then

--- a/src/semantic/scope/empty_scope.ghul
+++ b/src/semantic/scope/empty_scope.ghul
@@ -14,8 +14,8 @@ namespace Semantic is
         name: string;
         qualified_name: string => name;
         symbols: Iterable[Symbol] => LIST[Symbol]();
-        type: Type => null;
-        unspecialized_symbol: Symbol => null;
+        type: Type? => null;
+        unspecialized_symbol: Symbol? => null;
 
         init(name: string) is
             self.name = name;
@@ -29,9 +29,9 @@ namespace Semantic is
 
         qualify(name: string) -> string => "{_qualifier}{name}";
 
-        find_direct(name: string) -> Symbol => null;
-        find_member(name: string) -> Symbol => null;
-        find_enclosing(name: string) -> Symbol => null;
+        find_direct(name: string) -> Symbol? => null;
+        find_member(name: string) -> Symbol? => null;
+        find_enclosing(name: string) -> Symbol? => null;
 
         find_direct_matches(prefix: string, results: MutableMap[string,Symbol]) is
         si

--- a/src/semantic/scope/namespace_scope.ghul
+++ b/src/semantic/scope/namespace_scope.ghul
@@ -30,7 +30,7 @@ namespace Semantic is
 
         type: Type => Types.NONE.instance;
 
-        unspecialized_symbol: Symbol => null;
+        unspecialized_symbol: Symbol? => null;
 
         name: string => _namespace.name;
         qualified_name: string => _namespace.qualified_name;
@@ -60,7 +60,7 @@ namespace Semantic is
 
         qualify(name: string) -> string => _namespace.qualify(name);
 
-        find_direct(name: string) -> Symbol => _namespace.find_direct(name);
+        find_direct(name: string) -> Symbol? => _namespace.find_direct(name);
 
         find_direct_matches(prefix: string, matches: Collections.MutableMap[string,Symbol]) is
             _namespace.find_direct_matches(prefix, matches);
@@ -70,7 +70,7 @@ namespace Semantic is
             _namespace.find_member_matches(prefix, results);
         si        
 
-        cache_result(search: NAMESPACE_SEARCH) -> Symbol is
+        cache_result(search: NAMESPACE_SEARCH) -> Symbol? is
             let result = search.get_result();
 
             if result? then
@@ -80,11 +80,11 @@ namespace Semantic is
             return result;
         si
 
-        find_member(name: string) -> Symbol is
+        find_member(name: string) -> Symbol? is
             return find_enclosing(name);            
         si
         
-        find_enclosing(name: string) -> Symbol is
+        find_enclosing(name: string) -> Symbol? is
             let ns_location = _namespace.location;
 
             if _symbols.contains_key(name) then

--- a/src/semantic/scope/namespace_search_result.ghul
+++ b/src/semantic/scope/namespace_search_result.ghul
@@ -22,7 +22,7 @@ namespace Semantic is
             self.name = name;
         si
 
-        get_result() -> Symbols.Symbol is
+        get_result() -> Symbols.Symbol? is
             if other_symbol? then
                 return other_symbol;
             fi

--- a/src/semantic/scope/scope.ghul
+++ b/src/semantic/scope/scope.ghul
@@ -16,9 +16,9 @@ namespace Semantic is
 
         symbols: Collections.Iterable[Symbols.Symbol];
 
-        type: Type;
+        type: Type?;
 
-        unspecialized_symbol: Symbols.Symbol;
+        unspecialized_symbol: Symbols.Symbol?;
 
         is_trait: bool => false;
         is_classy: bool => false;
@@ -30,9 +30,9 @@ namespace Semantic is
         is_namespace: bool => false;
         
         qualify(name: string) -> string;
-        find_direct(name: string) -> Symbols.Symbol;
-        find_member(name: string) -> Symbols.Symbol;
-        find_enclosing(name: string) -> Symbols.Symbol;
+        find_direct(name: string) -> Symbols.Symbol?;
+        find_member(name: string) -> Symbols.Symbol?;
+        find_enclosing(name: string) -> Symbols.Symbol?;
 
         find_direct_matches(prefix: string, matches: Collections.MutableMap[string,Symbols.Symbol]);
         find_member_matches(prefix: string, matches: Collections.MutableMap[string,Symbols.Symbol]);

--- a/src/semantic/symbol_loader.ghul
+++ b/src/semantic/symbol_loader.ghul
@@ -261,7 +261,7 @@ namespace Semantic is
         load_static_property(location: Source.LOCATION, symbol: Symbols.Property) -> Value => load_property(location, null, symbol, true);
         load_global_property(location: Source.LOCATION, symbol: Symbols.Property) -> Value => load_property(location, null, symbol, true);
 
-        load_property(location: Source.LOCATION, from: Value mut, symbol: Symbols.Property, is_static: bool) -> Value is
+        load_property(location: Source.LOCATION, from: Value mut, symbol: Symbols.Property, is_static: bool) -> Value? is
             if !symbol? then
                 return null;
             fi
@@ -284,7 +284,7 @@ namespace Semantic is
         store_static_property(location: Source.LOCATION, symbol: Symbols.Property, value: Value) -> Value => store_property(location, null, symbol, value, true);
         store_global_property(location: Source.LOCATION, symbol: Symbols.Property, value: Value) -> Value => store_property(location, null, symbol, value, true);
 
-        store_property(location: Source.LOCATION, from: Value mut, symbol: Symbols.Property, value: Value, is_static: bool) -> Value is
+        store_property(location: Source.LOCATION, from: Value mut, symbol: Symbols.Property, value: Value, is_static: bool) -> Value? is
             if symbol == null then
                 return null;
             fi

--- a/src/semantic/symbol_map.ghul
+++ b/src/semantic/symbol_map.ghul
@@ -12,10 +12,10 @@ namespace Semantic is
             _map = Collections.MAP[string,Symbols.Symbol]();
         si
 
-        [name: string]: Symbols.Symbol
+        [name: string]: Symbols.Symbol?
             => if _map.contains_key(name) then _map[name] else null fi,
             = v is
-                _map[name] = v;
+                _map[name] = v!;
             si
 
         add(name: string, value: Symbols.Symbol) is _map.add(name, value); si

--- a/src/semantic/symbol_table.ghul
+++ b/src/semantic/symbol_table.ghul
@@ -16,7 +16,7 @@ namespace Semantic is
 
         stack: Collections.List[Scope] => _stack;
 
-        current_scope: Scope =>
+        current_scope: Scope? =>
             if _stack.count > 0 then
                 _stack[_stack.count-1];
             else
@@ -35,7 +35,7 @@ namespace Semantic is
             assert false else "no current namespace";
         si
 
-        current_declaration_context: DeclarationContext is
+        current_declaration_context: DeclarationContext? is
             for scope in Collections.LIST_REVERSE_ITERATOR[Scope](_stack) do
                 if isa DeclarationContext(scope) then
                     return cast DeclarationContext(scope);
@@ -44,7 +44,7 @@ namespace Semantic is
             return null;
         si
 
-        current_instance_context: Symbols.Classy is
+        current_instance_context: Symbols.Classy? is
             for scope in Collections.LIST_REVERSE_ITERATOR[Scope](_stack) do
                 if scope.is_instance_context then
                     return cast Symbols.Classy(scope);
@@ -53,7 +53,7 @@ namespace Semantic is
             return null;
         si
 
-        current_union_context: Symbols.UNION is
+        current_union_context: Symbols.UNION? is
             for scope in Collections.LIST_REVERSE_ITERATOR[Scope](_stack) do
                 if isa Symbols.UNION(scope) then
                     return scope;
@@ -62,7 +62,7 @@ namespace Semantic is
             return null;
         si
         
-        current_function: Symbols.Function is
+        current_function: Symbols.Function? is
             for scope in Collections.LIST_REVERSE_ITERATOR[Scope](_stack) do
                 if isa Symbols.Function(scope) then
                     return scope;
@@ -81,7 +81,7 @@ namespace Semantic is
             assert false else "no current closure context";
         si
 
-        current_capture_context: Symbols.Symbol is
+        current_capture_context: Symbols.Symbol? is
             for scope in Collections.LIST_REVERSE_ITERATOR[Scope](_stack) do
                 if scope.is_capture_context then
                     return cast Symbols.Symbol(scope);
@@ -90,7 +90,7 @@ namespace Semantic is
             return null;
         si
 
-        current_closure: Symbols.Closure is
+        current_closure: Symbols.Closure? is
             for scope in Collections.LIST_REVERSE_ITERATOR[Scope](_stack) do
                 if let result: Symbols.Closure = scope then
                     return result;
@@ -99,7 +99,7 @@ namespace Semantic is
             return null;
         si
 
-        current_function_group: Symbols.FUNCTION_GROUP is
+        current_function_group: Symbols.FUNCTION_GROUP? is
             for scope in Collections.LIST_REVERSE_ITERATOR[Scope](_stack) do
                 if isa Symbols.FUNCTION_GROUP(scope) then
                     return scope;
@@ -108,7 +108,7 @@ namespace Semantic is
             return null;
         si
 
-        current_property: Symbols.Property is
+        current_property: Symbols.Property? is
             for scope in Collections.LIST_REVERSE_ITERATOR[Scope](_stack) do
                 if isa Symbols.Property(scope) then
                     return scope;
@@ -140,7 +140,7 @@ namespace Semantic is
             enter_scope(Symbols.NAMESPACE(LOCATION.internal, "", null, "", true));
         si
 
-        scope_for(node: Node) -> Scope is
+        scope_for(node: Node) -> Scope? is
             if _scopes.contains_key(node) then
                 return _scopes[node];
             fi

--- a/src/semantic/symbol_use_locations.ghul
+++ b/src/semantic/symbol_use_locations.ghul
@@ -60,7 +60,7 @@ namespace Semantic is
             _add_symbol_reference(location, symbol);
         si
 
-        find_hover_use(file_name: string, line: int, column: int) -> HOVER_USE is
+        find_hover_use(file_name: string, line: int, column: int) -> HOVER_USE? is
             let matches = _hover_info_map.find_all(file_name, line, column);
 
             if !matches? \/ matches.count == 0 then
@@ -90,7 +90,7 @@ namespace Semantic is
             let matches = _symbol_use_map.find_all(file_name, line, column) in
             find_best_match(matches);
 
-        find_best_match(matches: Collections.List[LOCATION_SEARCH_RESULT[Symbols.Symbol]]) -> Symbols.Symbol =>
+        find_best_match(matches: Collections.List[LOCATION_SEARCH_RESULT[Symbols.Symbol]]) -> Symbols.Symbol? =>
             if !matches? \/ matches.count == 0 then
                 null;
             elif matches.count == 1 then
@@ -398,12 +398,16 @@ namespace Semantic is
         si
 
         put(location: LOCATION, value: T) is
-            let file mut = _get_file(location.file_name);
+            let existing = _get_file(location.file_name);
 
-            if file == null then
-                file = Collections.MAP[int, Collections.LIST[Pair[LOCATION,T]]]();
-                _file_name_to_file[location.file_name] = file;
-            fi
+            let file =
+                if existing? then
+                    existing
+                else
+                    let created = Collections.MAP[int, Collections.LIST[Pair[LOCATION,T]]]();
+                    _file_name_to_file[location.file_name] = created;
+                    created;
+                fi;
 
             let start_line = location.start_line;
             let end_line = location.end_line;
@@ -421,7 +425,7 @@ namespace Semantic is
             od
         si
 
-        find_all(file_name: string, line: int, column: int) -> List[LOCATION_SEARCH_RESULT[T]] is
+        find_all(file_name: string, line: int, column: int) -> List[LOCATION_SEARCH_RESULT[T]]? is
             let file = _get_file(file_name);
 
             if !file? \/ !file.contains_key(line) then
@@ -447,7 +451,7 @@ namespace Semantic is
             return result;
         si
         
-        _get_file(file_name: string) -> Collections.MAP[int, Collections.LIST[Pair[LOCATION,T]]] =>
+        _get_file(file_name: string) -> Collections.MAP[int, Collections.LIST[Pair[LOCATION,T]]]? =>
             if _file_name_to_file.contains_key(file_name) then
                 _file_name_to_file[file_name]
             else

--- a/src/semantic/symbols/classy.ghul
+++ b/src/semantic/symbols/classy.ghul
@@ -120,7 +120,7 @@ namespace Semantic.Symbols is
 
         get_closures() -> Collections.Iterable[Closure] => _closures;
 
-        find_member(name: string) -> Symbol => find_direct(name);
+        find_member(name: string) -> Symbol? => find_direct(name);
 
         find_enclosing(name: string) -> Symbol is
             if _enclosing_symbols.contains_key(name) then
@@ -225,7 +225,7 @@ namespace Semantic.Symbols is
             location: LOCATION,
             logger: Logger,
             actual_type_arguments: Collections.List[Type]
-        ) -> Symbol is
+        ) -> Symbol? is
             if !is_generic then
                 logger.error(location, "cannot explicitly specialize non-generic type");
                 return null;
@@ -878,7 +878,7 @@ namespace Semantic.Symbols is
             if _field_names.count == 0 then
                 "";
             else
-                "({_field_names | .map(name => let member = find_member(name) in "{member.name}: {member.type}") .join(", ")})";
+                "({_field_names | .map(name => let member = find_member(name) in "{member!.name}: {member!.type}") .join(", ")})";
             fi; 
         
         init(location: LOCATION, span: LOCATION, owner: Scope, name: string, arguments: Collections.List[string], is_stub: bool, enclosing_scope: Scope) is
@@ -890,7 +890,7 @@ namespace Semantic.Symbols is
 
         _calc_depth() -> int => 2; // object -> union -> variant
 
-        find_member(name: string) -> Symbol => 
+        find_member(name: string) -> Symbol? => 
             let direct_result = find_direct(name) in
 
             // we don't want the union's properties to conflict with
@@ -901,7 +901,7 @@ namespace Semantic.Symbols is
                 null
             fi;
 
-        get_destructure_member_name(index: int) -> string =>
+        get_destructure_member_name(index: int) -> string? =>
             if index < _field_names.count then
                 _field_names[index];
             else
@@ -1145,7 +1145,7 @@ namespace Semantic.Symbols is
             _constructor.set_arguments(argument_names, arguments);
         si
 
-        get_captured(name: string) -> Field is
+        get_captured(name: string) -> Field? is
             for c in _captures do
                 if c.name =~ name then
                     return c;
@@ -1259,7 +1259,7 @@ namespace Semantic.Symbols is
         get_create_instance(
             actual_arguments: Collections.List[Value],
             type_arguments: Collections.List[Type]
-        ) -> IR.Values.Value is
+        ) -> IR.Values.Value? is
             declare();
 
             try

--- a/src/semantic/symbols/closure.ghul
+++ b/src/semantic/symbols/closure.ghul
@@ -113,7 +113,7 @@ namespace Semantic.Symbols is
                         existing.set_type(variable.type);
                     fi
 
-                    return existing;
+                    return existing!;
                 fi
             else
                 if !is_self_captured then
@@ -471,9 +471,9 @@ namespace Semantic.Symbols is
             let frame_instance = frame.get_create_instance(actual_arguments, frozen_argument_types);
             unmap_type_arguments();
 
-            let frame_instance_copier = frame_instance.get_temp_copier(block, "frame-instance");
+            let frame_instance_copier = frame_instance!.get_temp_copier(block, "frame-instance");
 
-            owner = frame_instance.type.symbol;
+            owner = frame_instance!.type.symbol;
 
             map_type_arguments();
             let function = IR.Values.Load.FUNCTION_POINTER(self).freeze();
@@ -485,7 +485,7 @@ namespace Semantic.Symbols is
 
             let rec_member_symbol = owner.find_member("$recurse");
 
-            if rec_member_symbol? /\ !frame_instance.type.is_error then
+            if rec_member_symbol? /\ !frame_instance!.type.is_error then
                 let ff = frame_instance_copier();
                 let rr = result_copier();
                 map_type_arguments();
@@ -534,7 +534,7 @@ namespace Semantic.Symbols is
             owner = frame;
 
             let frame_instance = frame.get_create_instance(actual_arguments, null);
-            let frame_instance_copier = frame_instance.get_temp_copier(block, "frame-instance");
+            let frame_instance_copier = frame_instance!.get_temp_copier(block, "frame-instance");
 
             owner = frame_instance.type.symbol;
 

--- a/src/semantic/symbols/closure.ghul
+++ b/src/semantic/symbols/closure.ghul
@@ -489,7 +489,7 @@ namespace Semantic.Symbols is
                 let ff = frame_instance_copier();
                 let rr = result_copier();
                 map_type_arguments();
-                block.add(rec_member_symbol.store(location, ff, rr, loader, true).freeze());
+                block.add(rec_member_symbol!.store(location, ff, rr, loader, true).freeze());
                 unmap_type_arguments();
             fi
 

--- a/src/semantic/symbols/closure.ghul
+++ b/src/semantic/symbols/closure.ghul
@@ -12,7 +12,7 @@ namespace Semantic.Symbols is
     class Closure: Function, Types.Typed is
         _is_loading_captures: bool;
 
-        captured_values: Collections.SET[Symbol];
+        captured_values: Collections.SET[Symbol]?;
         captured_type_arguments: Collections.MAP[Symbol, CAPTURED_TYPE_ARGUMENT];
         next_type_argument_index: int;
 
@@ -22,7 +22,7 @@ namespace Semantic.Symbols is
 
         could_be_delegate: bool => false;
 
-        frame: FRAME;
+        frame: FRAME?;
 
         description: string => "{type} // closure";
         short_description: string => description;
@@ -228,7 +228,7 @@ namespace Semantic.Symbols is
         // the IR currently being built will be inserted. `current_function`
         // is no good here: when this runs, self is still on the stack so
         // `current_function` returns self.
-        _find_enclosing_closure() -> Closure is
+        _find_enclosing_closure() -> Closure? is
             let stack = IoC.CONTAINER.instance.symbol_table.stack;
             let i mut = stack.count - 1;
             let seen_self mut = false;
@@ -288,21 +288,21 @@ namespace Semantic.Symbols is
             generic_argument_names = args | .map(a => a.name) .collect();
         si
 
-        get_sorted_captured_type_argument_symbols() -> Collections.List[Symbol] =>
+        get_sorted_captured_type_argument_symbols() -> Collections.List[Symbol]? =>
             if captured_type_arguments? then
                 captured_type_arguments | .sort((a, b) => a.value.index - b.value.index) .map(p => p.key) .collect();
             else
                 null
             fi;
 
-        get_sorted_captured_type_argument_types() -> Collections.List[Types.Type] =>
+        get_sorted_captured_type_argument_types() -> Collections.List[Types.Type]? =>
             if captured_type_arguments? then
                 captured_type_arguments | .sort((a, b) => a.value.index - b.value.index) .map(p => p.key.type) .collect()
             else
                 null
             fi;
 
-        get_type_arguments_as_specialize_map() -> Collections.Map[string,Types.Type] =>
+        get_type_arguments_as_specialize_map() -> Collections.Map[string,Types.Type]? =>
             if captured_type_arguments? then
                 Collections.MAP[string,Types.Type](
                     captured_type_arguments.keys | .map(key => new Collections.KeyValuePair`2[string,Types.Type](key.name, key.type.freeze()))
@@ -370,7 +370,7 @@ namespace Semantic.Symbols is
                 fi
             si;
 
-            let enclosing: Closure mut = null;
+            let enclosing: Closure? mut = null;
 
             for c in captured_values do
                 if c == null then
@@ -397,7 +397,7 @@ namespace Semantic.Symbols is
                         enclosing = _find_enclosing_closure();
                     fi
 
-                    let value = enclosing.load_outer_recurse_value(outer, location, loader);
+                    let value = enclosing!.load_outer_recurse_value(outer, location, loader);
 
                     actual_arguments.add(value);
 
@@ -615,12 +615,12 @@ namespace Semantic.Symbols is
             return delegate;
         si
 
-        load_outer_self(location: Source.LOCATION, loader: SYMBOL_LOADER) -> Value is
+        load_outer_self(location: Source.LOCATION, loader: SYMBOL_LOADER) -> Value? is
             let symbol_table = IoC.CONTAINER.instance.symbol_table;
             let context = symbol_table.current_instance_context;
 
             if is_delegate then
-                return IR.Values.Load.REFERENCE_SELF(context, context.type);                
+                return IR.Values.Load.REFERENCE_SELF(context!, context!.type);                
             fi
             
             let is_captured = false;
@@ -657,7 +657,7 @@ namespace Semantic.Symbols is
 
             if !is_captured then
                 // load self normally: 
-                return IR.Values.Load.REFERENCE_SELF(context, context.type);
+                return IR.Values.Load.REFERENCE_SELF(context!, context!.type);
             fi
             return null;
         si
@@ -666,7 +666,7 @@ namespace Semantic.Symbols is
             if is_delegate then
                 let context = IoC.CONTAINER.instance.symbol_table.current_instance_context;
 
-                return IR.Values.Load.REFERENCE_SELF(context, context.type);                
+                return IR.Values.Load.REFERENCE_SELF(context!, context!.type);                
             fi
 
             let `field = find_or_add_capture_self();
@@ -674,7 +674,7 @@ namespace Semantic.Symbols is
             return loader.load_instance_variable(location, IR.Values.Load.REFERENCE_SELF(frame, frame.type), `field);
         si
 
-        load_outer_captured_value(location: LOCATION, symbol: Variable, loader: SYMBOL_LOADER) -> Value is
+        load_outer_captured_value(location: LOCATION, symbol: Variable, loader: SYMBOL_LOADER) -> Value? is
             let is_captured = false;
 
             let stack = IoC.CONTAINER.instance.symbol_table.stack;

--- a/src/semantic/symbols/function.ghul
+++ b/src/semantic/symbols/function.ghul
@@ -21,14 +21,14 @@ namespace Semantic.Symbols is
         _seen_entrypoint: bool static;
 
         _declaring_arguments: bool;
-        _override_class: METHOD_OVERRIDE_CLASS;
+        _override_class: METHOD_OVERRIDE_CLASS?;
 
         override_class: METHOD_OVERRIDE_CLASS is
             if !_override_class? then
                 _override_class = METHOD_OVERRIDE_CLASS(arguments);
             fi
 
-            return _override_class;
+            return _override_class!;
         si
 
         _overriders: Collections.MutableList[Symbol];
@@ -240,7 +240,7 @@ namespace Semantic.Symbols is
             return true;
         si
 
-        try_bind_generic_arguments(location: Source.LOCATION, args: Collections.List[Type]) -> Types.GENERIC_ARGUMENT_BIND_RESULTS is
+        try_bind_generic_arguments(location: Source.LOCATION, args: Collections.List[Type]) -> Types.GENERIC_ARGUMENT_BIND_RESULTS? is
             // This method binds the *function's* own generic args
             // (use try_bind_owner_generic_arguments for the owning
             // class's). When the function isn't generic there is
@@ -274,7 +274,7 @@ namespace Semantic.Symbols is
             return results;
         si
 
-        try_bind_owner_generic_arguments(location: Source.LOCATION, args: Collections.List[Type]) -> Types.GENERIC_ARGUMENT_BIND_RESULTS is
+        try_bind_owner_generic_arguments(location: Source.LOCATION, args: Collections.List[Type]) -> Types.GENERIC_ARGUMENT_BIND_RESULTS? is
             let owner_classy = cast Classy(owner);
 
             if !owner_classy? \/ !owner_classy.is_generic then
@@ -376,7 +376,7 @@ namespace Semantic.Symbols is
             location: LOCATION,
             logger: Logger,
             actual_type_arguments: Collections.List[Type]
-        ) -> Symbol is
+        ) -> Symbol? is
             if !is_generic then
                 logger.error(location, "cannot explicitly specialize non-generic type");
                 return null;

--- a/src/semantic/symbols/function_group.ghul
+++ b/src/semantic/symbols/function_group.ghul
@@ -61,7 +61,8 @@ namespace Semantic.Symbols is
             location: LOCATION,
             logger: Logger,
             actual_type_arguments: Collections.List[Type]
-        ) -> Symbol is
+        ) -> Symbol?
+        is
             let result_functions = Collections.LIST[Symbol]();
             let result = FUNCTION_GROUP(location, owner, name);
 

--- a/src/semantic/symbols/generic.ghul
+++ b/src/semantic/symbols/generic.ghul
@@ -151,7 +151,7 @@ namespace Semantic.Symbols is
             is_unsafe_constraints = symbol.is_unsafe_constraints;
         si
 
-        try_create_from(location: LOCATION, symbol: Classy, type_map: Collections.Map[string,Type]) -> GENERIC static is
+        try_create_from(location: LOCATION, symbol: Classy, type_map: Collections.Map[string,Type]) -> GENERIC? static is
             let arguments = Collections.LIST[Type]();
 
             for name in symbol.argument_names do
@@ -226,7 +226,7 @@ namespace Semantic.Symbols is
 
         // given a member of the class, trait or struct that this generic wraps, we want to get a copy of it
         // with all references to formal type parameters replaced with the corresponding actual type arguments
-        _specialize(member: Symbols.Symbol) -> Symbols.Symbol => 
+        _specialize(member: Symbols.Symbol) -> Symbols.Symbol? => 
             if !member? then
                 null;
             elif !member.is_specializable then
@@ -243,7 +243,7 @@ namespace Semantic.Symbols is
             return _specialize(symbol.find_direct(name));
         si
 
-        find_member(name: string) -> Symbol =>
+        find_member(name: string) -> Symbol? =>
             let result = symbol.find_member(name) in
             if result? then
                 _specialize(result);
@@ -251,7 +251,7 @@ namespace Semantic.Symbols is
                 null;
             fi;
 
-        find_specialized_function(function: Symbol) -> Function is
+        find_specialized_function(function: Symbol) -> Function? is
             let result = find_member(function.name);
 
             if !result? then

--- a/src/semantic/symbols/generic_argument.ghul
+++ b/src/semantic/symbols/generic_argument.ghul
@@ -25,7 +25,7 @@ namespace Semantic.Symbols is
 
         index: int;
 
-        _gen_type_override: (Symbol, StringBuilder) -> void;
+        _gen_type_override: ((Symbol, StringBuilder) -> void)?;
         
         // FIXME: should ancestor be a type not a symbol? We could then just use Symbol.ancestors.
         // We'll need multiple ancestors to support multiple constraints anyway
@@ -62,7 +62,7 @@ namespace Semantic.Symbols is
         get_ancestor(i: int) -> Type 
             => ancestors[i];
 
-        find_member(name: string) -> Symbol =>
+        find_member(name: string) -> Symbol? =>
             if _ancestor_type? then
                 _ancestor_type.find_member(name)
             else

--- a/src/semantic/symbols/generic_constraint_checker.ghul
+++ b/src/semantic/symbols/generic_constraint_checker.ghul
@@ -48,7 +48,7 @@ namespace Semantic.Symbols is
         // The explicit type bound of a type parameter (`[T: SomeBase]`),
         // or null when unbounded. The implicit `object` bound is not a
         // real constraint, so it is reported as unbounded.
-        type_bound(parameter: Symbol) -> Type is
+        type_bound(parameter: Symbol) -> Type? is
             let ancestors = parameter.ancestors;
 
             if ancestors? /\ ancestors.count > 0 /\ ancestors[0]? /\ !ancestors[0].is_object then

--- a/src/semantic/symbols/ineffective_trait_override_checker.ghul
+++ b/src/semantic/symbols/ineffective_trait_override_checker.ghul
@@ -45,7 +45,7 @@ namespace Semantic.Symbols is
             fi
         si
 
-        _find_intermediate_without_redeclaration(start: Classy, trait_owner: Classy, member_name: string) -> Classy is
+        _find_intermediate_without_redeclaration(start: Classy, trait_owner: Classy, member_name: string) -> Classy? is
             let current = _direct_class_parent(start);
 
             while current? do
@@ -62,7 +62,7 @@ namespace Semantic.Symbols is
             return null;
         si
 
-        _direct_class_parent(classy: Classy) -> Classy is
+        _direct_class_parent(classy: Classy) -> Classy? is
             for a in classy.ancestors do
                 if !a.is_trait /\ a.symbol? /\ isa Classy(a.symbol) then
                     return cast Classy(a.symbol);

--- a/src/semantic/symbols/method.ghul
+++ b/src/semantic/symbols/method.ghul
@@ -52,7 +52,7 @@ namespace Semantic.Symbols is
         load_self(location: LOCATION, loader: SYMBOL_LOADER) -> Value is
             let context = IoC.CONTAINER.instance.symbol_table.current_instance_context;
 
-            return IR.Values.Load.REFERENCE_SELF(context, context.type);
+            return IR.Values.Load.REFERENCE_SELF(context!, context!.type);
         si
 
         call(location: Source.LOCATION, from: Value, arguments: Collections.List[Value], type: Type, caller: FUNCTION_CALLER) -> Value is           
@@ -121,7 +121,7 @@ namespace Semantic.Symbols is
         load_self(location: LOCATION, loader: SYMBOL_LOADER) -> Value is
             let context = IoC.CONTAINER.instance.symbol_table.current_instance_context;
 
-            return IR.Values.Load.REFERENCE_SELF(context, context.type);
+            return IR.Values.Load.REFERENCE_SELF(context!, context!.type);
         si
 
         declare_closure(location: LOCATION, name: string, owner: Scope, enclosing: Scope, is_recursive: bool, symbol_definition_listener: SymbolDefinitionListener) -> Symbol is

--- a/src/semantic/symbols/method_override_map.ghul
+++ b/src/semantic/symbols/method_override_map.ghul
@@ -28,7 +28,7 @@ namespace Semantic is
         contains_any_methods: bool => methods.count > 0;
         contains_any_symbols: bool => _symbols.count > 0;
 
-        [method_class: METHOD_OVERRIDE_CLASS]: METHOD_OVERRIDE_SET is
+        [method_class: METHOD_OVERRIDE_CLASS]: METHOD_OVERRIDE_SET? is
             if methods.contains_key(method_class) then
                 return methods[method_class];
             fi

--- a/src/semantic/symbols/namespace.ghul
+++ b/src/semantic/symbols/namespace.ghul
@@ -63,7 +63,7 @@ namespace Semantic.Symbols is
             return name;
         si
 
-        find_direct(name: string) -> Symbol is
+        find_direct(name: string) -> Symbol? is
             assert name? else "searched name is null";
 
             let result = super.find_direct(name);

--- a/src/semantic/symbols/symbol.ghul
+++ b/src/semantic/symbols/symbol.ghul
@@ -92,10 +92,10 @@ namespace Semantic.Symbols is
 
         symbols: Collections.Iterable[Symbol] => Collections.LIST[Symbol]();
 
-        overriders: Collections.Iterable[Symbol] => null;
-        overridees: Collections.Iterable[Symbol] => null;
+        overriders: Collections.Iterable[Symbol]? => null;
+        overridees: Collections.Iterable[Symbol]? => null;
 
-        implementors: Collections.Iterable[Symbol] => null;
+        implementors: Collections.Iterable[Symbol]? => null;
 
         unspecialized_symbol: Symbol => self;
 
@@ -260,12 +260,12 @@ namespace Semantic.Symbols is
             location: LOCATION,
             logger: Logger,
             actual_type_arguments: Collections.List[Type]
-        ) -> Symbol is
+        ) -> Symbol? is
             logger.error(location, "cannot supply explicit type arguments here");
             return null;
         si
 
-        freeze() -> Symbol => null;
+        freeze() -> Symbol? => null;
         
         load(location: LOCATION, from: Value, loader: SYMBOL_LOADER) -> Value =>
             // will report error when consumed:
@@ -302,18 +302,18 @@ namespace Semantic.Symbols is
         add_overrider(overrider: Symbol);
         add_overridee(overridee: Symbol);
         
-        find_direct(name: string) -> Symbol => null;
+        find_direct(name: string) -> Symbol? => null;
 
-        find_member(name: string) -> Symbol => null;
+        find_member(name: string) -> Symbol? => null;
 
         get_destructure_member_name(index: int) -> string =>
             "`{index}";
-            
-        find_enclosing(name: string) -> Symbol => null;
+
+        find_enclosing(name: string) -> Symbol? => null;
 
         // FIXME: the way we handle inheritance and specialization of generics makes it tricky to get the correctly specialized owner of methods that
         // are interited from a super class or trait. The following works, but the fact that it's needed suggests we ought to be tracking this some other way
-        find_owning_ancestor(o: Scope) -> Scope is
+        find_owning_ancestor(o: Scope) -> Scope? is
             let search_symbol = o.unspecialized_symbol;
 
             if !search_symbol? then
@@ -344,17 +344,17 @@ namespace Semantic.Symbols is
             return null;
         si
 
-        find_ancestor(search_type: Type) -> Type is
+        find_ancestor(search_type: Type) -> Type? is
             if unspecialized_symbol == search_type.unspecialized_symbol then
                 return self.type;
             fi
-            
+
             for a in ancestors do
                 let result = a.find_ancestor(search_type);
-                
+
                 if result? then
                     return result;
-                fi                
+                fi
             od
             return null;
         si
@@ -754,7 +754,7 @@ namespace Semantic.Symbols is
             self.enclosing_scope = enclosing_scope;
         si
 
-        find_enclosing_only(name: string) -> Symbol is
+        find_enclosing_only(name: string) -> Symbol? is
             if enclosing_scope? then
                 return enclosing_scope.find_enclosing(name);
             fi
@@ -762,7 +762,7 @@ namespace Semantic.Symbols is
             return null;
         si
 
-        find_enclosing(name: string) -> Symbol is
+        find_enclosing(name: string) -> Symbol? is
             let result = find_direct(name);
 
             if result? then

--- a/src/semantic/symbols/symbol.ghul
+++ b/src/semantic/symbols/symbol.ghul
@@ -638,7 +638,7 @@ namespace Semantic.Symbols is
                     fi
 
                     return true;
-                elif !member.is_reflected \/ !existing.is_reflected then
+                elif !member.is_reflected \/ !existing!.is_reflected then
                     throw System.Exception("cannot add non-function {member} over the top of non-function member {existing}");
                 fi
 

--- a/src/semantic/symbols/symbol_inheritance_resolver.ghul
+++ b/src/semantic/symbols/symbol_inheritance_resolver.ghul
@@ -434,7 +434,7 @@ namespace Semantic is
             let type: Type mut = default;
             let inconsistent_types mut = false;
             let any_non_properties mut = false;
-            let property: Symbol mut = default;
+            let property: Symbol? mut = default;
 
             for s in overridee_symbols do
                 if isa Symbols.Property(s) then

--- a/src/semantic/symbols/tuple.ghul
+++ b/src/semantic/symbols/tuple.ghul
@@ -30,7 +30,7 @@ namespace Semantic.Symbols is
                 "`{index}"
             fi;
 
-        find_named_element(name: string) -> Symbol is
+        find_named_element(name: string) -> Symbol? is
             if !names? then 
                 return null;
             fi
@@ -55,7 +55,7 @@ namespace Semantic.Symbols is
             let named_element = find_named_element(name);
 
             if named_element? then
-                return named_element;
+                return named_element!;
             fi
 
             return _specialize(symbol.find_member(name));

--- a/src/semantic/symbols/variable.ghul
+++ b/src/semantic/symbols/variable.ghul
@@ -141,7 +141,7 @@ namespace Semantic.Symbols is
             return true;
         si
 
-        try_get_inferred_type() -> Type is
+        try_get_inferred_type() -> Type? is
             let candidate: Type mut = default;
 
             if _lub_map? then

--- a/src/semantic/type_arg_placeholder_registry.ghul
+++ b/src/semantic/type_arg_placeholder_registry.ghul
@@ -157,7 +157,7 @@ namespace Semantic is
                 return function;
             fi
 
-            return specialized;
+            return specialized!;
         si
 
         // Walk all phantom origins; for each whose body-retry didn't

--- a/src/semantic/types/generic_argument.ghul
+++ b/src/semantic/types/generic_argument.ghul
@@ -16,7 +16,7 @@ namespace Semantic.Types is
             results.add(self);
         si
 
-        freeze() -> Type is
+        freeze() -> Type? is
             let frozen = symbol.freeze();
 
             if !frozen? then

--- a/src/semantic/types/named.ghul
+++ b/src/semantic/types/named.ghul
@@ -158,28 +158,28 @@ namespace Semantic.Types is
             return Types.MATCH.DIFFERENT;            
         si
 
-        find_member(name: string) -> Symbols.Symbol =>
+        find_member(name: string) -> Symbols.Symbol? =>
             if symbol? then
                 symbol.find_member(name)
             else
                 null
             fi;
 
-        get_destructure_member_name(index: int) -> string =>
+        get_destructure_member_name(index: int) -> string? =>
             if symbol? then
                 symbol.get_destructure_member_name(index)
             else
                 null
             fi;
 
-        find_ancestor(type: Type) -> Type =>
+        find_ancestor(type: Type) -> Type? =>
             if symbol? then
                 symbol.find_ancestor(type)
             else
                 null
             fi;
 
-        freeze() -> Type =>
+        freeze() -> Type? =>
             if symbol? then
                 let result = symbol.freeze();
 

--- a/src/semantic/types/one_of.ghul
+++ b/src/semantic/types/one_of.ghul
@@ -54,7 +54,7 @@ namespace Semantic.Types is
         create(
             underlying_type: NAMED,
             variants: Collections.LIST[Symbols.Classy]
-        ) -> NAMED static is
+        ) -> NAMED? static is
             if !underlying_type? \/ !variants? \/ variants.count == 0 then
                 return null;
             fi
@@ -73,7 +73,7 @@ namespace Semantic.Types is
         build_singleton_variant_type(
             underlying_type: NAMED,
             variant: Symbols.Classy
-        ) -> NAMED static is
+        ) -> NAMED? static is
             if isa GENERIC(underlying_type) then
                 let generic = underlying_type;
                 return GENERIC(variant.location, variant, generic.arguments);

--- a/src/semantic/types/tuple.ghul
+++ b/src/semantic/types/tuple.ghul
@@ -13,7 +13,7 @@ namespace Semantic.Types is
         // Build an element-name list of exactly `arity` entries from
         // the leading entries of a flattened TupleElementNamesAttribute
         // array, padding with null.
-        take_element_names(names: Collections.List[string], arity: int) -> Collections.List[string] static is
+        take_element_names(names: Collections.List[string], arity: int) -> Collections.List[string]? static is
             if !names? then
                 return null;
             fi

--- a/src/semantic/types/type.ghul
+++ b/src/semantic/types/type.ghul
@@ -25,10 +25,10 @@ namespace Semantic.Types is
     class Type: Typed is
         type: Type => self;
 
-        name: string => null;
+        name: string? => null;
         depth: int => symbol.depth;
 
-        scope: Scope => null;
+        scope: Scope? => null;
 
         symbol: Symbols.Symbol =>
             if scope? /\ isa Symbols.Symbol(scope) then
@@ -42,7 +42,7 @@ namespace Semantic.Types is
 
         short_description: string => to_string();
 
-        unspecialized_symbol: Symbols.Symbol =>
+        unspecialized_symbol: Symbols.Symbol? =>
             let s = scope in
             if s? then
                 s.unspecialized_symbol
@@ -156,7 +156,7 @@ namespace Semantic.Types is
         // no names — they ride on a TupleElementNamesAttribute at the
         // declaration site — so a reflected tuple starts nameless and
         // is rebuilt with `apply_tuple_element_names`.
-        tuple_element_names: Collections.List[string] => null;
+        tuple_element_names: Collections.List[string]? => null;
 
         // Return an equivalent value-tuple type carrying `names` (one
         // per element, null for an unnamed element). A no-op for any
@@ -183,10 +183,10 @@ namespace Semantic.Types is
         compare(other: Type) -> MATCH
             => MATCH.DIFFERENT;
 
-        find_member(name: string) -> Symbols.Symbol
+        find_member(name: string) -> Symbols.Symbol?
             => null;
 
-        find_destructure_member(index: int) -> Symbols.Symbol =>
+        find_destructure_member(index: int) -> Symbols.Symbol? =>
             let name = get_destructure_member_name(index) in
 
             if name? then
@@ -196,10 +196,10 @@ namespace Semantic.Types is
                 null;
             fi;
 
-        get_destructure_member_name(index: int) -> string
+        get_destructure_member_name(index: int) -> string?
             => null;
 
-        find_ancestor(type: Type) -> Type => null;
+        find_ancestor(type: Type) -> Type? => null;
 
         specialize(type_map: Collections.Map[string,Type]) -> Type is
             throw System.NotImplementedException("not implemented by {self.get_type()}");
@@ -217,13 +217,13 @@ namespace Semantic.Types is
             return result;
         si
 
-        freeze() -> Type => null;
+        freeze() -> Type? => null;
 
         walk(action: (Type) -> void) is
             throw System.NotImplementedException("not implemented by {self.get_type()}");
         si
 
-        get_element_type() -> Type => null;
+        get_element_type() -> Type? => null;
         
         get_il_type() -> string is
             let result = StringBuilder();

--- a/src/syntax/parsers/base.ghul
+++ b/src/syntax/parsers/base.ghul
@@ -16,7 +16,7 @@ namespace Syntax.Parsers is
             return _expected_tokens;
         si
 
-        description: string => null;
+        description: string? => null;
 
         syntax_error_message: string is
             let d = description;

--- a/src/syntax/parsers/context.ghul
+++ b/src/syntax/parsers/context.ghul
@@ -5,17 +5,17 @@ namespace Syntax.Parsers is
     use Source;
 
     struct TOKEN_LOOKAHEAD_SPECULATE_THEN_COMMIT: Disposable is
-        _context: CONTEXT;
+        _context: CONTEXT?;
 
         is_speculating: bool => _context != null;
 
         init(context: CONTEXT) is
             _context = context;
-            _context.tokenizer_speculate();
+            _context!.tokenizer_speculate();
         si
 
         backtrack() is
-            _context.tokenizer_backtrack();
+            _context!.tokenizer_backtrack();
             _context = null;
         si
 
@@ -27,7 +27,7 @@ namespace Syntax.Parsers is
         si
 
         commit() is
-            _context.tokenizer_commit();
+            _context!.tokenizer_commit();
             _context = null;
         si
 
@@ -51,17 +51,17 @@ namespace Syntax.Parsers is
     si
 
     struct TOKEN_LOOKAHEAD_SPECULATE_THEN_BACKTRACK: Disposable is
-        _context: CONTEXT;
+        _context: CONTEXT?;
 
         is_speculating: bool => _context != null;
 
         init(context: CONTEXT) is
             _context = context;
-            _context.tokenizer_speculate();
+            _context!.tokenizer_speculate();
         si
 
         backtrack() is
-            _context.tokenizer_backtrack();
+            _context!.tokenizer_backtrack();
             _context = null;
         si
 
@@ -73,7 +73,7 @@ namespace Syntax.Parsers is
         si
 
         commit() is
-            _context.tokenizer_commit();
+            _context!.tokenizer_commit();
             _context = null;
         si
 

--- a/src/syntax/parsers/context.ghul
+++ b/src/syntax/parsers/context.ghul
@@ -21,7 +21,7 @@ namespace Syntax.Parsers is
 
         backtrack_if_speculating() is
             if _context != null then
-                _context.tokenizer_backtrack();
+                _context!.tokenizer_backtrack();
                 _context = null;
             fi
         si
@@ -33,7 +33,7 @@ namespace Syntax.Parsers is
 
         commit_if_speculating() is
             if _context != null then
-                _context.tokenizer_commit();
+                _context!.tokenizer_commit();
                 _context = null;
             fi
         si
@@ -44,7 +44,7 @@ namespace Syntax.Parsers is
 
         dispose() is
             if _context != null then
-                _context.tokenizer_commit();
+                _context!.tokenizer_commit();
                 _context = null;
             fi
         si
@@ -67,7 +67,7 @@ namespace Syntax.Parsers is
 
         backtrack_if_speculating() is
             if _context != null then
-                _context.tokenizer_backtrack();
+                _context!.tokenizer_backtrack();
                 _context = null;
             fi
         si
@@ -79,7 +79,7 @@ namespace Syntax.Parsers is
 
         commit_if_speculating() is
             if _context != null then
-                _context.tokenizer_commit();
+                _context!.tokenizer_commit();
                 _context = null;
             fi
         si
@@ -90,7 +90,7 @@ namespace Syntax.Parsers is
 
         dispose() is
             if _context != null then
-                _context.tokenizer_backtrack();
+                _context!.tokenizer_backtrack();
                 _context = null;
             fi
         si

--- a/src/syntax/parsers/definitions/class.ghul
+++ b/src/syntax/parsers/definitions/class.ghul
@@ -25,7 +25,7 @@ namespace Syntax.Parsers.Definitions is
             self.definition_list_parser = definition_list_parser;
         si
 
-        parse(context: CONTEXT) -> Trees.Definitions.CLASS is
+        parse(context: CONTEXT) -> Trees.Definitions.CLASS? is
             let start = context.location;
             context.in_classy = true;
             context.global_indent = start.start_column;

--- a/src/syntax/parsers/definitions/function.ghul
+++ b/src/syntax/parsers/definitions/function.ghul
@@ -31,7 +31,7 @@ namespace Syntax.Parsers.Definitions is
 
         parse_generic_arguments(
             context: CONTEXT
-        ) -> Syntax.Trees.TypeExpressions.LIST is
+        ) -> Syntax.Trees.TypeExpressions.LIST? is
             if context.current.token == Lexical.TOKEN.SQUARE_OPEN then
                 context.next_token();
 

--- a/src/syntax/parsers/definitions/indexer.ghul
+++ b/src/syntax/parsers/definitions/indexer.ghul
@@ -28,7 +28,7 @@ namespace Syntax.Parsers.Definitions is
             self.body_parser = body_parser;
         si
 
-        parse(context: CONTEXT) -> Trees.Definitions.INDEXER is
+        parse(context: CONTEXT) -> Trees.Definitions.INDEXER? is
             let name: Trees.Identifiers.Identifier mut = default;
             let start = context.location;
 

--- a/src/syntax/parsers/definitions/namespace.ghul
+++ b/src/syntax/parsers/definitions/namespace.ghul
@@ -15,7 +15,7 @@ namespace Syntax.Parsers.Definitions is
             self.definition_list_parser = definition_list_parser;
         si
 
-        parse(context: CONTEXT) -> Trees.Definitions.NAMESPACE is
+        parse(context: CONTEXT) -> Trees.Definitions.NAMESPACE? is
             context.next_token(Lexical.TOKEN.NAMESPACE);
 
             let start = context.location;

--- a/src/syntax/parsers/definitions/pragma.ghul
+++ b/src/syntax/parsers/definitions/pragma.ghul
@@ -54,7 +54,7 @@ namespace Syntax.Parsers.Definitions is
             self.precedence_map = precedence_map;
         si
 
-        parse(context: CONTEXT) -> Trees.Definitions.PRAGMA is
+        parse(context: CONTEXT) -> Trees.Definitions.PRAGMA? is
             let pragma = pragma_parser.parse(context);
         
             // FIXME: factor this out

--- a/src/syntax/parsers/definitions/struct.ghul
+++ b/src/syntax/parsers/definitions/struct.ghul
@@ -24,7 +24,7 @@ namespace Syntax.Parsers.Definitions is
             self.definition_list_parser = definition_list_parser;
         si
 
-        parse(context: CONTEXT) -> Trees.Definitions.STRUCT is
+        parse(context: CONTEXT) -> Trees.Definitions.STRUCT? is
             let start = context.location;
             context.in_classy = true;
             context.global_indent = start.start_column;

--- a/src/syntax/parsers/definitions/trait.ghul
+++ b/src/syntax/parsers/definitions/trait.ghul
@@ -25,7 +25,7 @@ namespace Syntax.Parsers.Definitions is
             self.definition_list_parser = definition_list_parser;
         si
 
-        parse(context: CONTEXT) -> Trees.Definitions.TRAIT is
+        parse(context: CONTEXT) -> Trees.Definitions.TRAIT? is
             let start = context.location;
             context.in_classy = true;
             context.global_indent = start.start_column;

--- a/src/syntax/parsers/definitions/union.ghul
+++ b/src/syntax/parsers/definitions/union.ghul
@@ -25,7 +25,7 @@ namespace Syntax.Parsers.Definitions is
             self.variant_list_parser = variant_list_parser;
         si
 
-        parse(context: CONTEXT) -> Trees.Definitions.UNION is            
+        parse(context: CONTEXT) -> Trees.Definitions.UNION? is            
             let start = context.location;
 
             context.in_classy = true;

--- a/src/syntax/parsers/definitions/variant.ghul
+++ b/src/syntax/parsers/definitions/variant.ghul
@@ -19,7 +19,7 @@ namespace Syntax.Parsers.Definitions is
             self.modifier_parser = modifier_parser;
         si
 
-        parse(context: CONTEXT) -> Trees.Definitions.VARIANT is
+        parse(context: CONTEXT) -> Trees.Definitions.VARIANT? is
             let start = context.location;
             context.in_classy = true;
             context.global_indent = start.start_column;

--- a/src/syntax/parsers/expressions/primary.ghul
+++ b/src/syntax/parsers/expressions/primary.ghul
@@ -521,8 +521,8 @@ namespace Syntax.Parsers.Expressions is
                 fi
             fi
 
-            let alignment: Trees.Expressions.Expression mut = null;
-            let format: string mut = null;
+            let alignment: Trees.Expressions.Expression? mut = null;
+            let format: string? mut = null;
 
             let line mut = 0;
 
@@ -541,7 +541,9 @@ namespace Syntax.Parsers.Expressions is
                     fi
                 fi
 
-                line = alignment.location.end_line;
+                if alignment? then
+                    line = alignment.location.end_line;
+                fi
             fi
 
             if context.current_token == Lexical.TOKEN.COLON then

--- a/src/syntax/parsers/expressions/secondary.ghul
+++ b/src/syntax/parsers/expressions/secondary.ghul
@@ -62,7 +62,7 @@ namespace Syntax.Parsers.Expressions is
 
                     let done mut = false;
 
-                    let left: Trees.Expressions.Expression mut = default;
+                    let left: Trees.Expressions.Expression? mut = default;
                     let identifier: Trees.Identifiers.Identifier mut = default;
 
                     if result.is_member then
@@ -315,7 +315,7 @@ namespace Syntax.Parsers.Expressions is
                     
                     let type_arguments = type_list_parser.parse(context);
 
-                    let left: Trees.Expressions.Expression mut = default;
+                    let left: Trees.Expressions.Expression? mut = default;
                     let identifier: Trees.Identifiers.Identifier mut = default;
 
                     if result.is_member then

--- a/src/syntax/parsers/expressions/tuple.ghul
+++ b/src/syntax/parsers/expressions/tuple.ghul
@@ -13,7 +13,7 @@ namespace Syntax.Parsers.Expressions is
             self.expression_list_parser = expression_list_parser;
         si
 
-        parse(context: CONTEXT) -> Trees.Expressions.TUPLE is
+        parse(context: CONTEXT) -> Trees.Expressions.TUPLE? is
             let start = context.location;
 
             if context.next_token(Lexical.TOKEN.PAREN_OPEN, syntax_error_message) then

--- a/src/syntax/parsers/identifiers/identifier.ghul
+++ b/src/syntax/parsers/identifiers/identifier.ghul
@@ -10,7 +10,7 @@ namespace Syntax.Parsers.Identifiers is
             super.init();
         si
 
-        parse(context: CONTEXT) -> Trees.Identifiers.Identifier =>
+        parse(context: CONTEXT) -> Trees.Identifiers.Identifier? =>
             if context.expect_token(Lexical.TOKEN.IDENTIFIER, syntax_error_message) then
                 let name = context.current.value_string;
                 let result = Trees.Identifiers.Identifier(context.location, name);

--- a/src/syntax/parsers/identifiers/qualified.ghul
+++ b/src/syntax/parsers/identifiers/qualified.ghul
@@ -11,7 +11,7 @@ namespace Syntax.Parsers.Identifiers is
             super.init();
         si
 
-        parse(context: CONTEXT) -> Trees.Identifiers.Identifier is
+        parse(context: CONTEXT) -> Trees.Identifiers.Identifier? is
             let start = context.location;
             
             if context.expect_token(Lexical.TOKEN.IDENTIFIER, syntax_error_message) then

--- a/src/syntax/parsers/modifiers/modifier.ghul
+++ b/src/syntax/parsers/modifiers/modifier.ghul
@@ -38,6 +38,6 @@ namespace Syntax.Parsers.Modifiers is
             );
         si
 
-        other_token(context: CONTEXT) -> Trees.Modifiers.Modifier => null;
+        other_token(context: CONTEXT) -> Trees.Modifiers.Modifier? => null;
     si
 si

--- a/src/syntax/parsers/pragmas/pragma.ghul
+++ b/src/syntax/parsers/pragmas/pragma.ghul
@@ -18,7 +18,7 @@ namespace Syntax.Parsers.Pragmas is
             self.expression_list_parser = expression_list_parser;
         si
 
-        parse(context: CONTEXT) -> Trees.Pragmas.PRAGMA is
+        parse(context: CONTEXT) -> Trees.Pragmas.PRAGMA? is
             let fail = false;
             let expect_semicolon = false;
             

--- a/src/syntax/parsers/statements/node.ghul
+++ b/src/syntax/parsers/statements/node.ghul
@@ -194,7 +194,7 @@ namespace Syntax.Parsers.Statements is
                         context.current.token == Lexical.TOKEN.DEFAULT
                     do
                         let match_start = context.location;
-                        let match_expressions: Trees.Expressions.LIST mut = null;
+                        let match_expressions: Trees.Expressions.LIST? mut = null;
                         if context.current.token != Lexical.TOKEN.DEFAULT then
                             context.next_token(Lexical.TOKEN.WHEN);
                             match_expressions = expression_list_parser.parse(context);
@@ -261,7 +261,7 @@ namespace Syntax.Parsers.Statements is
             add_parser(
                 (context) is
                     let start = context.location;
-                    let condition: Trees.Expressions.Expression mut = default;
+                    let condition: Trees.Expressions.Expression? mut = default;
 
                     if context.current.token == Lexical.TOKEN.WHILE then
                         context.next_token();
@@ -374,7 +374,7 @@ namespace Syntax.Parsers.Statements is
 
             do
                 let branch_start = context.location;
-                let condition: Trees.Expressions.Expression mut = default;
+                let condition: Trees.Expressions.Expression? mut = default;
                 let binding: Trees.Variables.VARIABLE mut = default;
 
                 if
@@ -469,7 +469,7 @@ namespace Syntax.Parsers.Statements is
             return probe? /\ context.current_token == Lexical.TOKEN.THEN;
         si
 
-        parse_if_let_binding(context: CONTEXT) -> Trees.Variables.VARIABLE is
+        parse_if_let_binding(context: CONTEXT) -> Trees.Variables.VARIABLE? is
             let variable = variable_parser.parse(context);
 
             if !variable? then
@@ -513,7 +513,7 @@ namespace Syntax.Parsers.Statements is
             return variable;
         si
 
-        other_token(context: CONTEXT) -> Trees.Statements.Statement is
+        other_token(context: CONTEXT) -> Trees.Statements.Statement? is
             if context.current.token == Lexical.TOKEN.IDENTIFIER then
                 let want_backtrack = true;
 

--- a/src/syntax/parsers/statements/pragma.ghul
+++ b/src/syntax/parsers/statements/pragma.ghul
@@ -15,7 +15,7 @@ namespace Syntax.Parsers.Statements is
             self.statement_parser = statement_parser;
         si
 
-        parse(context: CONTEXT) -> Trees.Statements.PRAGMA is
+        parse(context: CONTEXT) -> Trees.Statements.PRAGMA? is
             let pragma = pragma_parser.parse(context);
 
             if pragma? /\ !pragma.is_poisoned then

--- a/src/syntax/parsers/variables/destructure_left.ghul
+++ b/src/syntax/parsers/variables/destructure_left.ghul
@@ -13,7 +13,7 @@ namespace Syntax.Parsers.Variables is
             self.identifier_parser = identifier_parser;
         si
 
-        parse(context: CONTEXT) -> Trees.Variables.DESTRUCTURING_VARIABLE_LEFT is
+        parse(context: CONTEXT) -> Trees.Variables.DESTRUCTURING_VARIABLE_LEFT? is
             let start = context.location;
             let end mut = context.location;
             let elements = Collections.LIST[Trees.Variables.VariableLeft]();

--- a/src/syntax/parsers/variables/variable.ghul
+++ b/src/syntax/parsers/variables/variable.ghul
@@ -20,7 +20,7 @@ namespace Syntax.Parsers.Variables is
             self.expression_parser = expression_parser;
         si
 
-        parse(context: CONTEXT) -> Trees.Variables.VARIABLE is
+        parse(context: CONTEXT) -> Trees.Variables.VARIABLE? is
             let start = context.location;
 
             let variable_left: Trees.Variables.VariableLeft mut;

--- a/src/syntax/process/add_accessors_for_properties.ghul
+++ b/src/syntax/process/add_accessors_for_properties.ghul
@@ -561,7 +561,7 @@ namespace Syntax.Process is
         fields: Variables.LIST,
         property_name: string,
         want_concrete: bool
-    ) -> Definitions.PROPERTY is
+    ) -> Definitions.PROPERTY? is
         if fields.count == 0 then
             return null;
         fi
@@ -608,7 +608,7 @@ namespace Syntax.Process is
         fields: Variables.LIST,
         property_name: string,
         want_concrete: bool
-    ) -> Definitions.FUNCTION
+    ) -> Definitions.FUNCTION?
     is
         if fields.count == 0 then
             return null;
@@ -659,7 +659,7 @@ namespace Syntax.Process is
         variant_type_arguments: TypeExpressions.LIST,
         fields: Variables.LIST, 
         property_name: string
-    ) -> Definitions.PROPERTY is
+    ) -> Definitions.PROPERTY? is
         if !fields? \/ fields.count == 0 then
             return null;
         fi

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -124,7 +124,7 @@ namespace Syntax.Process is
         // otherwise. Caller-bounded to predicates whose narrowing
         // target must be a simple-identifier — qualified or
         // member-access targets are v1-deferred.
-        try_get_narrowing_target(expr: Trees.Expressions.Expression) -> Semantic.Symbols.Variable is
+        try_get_narrowing_target(expr: Trees.Expressions.Expression) -> Semantic.Symbols.Variable? is
             if !expr? \/ !isa Trees.Expressions.IDENTIFIER(expr) then
                 return null;
             fi
@@ -303,7 +303,7 @@ namespace Syntax.Process is
         try_describe_intersection_miss(
             receiver_type: Type,
             member_name: string
-        ) -> string is
+        ) -> string? is
             if !isa Semantic.Types.ONE_OF(receiver_type) then
                 return null;
             fi
@@ -390,7 +390,7 @@ namespace Syntax.Process is
 
         should_skip(node: Trees.Node) -> bool => _stub_depth > 0 \/ is_stable(node);
 
-        get_zero_argument_function(type: Type, name: string) -> Semantic.Symbols.Function is
+        get_zero_argument_function(type: Type, name: string) -> Semantic.Symbols.Function? is
             let symbol = type.find_member(name);
 
             if symbol? /\ isa Semantic.Symbols.FUNCTION_GROUP(symbol) then
@@ -964,7 +964,7 @@ namespace Syntax.Process is
             let names = Collections.LIST[string]();
 
             for element in elements do
-                let name: string mut = null;
+                let name: string? mut = null;
 
                 if element.is_simple_expression /\ isa Trees.Expressions.IDENTIFIER(element.expression) then
                     let id = cast Trees.Expressions.IDENTIFIER(element.expression);
@@ -1151,7 +1151,7 @@ namespace Syntax.Process is
         // subsequent normal walk through pre(SIMPLE_LEFT_EXPRESSION)
         // overwrites the inner expression's value with the STORE form
         // anyway, so the probe's read-form value never escapes.
-        _try_get_assignment_left_type(left: Trees.Expressions.AssignmentLeftExpression) -> Type is
+        _try_get_assignment_left_type(left: Trees.Expressions.AssignmentLeftExpression) -> Type? is
             let simple = cast Trees.Expressions.SIMPLE_LEFT_EXPRESSION(left);
 
             if !simple? \/ !simple.expression? then
@@ -1424,7 +1424,7 @@ namespace Syntax.Process is
         si
 
         // The frame for the `try` currently being walked, or null.
-        _try_flow_frame: TRY_FLOW_FRAME =>
+        _try_flow_frame: TRY_FLOW_FRAME? =>
             if _try_flow_stack.count > 0 then
                 _try_flow_stack[_try_flow_stack.count - 1]
             else
@@ -1982,7 +1982,7 @@ namespace Syntax.Process is
             let stack = _symbol_table.stack;
             let index mut = stack.count - 1;
             let seen_self mut = false;
-            let outer_recursive: Semantic.Symbols.Closure mut = null;
+            let outer_recursive: Semantic.Symbols.Closure? mut = null;
             let intermediates = Collections.LIST[Semantic.Symbols.Closure]();
 
             while index >= 0 do
@@ -2046,12 +2046,12 @@ namespace Syntax.Process is
         si
 
         visit(tuple: Trees.Expressions.TUPLE) is
-            let names mut = Collections.LIST[string]();
+            let names: Collections.LIST[string]? mut = Collections.LIST[string]();
             let values = Collections.LIST[Value]();
             let types = Collections.LIST[Type]();
 
-            let element_constraints: Collections.List[Type] mut = null;
-            let constraint_error_message: string mut = null;
+            let element_constraints: Collections.List[Type]? mut = null;
+            let constraint_error_message: string? mut = null;
 
             if tuple.constraint? /\ tuple.constraint.is_value_tuple then
                 element_constraints = tuple.constraint.arguments;
@@ -2695,7 +2695,7 @@ namespace Syntax.Process is
             argument_types: Collections.List[Semantic.Types.Type],
             cache_key: Trees.Node,
             location: LOCATION
-        ) -> Semantic.Symbols.Function is
+        ) -> Semantic.Symbols.Function? is
             if !candidate? \/ !cache_key? then
                 return candidate;
             fi
@@ -2726,7 +2726,7 @@ namespace Syntax.Process is
             group: Semantic.Symbols.FUNCTION_GROUP,
             arg_count: int,
             want_instance: bool
-        ) -> Semantic.Symbols.Function is
+        ) -> Semantic.Symbols.Function? is
             let result: Semantic.Symbols.Function mut = default;
             let count mut = 0;
 
@@ -3625,7 +3625,7 @@ namespace Syntax.Process is
             elif result == Trees.Expressions.AMBIGUOUS_EXPRESSION_RESULT.TYPE then
                 ambiguous_expression.value = TYPE_EXPRESSION(result_type, ambiguous_expression.location);
             elif result == Trees.Expressions.AMBIGUOUS_EXPRESSION_RESULT.FUNCTION then
-                let left_value: Value =
+                let left_value: Value? =
                     if ambiguous_expression.left? then
                         ambiguous_expression.left.value;
                     else
@@ -3705,7 +3705,7 @@ namespace Syntax.Process is
             elif result == Trees.Expressions.AMBIGUOUS_EXPRESSION_RESULT.TYPE then
                 generic_application.value = TYPE_EXPRESSION(result_type, generic_application.location);
             elif result == Trees.Expressions.AMBIGUOUS_EXPRESSION_RESULT.FUNCTION then
-                let left_value: Value =
+                let left_value: Value? =
                     if generic_application.left? then
                         generic_application.left.value;
                     else
@@ -4265,7 +4265,7 @@ namespace Syntax.Process is
         // Walk the scope stack from current_function outward to find
         // the recursive closure a `rec` reference here would bind to.
         // Mirrors the lookup in `visit(RECURSE)`.
-        _find_recursive_target() -> Semantic.Symbols.Closure is
+        _find_recursive_target() -> Semantic.Symbols.Closure? is
             let function = current_function;
 
             if !function? \/ !function.is_closure then
@@ -4340,7 +4340,7 @@ namespace Syntax.Process is
                 // resolved symbol's type when the value's snapshot
                 // is null — happens for outer-scope locals captured
                 // into a nested closure before being typed.
-                let actual: Semantic.Types.Type mut = null;
+                let actual: Semantic.Types.Type? mut = null;
                 if arg_expr? /\ arg_expr.value? /\ arg_expr.value.type? then
                     actual = arg_expr.value.type;
                 elif isa Trees.Expressions.IDENTIFIER(arg_expr) then
@@ -4559,7 +4559,7 @@ namespace Syntax.Process is
                                     continue;
                                 fi
 
-                                let f = push_candidate.arguments[index];
+                                let f = push_candidate!.arguments[index];
 
                                 if f? then
                                     a.set_constraint(f, "{{0}} is not assignable to {{1}}");

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -864,8 +864,21 @@ namespace Syntax.Process is
             if target_variable? then
                 _flow.on_assignment(target_variable);
                 _flow.mark_assigned(target_variable);
+
+                // A non-nullable RHS leaves the target known to hold
+                // a value — so `_field = arg; _field.method()` does
+                // not warn.
+                if _is_non_nullable_value(left.value) then
+                    _flow.mark_non_null(target_variable);
+                fi
             fi
         si
+
+        // True iff `value` is statically known to hold a value — its
+        // type is settled and is not a nullable / null type.
+        _is_non_nullable_value(value: IR.Values.Value) -> bool =>
+            value? /\ value.type? /\ value.type.is_settled /\
+            !value.type.is_null /\ !value.type.is_nullable;
         
         // Resolve the per-element members for a destructure (see
         // DESTRUCTURE_RESOLVER) and log an error against `location`
@@ -3793,6 +3806,17 @@ namespace Syntax.Process is
 
                 if left.right_value? then
                     left.value = symbol.store(left.location, null, left.right_value, _symbol_loader, true);
+
+                    // A non-nullable initializer leaves the local
+                    // known to hold a value — even where its declared
+                    // type is `T?` — so a following dereference does
+                    // not warn.
+                    if
+                        isa Semantic.Symbols.Variable(symbol) /\
+                        _is_non_nullable_value(left.right_value)
+                    then
+                        _flow.mark_non_null(cast Semantic.Symbols.Variable(symbol));
+                    fi
                 fi
             else
                 _logger.error(left.name.location, "couldn't find typed symbol for variable {left.name}");

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -2082,7 +2082,7 @@ namespace Syntax.Process is
                     let element = v;
 
                     seen_any_named = true;
-                    names.add(element.name.name);
+                    names!.add(element.name.name);
 
                     if element.initializer? then
                         if Value.check_is_consumable(_logger, element.initializer.location, element.initializer.value) then
@@ -2133,7 +2133,7 @@ namespace Syntax.Process is
                     types.add(Semantic.Types.ERROR());
 
                 elif Value.check_is_consumable(_logger, v.location, v.value) then
-                    names.add("`{index}");
+                    names!.add("`{index}");
 
                     if element_type_constraint? then
                         let type = element_type_constraint;
@@ -2648,7 +2648,7 @@ namespace Syntax.Process is
                 return;
             fi
 
-            let function mut = overload_result.function;
+            let function mut = overload_result!.function;
 
             function = _owner_constraint_specializer.specialize_from_constraint(`new.location, function, `new.constraint);
 
@@ -2866,7 +2866,7 @@ namespace Syntax.Process is
                 return (cast Value(Load.SYMBOL(null, function_group)), cast Value(DUMMY(type, location)));
             fi
 
-            if overload_result.score == Semantic.Types.MATCH.PARTIAL then
+            if overload_result!.score == Semantic.Types.MATCH.PARTIAL then
                 _logger.roll_back();
                 _logger.speculate();
 
@@ -2875,7 +2875,7 @@ namespace Syntax.Process is
                     if !a? then
                         continue;
                     elif a.value? /\ isa Trees.Expressions.FUNCTION(a) then
-                        let f = overload_result.function.arguments[index];
+                        let f = overload_result!.function.arguments[index];
 
                         a.set_constraint(f, "{{0}} is not assignable to {{1}}");
                         a.walk(self);
@@ -2896,7 +2896,7 @@ namespace Syntax.Process is
                 fi
             fi
 
-            let function mut = overload_result.function;
+            let function mut = overload_result!.function;
 
             function = _owner_constraint_specializer.specialize_from_constraint(location, function, constraint);
             function = _type_arg_placeholder_registry.specialize_with_placeholders(location, function, cache_key);
@@ -2967,7 +2967,7 @@ namespace Syntax.Process is
                     return;
                 fi
 
-                let function = overload_result.function;
+                let function = overload_result!.function;
 
                 if function.is_unsafe_constraints then
                     _logger.warn(unary.location, "call to {function} has unchecked constraints");
@@ -4591,7 +4591,7 @@ namespace Syntax.Process is
                         return;
                     fi
 
-                    if overload_result.score == Semantic.Types.MATCH.PARTIAL then
+                    if overload_result!.score == Semantic.Types.MATCH.PARTIAL then
                         // PARTIAL re-specialisation: the resolver may
                         // have driven its type-arg binding from a
                         // tainted lambda actual whose body errored on
@@ -4613,7 +4613,7 @@ namespace Syntax.Process is
                         // body could produce). Re-specialise so those
                         // slots become phantoms — back-feedable from
                         // inside the lambda body.
-                        let push_function mut = overload_result.function;
+                        let push_function mut = overload_result!.function;
 
                         if
                             _partial_arguments_contain_error(push_function) \/

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -2095,7 +2095,7 @@ namespace Syntax.Process is
                                     fi;
 
                                 if element.type_expression.check_is_not_reference(_logger, "tuple element cannot be a reference") then
-                                    if !type.is_assignable_from(element.initializer.value.type) then
+                                    if !type!.is_assignable_from(element.initializer.value.type) then
                                         _logger.error(element.location, "{element.initializer.value.type} is not assignable to {type}");
                                     elif element_type_constraint? /\ !element_type_constraint.is_assignable_from(element.type_expression.type) then
                                         _logger.error(
@@ -4002,6 +4002,10 @@ namespace Syntax.Process is
             fi
 
             let elements = left.elements;
+
+            if !elements? then
+                return;
+            fi
 
             let names = Collections.LIST[string]();
 

--- a/src/syntax/process/condition_analysis.ghul
+++ b/src/syntax/process/condition_analysis.ghul
@@ -216,6 +216,8 @@ namespace Syntax.Process is
                             NARROW_ENV.join(l.then_env, r.then_env),
                             r.else_env
                         );
+                    elif op =~ "==" then
+                        return _analyze_null_compare(binary, in_env);
                     fi
                 fi
             elif isa Trees.Expressions.UNARY(cond) then
@@ -242,6 +244,37 @@ namespace Syntax.Process is
         // edges keep the incoming environment.
         _opaque(in_env: NARROW_ENV) -> CONDITION_FACTS =>
             CONDITION_FACTS(in_env.copy(), in_env.copy());
+
+        // `x != null` / `x == null` — the comparison narrows the
+        // non-null operand. `!=` puts it on the true edge, `==` on the
+        // false edge. The `==` real operation covers both surface
+        // forms; `actual_operation` distinguishes them.
+        _analyze_null_compare(binary: Trees.Expressions.BINARY, in_env: NARROW_ENV) -> CONDITION_FACTS is
+            let then_env = in_env.copy();
+            let else_env = in_env.copy();
+
+            let operand: Trees.Expressions.Expression mut = default;
+
+            if isa Trees.Expressions.NULL(binary.right) then
+                operand = binary.left;
+            elif isa Trees.Expressions.NULL(binary.left) then
+                operand = binary.right;
+            fi
+
+            if operand? then
+                let target = _resolve_target(operand);
+
+                if target? then
+                    if binary.actual_operation? /\ binary.actual_operation =~ "!=" then
+                        then_env.set_non_null(target);
+                    else
+                        else_env.set_non_null(target);
+                    fi
+                fi
+            fi
+
+            return CONDITION_FACTS(then_env, else_env);
+        si
 
         _analyze_isa(`isa: Trees.Expressions.ISA, in_env: NARROW_ENV) -> CONDITION_FACTS is
             let then_env = in_env.copy();

--- a/src/syntax/process/condition_analysis.ghul
+++ b/src/syntax/process/condition_analysis.ghul
@@ -43,7 +43,7 @@ namespace Syntax.Process is
         // Drill `type` to the underlying Classy (peeling Symbols.GENERIC
         // wrapping for specialized generics). Null if `type` isn't a
         // NAMED of a Classy.
-        get_classy_for_narrowing(type: Type) -> Semantic.Symbols.Classy is
+        get_classy_for_narrowing(type: Type) -> Semantic.Symbols.Classy? is
             if !type? \/ !isa Semantic.Types.NAMED(type) then
                 return null;
             fi
@@ -65,7 +65,7 @@ namespace Syntax.Process is
         // variant-type construction. ONE_OF holds its original union
         // NAMED/GENERIC as `underlying_type`; any other NAMED can be
         // used directly.
-        pick_underlying_type(receiver_type: Type) -> Semantic.Types.NAMED is
+        pick_underlying_type(receiver_type: Type) -> Semantic.Types.NAMED? is
             if !receiver_type? then
                 return null;
             fi
@@ -88,7 +88,7 @@ namespace Syntax.Process is
         try_get_variant_for_is_accessor(
             receiver_type: Type,
             member_name: string
-        ) -> Semantic.Symbols.Classy is
+        ) -> Semantic.Symbols.Classy? is
             if !is_variant_accessor_name(member_name) then
                 return null;
             fi
@@ -127,7 +127,7 @@ namespace Syntax.Process is
         try_get_variant_type_for_is_accessor(
             receiver_type: Type,
             member_name: string
-        ) -> Type is
+        ) -> Type? is
             let variant = try_get_variant_for_is_accessor(receiver_type, member_name);
 
             if !variant? then
@@ -150,7 +150,7 @@ namespace Syntax.Process is
         try_get_complement_after_eliminated(
             receiver_type: Type,
             eliminated: Collections.Iterable[Semantic.Symbols.Classy]
-        ) -> Type is
+        ) -> Type? is
             let classy = get_classy_for_narrowing(receiver_type);
 
             if !classy? \/ !classy.is_union then

--- a/src/syntax/process/generate_il.ghul
+++ b/src/syntax/process/generate_il.ghul
@@ -1104,7 +1104,7 @@ namespace Syntax.Process is
 
             if `assert.message? then
                 let message_value = `assert.message.value; 
-                if !_innate_symbol_lookup.get_exception_type().is_assignable_from(message_value.type) then
+                if !_innate_symbol_lookup.get_exception_type().is_assignable_from(message_value!.type) then
                     add(
                         Literal.STRING(
                             "{`assert.location}: ",
@@ -1198,7 +1198,7 @@ namespace Syntax.Process is
                 while i >= 0 do
                     let v = to_dispose[i];
 
-                    let skip_label: LABEL mut = null;
+                    let skip_label: LABEL? mut = null;
 
                     if !v.type.is_value_type then
                         skip_label = LABEL();
@@ -1254,7 +1254,7 @@ namespace Syntax.Process is
 
             for b in `if.branches do
                 let next = LABEL();
-                let if_let_temp: TEMP mut = null;
+                let if_let_temp: TEMP? mut = null;
 
                 if b.condition? then
                     b.condition.walk(self);
@@ -1278,16 +1278,16 @@ namespace Syntax.Process is
                         // The presence test: a reference type is absent
                         // when null; an option-shaped value type is
                         // absent when its `has_value` member is false.
-                        let presence: Value mut = null;
+                        let presence: Value? mut = null;
 
                         if init_type? /\ init_type.is_value_type then
                             let has_value_member = init_type.find_member("has_value");
 
                             if has_value_member? then
-                                presence = has_value_member.load(LOCATION.internal, if_let_temp.load(), _symbol_loader);
+                                presence = has_value_member.load(LOCATION.internal, if_let_temp!.load(), _symbol_loader);
                             fi
                         else
-                            presence = if_let_temp.load();
+                            presence = if_let_temp!.load();
                         fi
 
                         if presence? then
@@ -1815,13 +1815,13 @@ namespace Syntax.Process is
     si
 
     class LOOP_LABEL_STACK is
-        _next_name: string;
+        _next_name: string?;
 
         loops: Collections.MutableList[LOOP_LABELS];
         is_in_loop: bool => get_current_loop() != null;
         is_in_try: bool => get_current_try() != null;
 
-        get_current_try() -> LOOP_LABELS is
+        get_current_try() -> LOOP_LABELS? is
             let index: int mut = loops.count - 1;
             
             while index >= 0 do
@@ -1836,7 +1836,7 @@ namespace Syntax.Process is
             return null;
         si
 
-        get_current_loop() -> LOOP_LABELS is
+        get_current_loop() -> LOOP_LABELS? is
             let index: int mut = loops.count - 1;
             
             while index >= 0 do
@@ -1859,7 +1859,7 @@ namespace Syntax.Process is
             _next_name = name;
         si
 
-        find(name: string) -> LOOP_LABELS is
+        find(name: string) -> LOOP_LABELS? is
             for i in loops.count..0 do
                 Std.error.write_line("try loop {i} out of {loops.count}");
 

--- a/src/syntax/process/generate_il.ghul
+++ b/src/syntax/process/generate_il.ghul
@@ -197,7 +197,7 @@ namespace Syntax.Process is
             println_comment("define {symbol.description}");
 
             let buffer = System.Text.StringBuilder();
-            symbol.gen_definition_header(buffer);
+            symbol!.gen_definition_header(buffer);
 
             println(buffer);
 
@@ -506,7 +506,7 @@ namespace Syntax.Process is
             let symbol = current_scope.find_member(enum_member.name.name);
 
             let buffer = System.Text.StringBuilder();
-            symbol.gen_definition_header(buffer);
+            symbol!.gen_definition_header(buffer);
             println(buffer);
             return false;
         si
@@ -521,7 +521,7 @@ namespace Syntax.Process is
             println_comment("define {symbol.description}");
 
             let buffer = System.Text.StringBuilder();
-            symbol.gen_definition_header(buffer);
+            symbol!.gen_definition_header(buffer);
             println(buffer);
 
             println("{{");
@@ -688,7 +688,7 @@ namespace Syntax.Process is
             fi
 
             let buffer = System.Text.StringBuilder();
-            symbol.gen_definition_header(buffer);
+            symbol!.gen_definition_header(buffer);
             println(buffer.to_string());
 
             if globals_namespace? then
@@ -928,7 +928,7 @@ namespace Syntax.Process is
                     globals_namespace = cast Semantic.Symbols.NAMESPACE(global_variable.owner);
                 fi
 
-                symbol.gen_definition_header(buffer);
+                symbol!.gen_definition_header(buffer);
             od
 
             if buffer.length > 0 then
@@ -1562,7 +1562,7 @@ namespace Syntax.Process is
 
             let symbol = find(`catch.variable.name);
 
-            add("stloc {symbol.get_il_reference()}");
+            add("stloc {symbol!.get_il_reference()}");
 
             `catch.body.walk(self);
 

--- a/src/syntax/process/narrow_env.ghul
+++ b/src/syntax/process/narrow_env.ghul
@@ -54,7 +54,7 @@ namespace Syntax.Process is
 
         // The narrowed type recorded for `v`, or null when `v` is
         // not narrowed in this environment.
-        narrowed_type_of(v: Variable) -> Type is
+        narrowed_type_of(v: Variable) -> Type? is
             let result: Type mut = default;
 
             if _narrows.try_get_value(v, result ref) then

--- a/src/syntax/process/narrowing_flow.ghul
+++ b/src/syntax/process/narrowing_flow.ghul
@@ -99,7 +99,7 @@ namespace Syntax.Process is
 
         // The declared (pre-narrowing) type of `v` — used for the
         // assignment-LHS typecheck, which must see past any narrow.
-        declared_type_of(v: Variable) -> Type is
+        declared_type_of(v: Variable) -> Type? is
             if !v? then
                 return null;
             fi

--- a/src/syntax/process/numeric_literal_classifier.ghul
+++ b/src/syntax/process/numeric_literal_classifier.ghul
@@ -33,7 +33,7 @@ namespace Syntax.Process is
             _innate_symbol_lookup = innate_symbol_lookup;
         si
 
-        classify_integer(location: LOCATION, value_string: string) -> Literal.NUMBER is
+        classify_integer(location: LOCATION, value_string: string) -> Literal.NUMBER? is
             let type: Type mut;
             let suffix mut = "i4";
             let conv: string mut = default;

--- a/src/syntax/process/resolve_explicit_variable_types.ghul
+++ b/src/syntax/process/resolve_explicit_variable_types.ghul
@@ -91,16 +91,16 @@ namespace Syntax.Process is
             od
 
             if !isa Trees.TypeExpressions.INFER(function.type_expression) then
-                symbol.return_type = function.type_expression.type;
+                symbol!.return_type = function.type_expression.type;
 
                 // FIXME QQ should probably do this
                 // symbol.set_return_type(function.type_expression.type);
             else
-                symbol.set_void_return_type();
+                symbol!.set_void_return_type();
             fi
 
-            symbol.arguments = types;
-            symbol.argument_names = names;
+            symbol!.arguments = types;
+            symbol!.argument_names = names;
 
             super.visit(function);
         si

--- a/src/syntax/process/resolve_type_expressions.ghul
+++ b/src/syntax/process/resolve_type_expressions.ghul
@@ -257,7 +257,7 @@ namespace Syntax.Process is
         si
 
         visit(tuple: Trees.TypeExpressions.TUPLE) is
-            let names mut = Collections.LIST[string]();
+            let names: Collections.LIST[string]? mut = Collections.LIST[string]();
             let types = Collections.LIST[Type]();
 
             let seen_any_named mut = false;

--- a/src/syntax/process/resolve_type_expressions.ghul
+++ b/src/syntax/process/resolve_type_expressions.ghul
@@ -266,7 +266,7 @@ namespace Syntax.Process is
                 if isa Trees.TypeExpressions.NAMED_TUPLE_ELEMENT(a) then
                     let element = cast Trees.TypeExpressions.NAMED_TUPLE_ELEMENT(a);
 
-                    names.add(element.name.name);
+                    names!.add(element.name.name);
                     seen_any_named = true;
 
                     if element.type_expression? then
@@ -275,7 +275,7 @@ namespace Syntax.Process is
                         types.add(Semantic.Types.ERROR());
                     fi
                 else
-                    names.add("`{index}");
+                    names!.add("`{index}");
                     types.add(get_type_or_any(a.type));
                 fi
             od

--- a/src/syntax/process/scopedvisitor.ghul
+++ b/src/syntax/process/scopedvisitor.ghul
@@ -49,7 +49,7 @@ namespace Syntax.Process is
                     return null;
                 fi
 
-                result = qualifier.find_member(identifier.name);
+                result = qualifier!.find_member(identifier.name);
             else
                 result =
                     _symbol_table

--- a/src/syntax/process/scopedvisitor.ghul
+++ b/src/syntax/process/scopedvisitor.ghul
@@ -35,7 +35,7 @@ namespace Syntax.Process is
             _symbol_table.current_scope.find_enclosing_matches(prefix, matches);
         si
         
-        find(identifier: Identifiers.Identifier) -> Semantic.Symbols.Symbol is
+        find(identifier: Identifiers.Identifier) -> Semantic.Symbols.Symbol? is
             if identifier.name == null then
                 return null;
             fi

--- a/src/syntax/process/scopevisitorbase.ghul
+++ b/src/syntax/process/scopevisitorbase.ghul
@@ -40,7 +40,7 @@ namespace Syntax is
 
         function_for(node: Node) -> Semantic.Symbols.Function => cast Semantic.Symbols.Function(_symbol_table.scope_for(node));
 
-        find_member(identifier: Identifiers.Identifier) -> Semantic.Symbols.Symbol is
+        find_member(identifier: Identifiers.Identifier) -> Semantic.Symbols.Symbol? is
             let qualifier = identifier.qualifier;
 
             if qualifier? then
@@ -58,7 +58,7 @@ namespace Syntax is
             fi
         si
 
-        find_enclosing(identifier: Identifiers.Identifier) -> Semantic.Symbols.Symbol is
+        find_enclosing(identifier: Identifiers.Identifier) -> Semantic.Symbols.Symbol? is
             let qualifier = identifier.qualifier;
 
             if qualifier? then

--- a/src/syntax/process/signature_help.ghul
+++ b/src/syntax/process/signature_help.ghul
@@ -157,7 +157,7 @@ namespace Syntax.Process is
 
             let overload_results = _overload_resolver.find_matches(function_group, argument_types);
 
-            if overload_results.results.count == 0 then
+            if overload_results!.results.count == 0 then
                 return null;
             fi
 
@@ -195,7 +195,7 @@ namespace Syntax.Process is
 
             let overload_results = _overload_resolver.find_matches(function_group, argument_types);
 
-            if overload_results.results.count == 0 then
+            if overload_results!.results.count == 0 then
                 return null;
             fi
 

--- a/src/syntax/process/signature_help.ghul
+++ b/src/syntax/process/signature_help.ghul
@@ -175,7 +175,7 @@ namespace Syntax.Process is
                 return null;
             fi
 
-            let symbol = type.find_member("init");
+            let symbol = type!.find_member("init");
 
             if !symbol? \/ !symbol.is_function_group then
                 return null;

--- a/src/syntax/process/signature_help.ghul
+++ b/src/syntax/process/signature_help.ghul
@@ -11,7 +11,7 @@ namespace Syntax.Process is
         _target_line: int;
         _target_column: int;
 
-        _results: Semantic.OVERLOAD_MATCHES_RESULT;
+        _results: Semantic.OVERLOAD_MATCHES_RESULT?;
 
         init(
             logger: Logger,
@@ -25,7 +25,7 @@ namespace Syntax.Process is
             _overload_resolver = overload_resolver;
         si
 
-        find_signatures(root: Trees.Node, target_line: int, target_column: int) -> Semantic.OVERLOAD_MATCHES_RESULT is
+        find_signatures(root: Trees.Node, target_line: int, target_column: int) -> Semantic.OVERLOAD_MATCHES_RESULT? is
             _results = null;
 
             _target_line = target_line;
@@ -128,7 +128,7 @@ namespace Syntax.Process is
             return 0;
         si
         
-        help_for(call: Trees.Expressions.CALL) -> Semantic.OVERLOAD_MATCHES_RESULT is
+        help_for(call: Trees.Expressions.CALL) -> Semantic.OVERLOAD_MATCHES_RESULT? is
             if _results? then
                 return null;
             fi
@@ -164,7 +164,7 @@ namespace Syntax.Process is
             return overload_results;
         si
 
-        help_for(`new: Trees.Expressions.NEW) -> Semantic.OVERLOAD_MATCHES_RESULT is
+        help_for(`new: Trees.Expressions.NEW) -> Semantic.OVERLOAD_MATCHES_RESULT? is
             if _results? then
                 return null;
             fi

--- a/src/syntax/trees/definitions/pragma.ghul
+++ b/src/syntax/trees/definitions/pragma.ghul
@@ -20,7 +20,7 @@ namespace Syntax.Trees.Definitions is
 
         is_name_equal_to(name: string) -> bool => pragma? /\ pragma.is_name_equal_to(name);
 
-        try_get_string_literal_at(index: int) -> string =>
+        try_get_string_literal_at(index: int) -> string? =>
             if pragma? then
                 pragma.try_get_string_literal_at(index)
             else

--- a/src/syntax/trees/definitions/variables/variable.ghul
+++ b/src/syntax/trees/definitions/variables/variable.ghul
@@ -99,9 +99,9 @@ namespace Syntax.Trees.Variables is
 
     class VariableLeft: Trees.Node is
         is_simple_name: bool => false;
-        name: Identifiers.Identifier => null;
-        names: Collections.Iterator[Identifiers.Identifier] => null;
-        elements: Collections.List[VariableLeft] => null;
+        name: Identifiers.Identifier? => null;
+        names: Collections.Iterator[Identifiers.Identifier]? => null;
+        elements: Collections.List[VariableLeft]? => null;
 
         // used in compile expressions pass:
         value: IR.Values.Value public; // code to store from the initializer
@@ -216,7 +216,7 @@ namespace Syntax.Trees.Variables is
     class DESTRUCTURE_LEFT_NAMES_ITERATOR: Collections.Iterator[Identifiers.Identifier] is
         _stack: Collections.STACK[Collections.Iterator[VariableLeft]];
 
-        current: Identifiers.Identifier;
+        current: Identifiers.Identifier?;
 
         init(elements: Collections.List[VariableLeft]) is
             _stack = Collections.STACK[Collections.Iterator[VariableLeft]]();

--- a/src/syntax/trees/expressions/assignment_left.ghul
+++ b/src/syntax/trees/expressions/assignment_left.ghul
@@ -3,9 +3,9 @@ namespace Syntax.Trees.Expressions is
 
     class AssignmentLeftExpression: Expression is
         is_simple_expression: bool => false;
-        expression: Expression => null;
-        expressions: Collections.Iterator[Expression] => null;
-        elements: Collections.List[AssignmentLeftExpression] => null;
+        expression: Expression? => null;
+        expressions: Collections.Iterator[Expression]? => null;
+        elements: Collections.List[AssignmentLeftExpression]? => null;
         assign_location: LOCATION public;
 
         init(location: LOCATION) is
@@ -110,7 +110,7 @@ namespace Syntax.Trees.Expressions is
     class DESTRUCTURE_LEFT_NAMES_ITERATOR: Collections.Iterator[Expression] is
         _stack: Collections.STACK[Collections.Iterator[AssignmentLeftExpression]];
 
-        current: Expression;
+        current: Expression?;
 
         init(elements: Collections.List[AssignmentLeftExpression]) is
             _stack = Collections.STACK[Collections.Iterator[AssignmentLeftExpression]]();

--- a/src/syntax/trees/expressions/call.ghul
+++ b/src/syntax/trees/expressions/call.ghul
@@ -12,8 +12,8 @@ namespace Syntax.Trees.Expressions is
         // call (e.g. `Box()` against `let b: Box[int]`) the visitor uses
         // it to bind the owner generic arguments when they can't be
         // inferred from the supplied constructor arguments alone.
-        constraint: Semantic.Types.Type;
-        constraint_error_message: string;
+        constraint: Semantic.Types.Type?;
+        constraint_error_message: string?;
 
         init(location: LOCATION, function: Expression, arguments: LIST) is
             super.init(location);

--- a/src/syntax/trees/expressions/default.ghul
+++ b/src/syntax/trees/expressions/default.ghul
@@ -10,8 +10,8 @@ namespace Syntax.Trees.Expressions is
         // Constraint pushed in by the parent context (assignment RHS,
         // return position, typed `let` initializer, call argument).
         // For a bare `default` this is what gives it its type.
-        constraint: Semantic.Types.Type;
-        constraint_error_message: string;
+        constraint: Semantic.Types.Type?;
+        constraint_error_message: string?;
 
         init(location: LOCATION, type_expression: TypeExpressions.TypeExpression) is
             super.init(location);

--- a/src/syntax/trees/expressions/explicit_specialization.ghul
+++ b/src/syntax/trees/expressions/explicit_specialization.ghul
@@ -3,7 +3,7 @@ namespace Syntax.Trees.Expressions is
 
     use IR.Values.Value;
     class EXPLICIT_SPECIALIZATION: Expression is
-        value: Value public; // FIXME: should this be here?
+        value: Value? public; // FIXME: should this be here?
 
         left: Expression;
         types: TypeExpressions.LIST;

--- a/src/syntax/trees/expressions/expression.ghul
+++ b/src/syntax/trees/expressions/expression.ghul
@@ -6,7 +6,7 @@ namespace Syntax.Trees.Expressions is
     use Logging;
 
     class Expression: Trees.Node, TypeConstrained is
-        value: Value public;
+        value: Value? public;
         right_location: LOCATION => location;
 
         is_identifier: bool => false;
@@ -24,8 +24,8 @@ namespace Syntax.Trees.Expressions is
         // Default storage is "no constraint". Subclasses that carry an
         // actual constraint (SEQUENCE, TUPLE, ...) shadow these with
         // real fields and override the mutators.
-        constraint: Semantic.Types.Type => null;
-        concrete_constraint: Semantic.Types.Type => null;
+        constraint: Semantic.Types.Type? => null;
+        concrete_constraint: Semantic.Types.Type? => null;
 
         init(location: LOCATION) is
             super.init(location);
@@ -35,16 +35,16 @@ namespace Syntax.Trees.Expressions is
             visitor.visit(self);
         si
 
-        try_copy_as_variables() -> Variables.LIST => null;
-        try_copy_as_variable() -> VARIABLE => null;
-        try_copy_as_tuple_element() -> TUPLE_ELEMENT => null;
-        try_copy_as_type_expression() -> TypeExpressions.TypeExpression => null;
-        try_copy_as_identifer() -> Identifiers.Identifier => null;
+        try_copy_as_variables() -> Variables.LIST? => null;
+        try_copy_as_variable() -> VARIABLE? => null;
+        try_copy_as_tuple_element() -> TUPLE_ELEMENT? => null;
+        try_copy_as_type_expression() -> TypeExpressions.TypeExpression? => null;
+        try_copy_as_identifer() -> Identifiers.Identifier? => null;
 
         rewrite_as_assignment_left() -> AssignmentLeftExpression => SIMPLE_LEFT_EXPRESSION(location, self);
         rewrite_as_expression() -> Expression => self;
 
-        try_get_string_literal() -> string => null;
+        try_get_string_literal() -> string? => null;
 
         set_constraint(constraint: Semantic.Types.Type, error_message: string) is si
         clear_constraint() is si

--- a/src/syntax/trees/expressions/function.ghul
+++ b/src/syntax/trees/expressions/function.ghul
@@ -13,8 +13,8 @@ namespace Syntax.Trees.Expressions is
         // for argument-type inference when the existing
         // _partial_argument_function_type implication channel hasn't
         // been set.
-        constraint: Semantic.Types.Type;
-        constraint_error_message: string;
+        constraint: Semantic.Types.Type?;
+        constraint_error_message: string?;
 
         init(
             location: LOCATION,

--- a/src/syntax/trees/expressions/identifier.ghul
+++ b/src/syntax/trees/expressions/identifier.ghul
@@ -11,7 +11,7 @@ namespace Syntax.Trees.Expressions is
         is_identifier: bool => true;
         is_unqualified_identifier: bool => identifier? /\ !identifier.is_qualified;
 
-        try_copy_as_type_expression() -> TypeExpressions.TypeExpression =>
+        try_copy_as_type_expression() -> TypeExpressions.TypeExpression? =>
             if could_be_type_expression then
                 return TypeExpressions.NAMED(location, identifier.copy());
             else

--- a/src/syntax/trees/expressions/list.ghul
+++ b/src/syntax/trees/expressions/list.ghul
@@ -13,7 +13,7 @@ namespace Syntax.Trees.Expressions is
 
         iterator: Collections.Iterator[Expression] => expressions.iterator;
 
-        try_get_string_literal_at(index: int) -> string =>
+        try_get_string_literal_at(index: int) -> string? =>
             if expressions? /\ index < expressions.count then
                 expressions[index].try_get_string_literal()
             else

--- a/src/syntax/trees/expressions/literals/string.ghul
+++ b/src/syntax/trees/expressions/literals/string.ghul
@@ -11,7 +11,7 @@ namespace Syntax.Trees.Expressions.Literals is
             visitor.visit(self);
         si
 
-        try_get_string_literal() -> string =>
+        try_get_string_literal() -> string? =>
             if value_string? /\ value_string.length > 0 then
                 value_string
             else

--- a/src/syntax/trees/expressions/member.ghul
+++ b/src/syntax/trees/expressions/member.ghul
@@ -11,7 +11,7 @@ namespace Syntax.Trees.Expressions is
         is_member: bool => true;
         could_be_type_expression: bool => left.could_be_type_expression;
 
-        try_copy_as_identifer() -> Identifiers.Identifier =>
+        try_copy_as_identifer() -> Identifiers.Identifier? =>
             let maybe_left_as_identifier = left.try_copy_as_identifer() in
             if maybe_left_as_identifier? then
                 Trees.Identifiers.QUALIFIED(

--- a/src/syntax/trees/expressions/new.ghul
+++ b/src/syntax/trees/expressions/new.ghul
@@ -11,8 +11,8 @@ namespace Syntax.Trees.Expressions is
         // the constraint to bind owner generic arguments when they
         // can't be inferred from the supplied constructor arguments
         // alone.
-        constraint: Semantic.Types.Type;
-        constraint_error_message: string;
+        constraint: Semantic.Types.Type?;
+        constraint_error_message: string?;
 
         init(location: LOCATION, type_expression: TypeExpressions.TypeExpression, arguments: LIST) is
             super.init(location);

--- a/src/syntax/trees/expressions/null.ghul
+++ b/src/syntax/trees/expressions/null.ghul
@@ -7,8 +7,8 @@ namespace Syntax.Trees.Expressions is
         // initializer, assignment RHS, return position, call
         // argument). When it is the value-type OPTION[T], `null`
         // lowers to an empty Nullable rather than a bare ldnull.
-        constraint: Semantic.Types.Type;
-        constraint_error_message: string;
+        constraint: Semantic.Types.Type?;
+        constraint_error_message: string?;
 
         init(location: LOCATION) is
             super.init(location);

--- a/src/syntax/trees/expressions/sequence.ghul
+++ b/src/syntax/trees/expressions/sequence.ghul
@@ -5,8 +5,8 @@ namespace Syntax.Trees.Expressions is
     class SEQUENCE: Expression  is
         elements: LIST;
         type_expression: TypeExpressions.TypeExpression;
-        constraint: Semantic.Types.Type;
-        constraint_error_message: string;
+        constraint: Semantic.Types.Type?;
+        constraint_error_message: string?;
 
         init(location: LOCATION, elements: LIST, type_expression: TypeExpressions.TypeExpression) is
             super.init(location);

--- a/src/syntax/trees/expressions/statement.ghul
+++ b/src/syntax/trees/expressions/statement.ghul
@@ -3,7 +3,7 @@ namespace Syntax.Trees.Expressions is
 
     class STATEMENT: Expression is
         statement: Statements.Statement;
-        temp: IR.TEMP public;
+        temp: IR.TEMP? public;
 
         is_tuple_literal: bool => statement.is_tuple_literal;
 

--- a/src/syntax/trees/expressions/tuple.ghul
+++ b/src/syntax/trees/expressions/tuple.ghul
@@ -15,8 +15,8 @@ namespace Syntax.Trees.Expressions is
         is_tuple_literal: bool => elements.expressions.count != 1;
 
         elements: LIST;
-        constraint: Semantic.Types.Type;
-        constraint_error_message: string;
+        constraint: Semantic.Types.Type?;
+        constraint_error_message: string?;
 
         could_be_formal_argument: bool => true;
 

--- a/src/syntax/trees/identifiers/identifier.ghul
+++ b/src/syntax/trees/identifiers/identifier.ghul
@@ -6,7 +6,7 @@ namespace Syntax.Trees.Identifiers is
     class Identifier: Trees.Node, Collections.Iterable[string] is
         name: string public;
 
-        qualifier: Identifier => null;
+        qualifier: Identifier? => null;
         
         qualifier_names: Collections.LIST[string] => Collections.LIST[string](0);
 

--- a/src/syntax/trees/pragmas/pragma.ghul
+++ b/src/syntax/trees/pragmas/pragma.ghul
@@ -20,7 +20,7 @@ namespace Syntax.Trees.Pragmas is
 
         is_name_equal_to(other_name: string) -> bool => name? /\ other_name =~ name.name;
 
-        try_get_string_literal_at(index: int) -> string is
+        try_get_string_literal_at(index: int) -> string? is
             if !arguments? then
                 return null;
             fi

--- a/src/syntax/trees/statements/if.ghul
+++ b/src/syntax/trees/statements/if.ghul
@@ -6,8 +6,8 @@ namespace Syntax.Trees.Statements is
     class IF: Statement is
         branches: Collections.Iterable[IF_BRANCH];
         provides_value: bool => true;
-        constraint: Semantic.Types.Type;
-        constraint_error_message: string;
+        constraint: Semantic.Types.Type?;
+        constraint_error_message: string?;
 
         is_tuple_literal: bool => 
             if branches | .all(b => b.body.is_tuple_literal) then

--- a/src/syntax/trees/statements/list.ghul
+++ b/src/syntax/trees/statements/list.ghul
@@ -34,7 +34,7 @@ namespace Syntax.Trees.Statements is
 
         is_empty: bool => _statements.count == 0;
 
-        last: Statement =>
+        last: Statement? =>
             if _statements.count == 0 then
                 null
             else

--- a/src/syntax/trees/statements/pragma.ghul
+++ b/src/syntax/trees/statements/pragma.ghul
@@ -4,7 +4,7 @@ namespace Syntax.Trees.Statements is
 
     class PRAGMA: Statement  is
         pragma: Pragmas.PRAGMA;
-        statement: Statement public;
+        statement: Statement? public;
         
         init(
             location: LOCATION,

--- a/src/syntax/trees/statements/statement.ghul
+++ b/src/syntax/trees/statements/statement.ghul
@@ -5,7 +5,7 @@ namespace Syntax.Trees.Statements is
     use Logging;
     
     class Statement: Trees.Node  is
-        value: Value public;
+        value: Value? public;
         expects_semicolon: bool => false;
         provides_value: bool => false;
         is_tuple_literal: bool => false;

--- a/src/syntax/trees/type_expressions/generic.ghul
+++ b/src/syntax/trees/type_expressions/generic.ghul
@@ -9,7 +9,7 @@ namespace Syntax.Trees.TypeExpressions is
         is_void: bool =>
             arguments | .any(e => e? /\ e.is_void);
 
-        try_copy_as_value_expression() -> Expressions.Expression is
+        try_copy_as_value_expression() -> Expressions.Expression? is
             if arguments.count != 1 then
                 return null;
             fi

--- a/src/syntax/trees/type_expressions/member.ghul
+++ b/src/syntax/trees/type_expressions/member.ghul
@@ -5,7 +5,7 @@ namespace Syntax.Trees.TypeExpressions is
         left: TypeExpression;
         name: Identifiers.Identifier;
 
-        try_copy_as_value_expression() -> Expressions.Expression =>
+        try_copy_as_value_expression() -> Expressions.Expression? =>
             let maybe_left = left.try_copy_as_value_expression() in
             if maybe_left? then
                 Expressions.MEMBER(location, left.try_copy_as_value_expression(), name.copy(), name.location)

--- a/src/syntax/trees/type_expressions/tuple.ghul
+++ b/src/syntax/trees/type_expressions/tuple.ghul
@@ -18,7 +18,7 @@ namespace Syntax.Trees.TypeExpressions is
                 elements.shallow_copy()
             );
 
-        try_copy_as_value_expression() -> Trees.Expressions.Expression is
+        try_copy_as_value_expression() -> Trees.Expressions.Expression? is
             let args = Collections.LIST[Trees.Expressions.Expression]();
 
             for e in elements do

--- a/src/syntax/trees/type_expressions/type_expression.ghul
+++ b/src/syntax/trees/type_expressions/type_expression.ghul
@@ -7,10 +7,10 @@ namespace Syntax.Trees.TypeExpressions is
     use Semantic.Types.Type;
 
     class TypeExpression: Trees.Node, Semantic.Types.SettableTyped is
-        name: Identifiers.Identifier => null;
-        type_expression: TypeExpression => null;
+        name: Identifiers.Identifier? => null;
+        type_expression: TypeExpression? => null;
 
-        type: Type public;
+        type: Type? public;
         right_location: LOCATION => location;
         is_named: bool => false;
         is_bare_identifier: bool => false;
@@ -20,7 +20,7 @@ namespace Syntax.Trees.TypeExpressions is
 
         could_be_value_expression: bool => false;
 
-        try_copy_as_value_expression() -> Expressions.Expression => null;
+        try_copy_as_value_expression() -> Expressions.Expression? => null;
 
         check_is_not_reference(logger: Logging.Logger, message: string) -> bool is
             if is_reference then


### PR DESCRIPTION
Technical:
- Annotate the compiler's own `src/` with `?` nullability — every type that can hold null outside its owner's constructor is now marked nullable, and the dereferences that follow are guarded or asserted with `!`.
- Drives the possible-null-dereference and non-nullable-by-default warnings on `src/` to zero. Bootstrap remains byte-identical.