### PR TITLE
Recycle the analyser on heap growth, not operation count

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.12.13",
+      "version": "0.12.14",
       "commands": [
         "ghul-compiler"
       ],

--- a/analysis-tests/src/protocol/analyser_process.ghul
+++ b/analysis-tests/src/protocol/analyser_process.ghul
@@ -363,6 +363,17 @@ namespace Analysis.Protocol is
             flush();
         si
 
+        // Ask the analyser to recycle. It answers with a RESTART frame and
+        // then exits, so the IDE can spawn a fresh process.
+        send_restart() is
+            write("#RESTART#\n");
+            flush();
+        si
+
+        // Block until the subprocess exits, up to timeout_ms. True if it exited.
+        wait_for_exit(timeout_ms: int) -> bool =>
+            _process.wait_for_exit(timeout_ms);
+
         send_hover(path: string, line: int, column: int) is
             write("#HOVER#\n");
             write("{path}\n");

--- a/analysis-tests/src/tests/recycle_tests.ghul
+++ b/analysis-tests/src/tests/recycle_tests.ghul
@@ -1,0 +1,38 @@
+namespace Analysis.Tests is
+    use Analysis.Protocol.ANALYSER_PROCESS;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    // The analyser recycles itself (heap growth, instability) and on an explicit
+    // RESTART command, all through WATCHDOG.recycle: emit a RESTART frame, then
+    // exit so the IDE can spawn a fresh process. This pins that contract for the
+    // one trigger a test can drive deterministically — the RESTART command.
+    class RECYCLE_TESTS is
+        @test()
+
+        init() is si
+
+        restart_command_should_emit_restart_frame_then_exit() is
+            @test()
+
+            let use analyser = ANALYSER_PROCESS();
+
+            analyser.send_restart();
+
+            let response = analyser.read_response();
+
+            Assert.are_equal(
+                "RESTART",
+                response.header,
+                "RESTART command should answer with a RESTART frame\n"
+                "--- analyser stderr ---\n{analyser.stderr_capture}"
+            );
+
+            Assert.is_true(
+                analyser.wait_for_exit(5000),
+                "analyser did not exit after the RESTART frame\n"
+                "--- analyser stderr ---\n{analyser.stderr_capture}"
+            );
+        si
+    si
+si

--- a/src/analysis/analyser.ghul
+++ b/src/analysis/analyser.ghul
@@ -68,7 +68,7 @@ namespace Analysis is
             let references_handler = REFERENCES_HANDLER(watchdog, symbol_use_locations, full_compiler);
             let implementation_handler = IMPLEMENTATION_HANDLER(watchdog, symbol_use_locations, full_compiler);
             let rename_request_handler = RENAME_REQUEST_HANDLER(watchdog, symbol_use_locations, full_compiler);
-            let restart_handler = RESTART_HANDLER();
+            let restart_handler = RESTART_HANDLER(watchdog);
 
             _despatcher.add_handler(
                 "EDIT", file_edited_handler

--- a/src/analysis/command_despatcher.ghul
+++ b/src/analysis/command_despatcher.ghul
@@ -63,17 +63,13 @@ namespace Analysis is
                 if _command_map.contains_key(command) then
                     let handler = _command_map[command];
 
-                    if _watchdog.want_restart /\ command !~ "EDIT" /\ command !~ "ANALYSE" then
-                        _log.write_line("poisoned: should ignore non-edit command: {command}");
-                    fi
-
                     let timer_name = command.to_lower_invariant();
 
                     _timers.start(timer_name);
                     handler.handle(_reader, _writer);
                     _timers.finish(timer_name);
-                    
-                    _watchdog.increment(_writer);
+
+                    _watchdog.on_operation_complete(_writer);
 
                     if _want_stats_report then
                         let elapsed_since_last_report = System.DateTime.now.subtract(_last_report_time);
@@ -90,6 +86,7 @@ namespace Analysis is
                     _log.write_line("ghūl: no handler found for command: '{command}' in {_command_map}");
 
                     _watchdog.request_restart();
+                    _watchdog.on_operation_complete(_writer);
 
                     return true;
                 fi
@@ -142,10 +139,6 @@ namespace Analysis is
             od
 
             return null;
-        si
-                
-        restart(writer: IO.TextWriter) is
-            throw System.NotImplementedException("restart");
         si
     si
 si

--- a/src/analysis/command_handlers.ghul
+++ b/src/analysis/command_handlers.ghul
@@ -247,9 +247,9 @@ namespace Analysis is
                     _compiler.build();
 
                     IoC.CONTAINER.instance.logger.write_all_diagnostics(writer, IoC.CONTAINER.instance.logger_formatter);
-                fi
 
-                _watchdog.enable();
+                    _watchdog.note_full_compile();
+                fi
 
             catch e: Exception
                 debug_always("FULL_COMPILE caught: {e.get_type()}: {e.message}");
@@ -380,10 +380,8 @@ namespace Analysis is
                     _compiler.queue(self);
                     _compiler.build();
 
-                    IoC.CONTAINER.instance.logger.write_all_diagnostics(writer, IoC.CONTAINER.instance.logger_formatter);        
+                    IoC.CONTAINER.instance.logger.write_all_diagnostics(writer, IoC.CONTAINER.instance.logger_formatter);
                 fi
-
-                _watchdog.enable();
 
             catch ex: Exception
                 debug_always("ANALYSE caught: {ex.get_type()} {ex.message}");
@@ -465,10 +463,10 @@ namespace Analysis is
 
                     _compiler.build();
 
-                    IoC.CONTAINER.instance.logger.write_all_diagnostics(writer, IoC.CONTAINER.instance.logger_formatter);        
+                    IoC.CONTAINER.instance.logger.write_all_diagnostics(writer, IoC.CONTAINER.instance.logger_formatter);
+
+                    _watchdog.note_full_compile();
                 fi
- 
-                _watchdog.enable();
 
             catch ex: Exception
                 debug_always("FULL COMPILE caught: {ex.get_type()} {ex.message}");
@@ -993,15 +991,16 @@ namespace Analysis is
     si    
 
     class RESTART_HANDLER: CommandHandler is
-        init() is si
+        _watchdog: WATCHDOG;
+
+        init(watchdog: WATCHDOG) is
+            _watchdog = watchdog;
+        si
 
         handle(reader: IO.TextReader, writer: IO.TextWriter) is
             IoC.CONTAINER.instance.want_tab_delimited_logger(writer);
 
-            writer.write("{cast char(12)}");
-            writer.close();
-
-            System.Environment.exit(1);
+            _watchdog.recycle(writer, "client requested restart");
         si
     si
 si

--- a/src/analysis/watchdog.ghul
+++ b/src/analysis/watchdog.ghul
@@ -1,65 +1,131 @@
 namespace Analysis is
-    use System.Exception;
     use IO.Std;
 
-    use Collections.Iterable;
+    // Decides when the long-lived analyser should exit so the IDE can spawn a
+    // fresh process. Two independent triggers:
+    //
+    //  - heap growth: the managed heap is sampled after the first full compile
+    //    to fix a baseline, then after every later full compile. The compiler
+    //    retains state across compiles (ASTs, caches) that clear_symbols does
+    //    not all reclaim, so a steady climb is the expected leak signature.
+    //    A recycle returns that memory to a fresh process.
+    //
+    //  - instability: a burst of exceptions escaping command handlers. Isolated
+    //    failures decay away; a sustained run of them means the analyser's
+    //    state is corrupt and a fresh process is the only recovery.
+    class WATCHDOG is
+        // Recycle once the heap has grown past both thresholds relative to the
+        // baseline: a multiple of it, and an absolute floor so a small baseline
+        // can't trip a recycle on ordinary working-set noise.
+        heap_growth_factor: double static => 2.0D;
+        heap_growth_floor_bytes: long static => 256L * 1024L * 1024L;
 
-    use Pair = Collections.KeyValuePair`2;
+        // Consecutive failing operations needed to trip an instability recycle.
+        // request_restart() adds 2 per failure, a clean operation decays 1, so
+        // this is reached by roughly this many failures in an unbroken run.
+        instability_limit: int static => 20;
 
-    use IoC;
-    use Logging;
-    use Source;
-    use Compiler;
+        // How often to echo a heap reading to the log (every Nth full compile).
+        heap_log_interval: int static => 32;
 
-    class WATCHDOG is        
-        operation_limit: int static => 10000;
+        _restart_score: int;
 
-        _is_enabled: bool;
-        _operation_count: int;
-        _restart_count: int;
+        _have_baseline: bool;
+        _baseline_heap_bytes: long;
+        _full_compile_pending: bool;
+        _compile_count: int;
 
         want_restart: bool;
 
         init() is si
 
+        // An exception escaped a command handler. Nudge the instability score;
+        // a sustained run of failures trips want_restart, isolated ones decay.
         request_restart() is
-            _restart_count = _restart_count + 2;
+            _restart_score = _restart_score + 2;
 
-            if _restart_count > 20 then
+            if _restart_score > instability_limit then
                 want_restart = true;
             fi
         si
-        
-        enable() is
-            _is_enabled = true;
+
+        // A full project compile completed successfully. The heap reading is
+        // taken at the next operation boundary (on_operation_complete), once
+        // the in-flight response frame has been flushed.
+        note_full_compile() is
+            _full_compile_pending = true;
+            _compile_count = _compile_count + 1;
         si
 
-        increment(writer: IO.TextWriter) is
-            if _is_enabled then
-                _operation_count = _operation_count + 1;
-            fi
-            
-            if want_restart \/ _operation_count > operation_limit then
-                want_restart = false;
-
-                if want_restart then
-                    Std.error.write_line("watchdog: restart due to instability...");
-                else
-                    Std.error.write_line("watchdog: recycle...");
-                fi
-
-                Std.error.flush();
-
-                writer.write_line("RESTART");
-                writer.write("{cast char(12)}");
-                writer.flush();
-
-                System.Environment.exit(1);
+        // Called by the despatcher after every command, once the handler has
+        // returned and its response is on the wire. This is the only place a
+        // recycle is issued, so a recycle never truncates a response frame.
+        on_operation_complete(writer: IO.TextWriter) is
+            if want_restart then
+                recycle(writer, "instability");
             fi
 
-            if _restart_count > 0 then
-                _restart_count = _restart_count - 1;
+            if _restart_score > 0 then
+                _restart_score = _restart_score - 1;
             fi
+
+            if _full_compile_pending then
+                _full_compile_pending = false;
+
+                check_heap(writer);
+            fi
+        si
+
+        check_heap(writer: IO.TextWriter) is
+            let heap = System.GC.get_total_memory(true);
+
+            if !_have_baseline then
+                set_baseline(heap);
+
+                return;
+            fi
+
+            if _compile_count % heap_log_interval == 0 then
+                log_heap("heap", heap);
+            fi
+
+            if is_heap_over_limit(heap) then
+                log_heap("heap", heap);
+                recycle(writer, "heap growth");
+            fi
+        si
+
+        set_baseline(heap: long) is
+            _have_baseline = true;
+            _baseline_heap_bytes = heap;
+
+            log_heap("baseline", heap);
+        si
+
+        // The recycle decision for a heap reading. Pure — no sampling, no exit —
+        // so it can be exercised directly by unit tests. Both thresholds must be
+        // crossed: a multiple of the baseline and an absolute byte floor.
+        is_heap_over_limit(heap: long) -> bool =>
+            _have_baseline /\
+            heap - _baseline_heap_bytes > heap_growth_floor_bytes /\
+            cast double(heap) > cast double(_baseline_heap_bytes) * heap_growth_factor;
+
+        log_heap(label: string, heap: long) is
+            Std.error.write_line(
+                "watchdog: {label} {heap / 1024L / 1024L} MB (baseline {_baseline_heap_bytes / 1024L / 1024L} MB, {_compile_count} compiles)"
+            );
+            Std.error.flush();
+        si
+
+        recycle(writer: IO.TextWriter, reason: string) is
+            Std.error.write_line("watchdog: recycling analyser ({reason})");
+            Std.error.flush();
+
+            writer.write_line("RESTART");
+            writer.write("{cast char(12)}");
+            writer.flush();
+
+            System.Environment.exit(1);
         si
     si
 si

--- a/unit-tests/src/analysis/watchdog_tests.ghul
+++ b/unit-tests/src/analysis/watchdog_tests.ghul
@@ -1,0 +1,86 @@
+namespace Analysis.UnitTests is
+    use Analysis.WATCHDOG;
+
+    class WATCHDOG_TESTS is
+        @test()
+
+        init() is si
+
+        mb(n: int) -> long => cast long(n) * 1024L * 1024L;
+
+        given_a_new_watchdog__want_restart__should_be_false() is
+            @test()
+
+            let watchdog = WATCHDOG();
+
+            assert !watchdog.want_restart;
+        si
+
+        given_failures_below_the_instability_limit__want_restart__should_be_false() is
+            @test()
+
+            let watchdog = WATCHDOG();
+
+            // request_restart() adds 2 each; 10 calls reach exactly the limit (20).
+            for i in 0..10 do
+                watchdog.request_restart();
+            od
+
+            assert !watchdog.want_restart;
+        si
+
+        given_failures_past_the_instability_limit__want_restart__should_be_true() is
+            @test()
+
+            let watchdog = WATCHDOG();
+
+            for i in 0..11 do
+                watchdog.request_restart();
+            od
+
+            assert watchdog.want_restart;
+        si
+
+        given_no_baseline__is_heap_over_limit__should_be_false() is
+            @test()
+
+            let watchdog = WATCHDOG();
+
+            assert !watchdog.is_heap_over_limit(mb(8000));
+        si
+
+        given_a_baseline__heap_within_both_thresholds__should_not_be_over_limit() is
+            @test()
+
+            let watchdog = WATCHDOG();
+
+            watchdog.set_baseline(mb(100));
+
+            // 200 MB: over the factor (>2x) but only 100 MB above the baseline,
+            // short of the 256 MB floor.
+            assert !watchdog.is_heap_over_limit(mb(200));
+        si
+
+        given_a_baseline__heap_over_the_floor_but_within_the_factor__should_not_be_over_limit() is
+            @test()
+
+            let watchdog = WATCHDOG();
+
+            watchdog.set_baseline(mb(500));
+
+            // 900 MB: 400 MB above the baseline (over the floor) but below 2x.
+            assert !watchdog.is_heap_over_limit(mb(900));
+        si
+
+        given_a_baseline__heap_past_both_thresholds__should_be_over_limit() is
+            @test()
+
+            let watchdog = WATCHDOG();
+
+            watchdog.set_baseline(mb(100));
+
+            // 400 MB: 300 MB above the baseline and over 2x.
+            assert watchdog.is_heap_over_limit(mb(400));
+        si
+    si
+si


### PR DESCRIPTION
Technical:
- The analysis-mode watchdog recycled the long-lived analyser after a fixed 10000 operations — a count unrelated to actual memory use, so it recycled mid-session for a heavy user and never for a light one. It now takes a managed-heap baseline after the first full compile and recycles when the heap later climbs past both twice the baseline and 256 MB above it, sampled after each full compile.
- WATCHDOG rewritten around that heuristic; the exception-instability trigger is retained. Recycle and the RESTART command share one exit path emitting a consistent RESTART frame — the command previously emitted a bare form-feed, which the IDE read as a protocol error. Dead COMMAND_DESPATCHER.restart() removed.
- analysis-tests cover the RESTART recycle path; unit tests pin the heap and instability thresholds.