### PR TITLE
Add a code formatter

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.12.14",
+      "version": "0.12.16",
       "commands": [
         "ghul-compiler"
       ],

--- a/src/analysis/analyser.ghul
+++ b/src/analysis/analyser.ghul
@@ -69,6 +69,7 @@ namespace Analysis is
             let implementation_handler = IMPLEMENTATION_HANDLER(watchdog, symbol_use_locations, full_compiler);
             let rename_request_handler = RENAME_REQUEST_HANDLER(watchdog, symbol_use_locations, full_compiler);
             let restart_handler = RESTART_HANDLER(watchdog);
+            let format_handler = FORMAT_HANDLER(compiler, build_flags);
 
             _despatcher.add_handler(
                 "EDIT", file_edited_handler
@@ -116,6 +117,10 @@ namespace Analysis is
 
             _despatcher.add_handler(
                 "RESTART", restart_handler
+            );
+
+            _despatcher.add_handler(
+                "FORMAT", format_handler
             );
         si
 

--- a/src/analysis/command_handlers.ghul
+++ b/src/analysis/command_handlers.ghul
@@ -1003,4 +1003,63 @@ namespace Analysis is
             _watchdog.recycle(writer, "client requested restart");
         si
     si
+
+    // Reformats a single file. The request frame is the file path followed
+    // by the buffer contents (form-feed terminated); the buffer is parsed
+    // fresh — no symbol table, no dependence on prior EDIT state — and the
+    // reformatted text is returned whole. On any failure the original buffer
+    // is echoed back unchanged, so a format request can never corrupt it.
+    class FORMAT_HANDLER: CommandHandler is
+        _compiler: COMPILER;
+        _build_flags: BUILD_FLAGS;
+
+        init(compiler: COMPILER, build_flags: BUILD_FLAGS) is
+            _compiler = compiler;
+            _build_flags = build_flags;
+        si
+
+        handle(reader: IO.TextReader, writer: IO.TextWriter) is
+            let path = reader.read_line();
+
+            let buffer = System.Text.StringBuilder();
+
+            do
+                let c = reader.read();
+                if c < 0 \/ c == 12 then
+                    break;
+                fi
+                buffer.append(cast char(c));
+            od
+
+            let source = buffer.to_string();
+
+            let result mut = source;
+
+            try
+                IoC.CONTAINER.instance.logger.clear(path, false);
+
+                let source_file =
+                    _compiler.parse(
+                        path,
+                        IO.StringReader(source),
+                        _build_flags,
+                        false
+                    );
+
+                if !IoC.CONTAINER.instance.logger.any_errors then
+                    let formatter =
+                        Syntax.Process.Printer.FORMATTER(source_file.trivia, 100);
+
+                    result = formatter.format(source_file.definition);
+                fi
+            catch ex: Exception
+                debug_always("FORMAT caught: {ex.get_type()} {ex.message}");
+            yrt
+
+            writer.write_line("FORMAT");
+            writer.write(result);
+            writer.write("{cast char(12)}");
+            writer.flush();
+        si
+    si
 si

--- a/src/compiler/compiler.ghul
+++ b/src/compiler/compiler.ghul
@@ -201,6 +201,8 @@ namespace Compiler is
                     )
                 );
 
+            result.trivia = tokenizer.trivia;
+
             return result;
         si
 

--- a/src/compiler/source_file.ghul
+++ b/src/compiler/source_file.ghul
@@ -12,6 +12,10 @@ namespace Compiler is
         // the build loop after each successful pass.apply.
         compiled_through: Pass? public;
 
+        // Comments and blank-line markers collected by the tokenizer, in
+        // source order. Used by the formatter; null when not captured.
+        trivia: Collections.Iterable[Lexical.TRIVIA] public;
+
         init(
             build_flags: BUILD_FLAGS,
             file_name: string,

--- a/src/driver/main.ghul
+++ b/src/driver/main.ghul
@@ -38,6 +38,8 @@ namespace Driver is
 
         emit_boilerplate_il: string;
 
+        want_format: bool;
+
         compiler_version: string is
             let assembly_version = 
                 System.Reflection.Assembly.get_entry_assembly().get_custom_attributes(typeof System.Reflection.AssemblyInformationalVersionAttribute, false) |
@@ -125,6 +127,12 @@ namespace Driver is
 
                 if flags.want_analyse then
                     analyse();
+
+                    System.Environment.exit(0);
+                fi
+
+                if want_format then
+                    format_files();
 
                     System.Environment.exit(0);
                 fi
@@ -279,6 +287,8 @@ namespace Driver is
                     emit_boilerplate_il_path = get_next_argument(args_iterator);
                 elif s =~ "--show-analysis-stats" then
                     flags.want_analysis_stats = true;
+                elif s =~ "--format" then
+                    want_format = true;
                 elif s =~ "--warn-implicit-mutable-let" then
                     flags.want_warn_implicit_mutable_let = true;
                 elif s =~ "--no-warn-definite-return" then
@@ -318,6 +328,23 @@ namespace Driver is
             fi
             
             container.conditional_compilation.set_is_enabled(conditional_defines);
+        si
+
+        format_files() is
+            for path in ghul_source_files do
+                try
+                    let source_file =
+                        compiler.parse(path, File.open_text(path), flags, false);
+
+                    let formatter =
+                        Syntax.Process.Printer.FORMATTER(source_file.trivia, 100);
+
+                    Std.out.write(formatter.format(source_file.definition));
+                    Std.out.flush();
+                catch ex: Exception
+                    Std.error.write_line("error: could not format {path}: {ex.message}");
+                yrt
+            od
         si
 
         start_build() is

--- a/src/lexical/tokenizer.ghul
+++ b/src/lexical/tokenizer.ghul
@@ -87,6 +87,12 @@ namespace Lexical is
         _interpolation_depth: int;
         _expect_format_string: bool;
 
+        _trivia: Collections.LIST[TRIVIA];
+
+        // Comments and blank-line markers, in source order. Discarded by the
+        // parser; consumed by the formatter to round-trip non-token content.
+        trivia: Collections.Iterable[TRIVIA] => _trivia;
+
         static_init() static is 
             if _symbol_tokens == null then
                 _operator_chars = Collections.SET[char]([
@@ -166,6 +172,8 @@ namespace Lexical is
 
             _end_of_file = false;
             _input = i;
+
+            _trivia = Collections.LIST[TRIVIA]();
 
             static_init();
 
@@ -264,8 +272,17 @@ namespace Lexical is
 
         skip_white_space() -> char is
             let c: char mut = default;
+            let newlines mut = 0;
+            let blank_location: LOCATION mut = null;
             do
                 c = next_char();
+
+                if c == '\n' then
+                    newlines = newlines + 1;
+                    if newlines == 2 then
+                        blank_location = character_location;
+                    fi
+                fi
 
                 let is_white_space = (c==' ' \/ c==cast char(9) \/ c=='\n');
 
@@ -275,6 +292,11 @@ namespace Lexical is
                     break;
                 fi
             od
+
+            if newlines >= 2 /\ blank_location? then
+                _trivia.add(TRIVIA(TRIVIA_KIND.BLANK_LINE, null, blank_location));
+            fi
+
             return c;
         si
 
@@ -458,6 +480,7 @@ namespace Lexical is
                 r = _symbol_tokens[s];
                 return TOKEN_PAIR(r, location, s);
             elif c == '/' then
+                let comment_location = location;
                 c = next_char();
                 if c == '/' then
                     _buffer = System.Text.StringBuilder("//");
@@ -466,11 +489,19 @@ namespace Lexical is
                         if c != '\n' then
                             _buffer.append(c);
                         fi
-                        
+
                         if !(!_end_of_file/\c!='\n') then
                             break;
                         fi
                     od
+
+                    _trivia.add(
+                        TRIVIA(
+                            TRIVIA_KIND.LINE_COMMENT,
+                            _buffer.to_string().trim_end(),
+                            comment_location
+                        )
+                    );
 
                     return read_token();
                 elif c == '*' then
@@ -493,6 +524,16 @@ namespace Lexical is
                             break;
                         fi
                     od
+
+                    _buffer.append("*/");
+
+                    _trivia.add(
+                        TRIVIA(
+                            TRIVIA_KIND.BLOCK_COMMENT,
+                            _buffer.to_string(),
+                            comment_location
+                        )
+                    );
 
                     return read_token();
                 else

--- a/src/lexical/trivia.ghul
+++ b/src/lexical/trivia.ghul
@@ -1,0 +1,33 @@
+namespace Lexical is
+    use Source;
+
+    enum TRIVIA_KIND is
+        LINE_COMMENT,
+        BLOCK_COMMENT,
+        BLANK_LINE
+    si
+
+    // A piece of non-token source content the parser discards but the
+    // formatter must preserve: a comment, or a run of blank lines collapsed
+    // to a single marker. The tokenizer collects these in source order so
+    // the formatter can interleave them back into the printed AST by
+    // comparing locations.
+    class TRIVIA is
+        kind: TRIVIA_KIND;
+        text: string;
+        location: LOCATION;
+
+        init(kind: TRIVIA_KIND, text: string, location: LOCATION) is
+            self.kind = kind;
+            self.text = text;
+            self.location = location;
+        si
+
+        is_comment: bool =>
+            kind == TRIVIA_KIND.LINE_COMMENT \/ kind == TRIVIA_KIND.BLOCK_COMMENT;
+
+        is_blank_line: bool => kind == TRIVIA_KIND.BLANK_LINE;
+
+        to_string() -> string => "{location}: {kind} {text}";
+    si
+si

--- a/src/syntax/process/printer/doc.ghul
+++ b/src/syntax/process/printer/doc.ghul
@@ -1,0 +1,137 @@
+namespace Syntax.Process.Printer is
+    use Collections;
+
+    // Document intermediate representation for the layout engine.
+    //
+    // A formatter visitor builds a tree of these; DOC_RENDERER turns the tree
+    // into text against a column budget. A GROUP renders flat (its LINEs become
+    // spaces) when it fits the budget, otherwise broken (its LINEs become
+    // newlines). This is what trades horizontal width against vertical sprawl.
+    union DOC is
+        // Empty document.
+        NIL;
+        // Literal text. Must not contain newlines.
+        TEXT(text: string);
+        // Soft break: a space when the enclosing group is flat, a newline when
+        // broken.
+        LINE;
+        // Soft break with no flat-mode content: nothing when flat, a newline
+        // when broken.
+        SOFT_LINE;
+        // Unconditional newline. Forces every enclosing group to break.
+        HARD_LINE;
+        // Sequence of documents.
+        CONCAT(items: LIST[DOC]);
+        // Indent the contained document by `indent` extra columns when it
+        // breaks.
+        NEST(indent: int, doc: DOC);
+        // A breaking unit: rendered flat if it fits the budget, else broken.
+        GROUP(doc: DOC);
+    si
+
+    // One open group/nest frame in DOC_BUILDER's stack.
+    class DOC_FRAME is
+        items: LIST[DOC];
+        is_group: bool;
+        nest: int;
+
+        init(is_group: bool, nest: int) is
+            self.items = LIST[DOC]();
+            self.is_group = is_group;
+            self.nest = nest;
+        si
+    si
+
+    // Imperative builder for a DOC tree. Mirrors the write/indent/outdent shape
+    // of the old string-based printer so the visitor stays readable: emit text
+    // and breaks into the current frame, open a GROUP or NEST with begin_*, and
+    // close it with the matching end_*.
+    class DOC_BUILDER is
+        _stack: LIST[DOC_FRAME];
+
+        init() is
+            _stack = LIST[DOC_FRAME]();
+            _stack.add(DOC_FRAME(false, 0));
+        si
+
+        _top: DOC_FRAME => _stack[_stack.count - 1];
+
+        emit(d: DOC) is
+            _top.items.add(d);
+        si
+
+        text(s: string) is
+            emit(DOC.TEXT(s));
+        si
+
+        line() is
+            emit(DOC.LINE());
+        si
+
+        soft_line() is
+            emit(DOC.SOFT_LINE());
+        si
+
+        hard_line() is
+            emit(DOC.HARD_LINE());
+        si
+
+        begin_group() is
+            _stack.add(DOC_FRAME(true, 0));
+        si
+
+        // Open a nest. The newline that introduces an indented block is
+        // emitted (by the printer) just before the nest opens; absorb it so
+        // it lands inside the nest and is therefore indented — matching the
+        // depth-at-write-time behaviour of the old string printer.
+        begin_nest(amount: int) is
+            let frame = DOC_FRAME(false, amount);
+            let parent = _top;
+
+            if parent.items.count > 0 then
+                let last = parent.items[parent.items.count - 1];
+                if isa DOC.HARD_LINE(last) then
+                    parent.items.remove_at(parent.items.count - 1);
+                    frame.items.add(last);
+                fi
+            fi
+
+            _stack.add(frame);
+        si
+
+        end_group() is
+            let frame = _top;
+            _stack.remove_at(_stack.count - 1);
+            emit(DOC.GROUP(DOC.CONCAT(frame.items)));
+        si
+
+        // Close a nest. The block's last statement leaves a trailing newline
+        // inside the nest; eject it so the closing keyword that follows sits
+        // at the outer indent.
+        end_nest() is
+            let frame = _top;
+            _stack.remove_at(_stack.count - 1);
+
+            let trailing: DOC mut = null;
+            if
+                frame.items.count > 0 /\
+                isa DOC.HARD_LINE(frame.items[frame.items.count - 1])
+            then
+                trailing = frame.items[frame.items.count - 1];
+                frame.items.remove_at(frame.items.count - 1);
+            fi
+
+            let result: DOC mut = DOC.CONCAT(frame.items);
+            if frame.nest != 0 then
+                result = DOC.NEST(frame.nest, result);
+            fi
+            emit(result);
+
+            if trailing? then
+                emit(trailing);
+            fi
+        si
+
+        build() -> DOC => DOC.CONCAT(_stack[0].items);
+    si
+si

--- a/src/syntax/process/printer/doc_renderer.ghul
+++ b/src/syntax/process/printer/doc_renderer.ghul
@@ -1,0 +1,221 @@
+namespace Syntax.Process.Printer is
+    use Collections;
+
+    // One unit of pending work for the renderer: a document to lay out at a
+    // given indent, in flat (`flat`) or broken mode.
+    class RENDER_CMD is
+        indent: int;
+        flat: bool;
+        doc: DOC;
+
+        init(indent: int, flat: bool, doc: DOC) is
+            self.indent = indent;
+            self.flat = flat;
+            self.doc = doc;
+        si
+    si
+
+    // Renders a DOC tree to text against a column budget.
+    //
+    // Classic Wadler/Prettier algorithm: a worklist of RENDER_CMDs is consumed
+    // depth-first; at each GROUP, `_fits` measures whether the group rendered
+    // flat — together with whatever follows it on the same line — stays within
+    // the budget, and picks flat or broken accordingly.
+    class DOC_RENDERER is
+        _width: int;
+
+        init(width: int) is
+            _width = width;
+        si
+
+        render(doc: DOC) -> string is
+            let out = System.Text.StringBuilder();
+            let cmds = LIST[RENDER_CMD]();
+
+            cmds.add(RENDER_CMD(0, false, doc));
+
+            let pos mut = 0;
+
+            while cmds.count > 0 do
+                let c = cmds[cmds.count - 1];
+                cmds.remove_at(cmds.count - 1);
+
+                let d = c.doc;
+
+                if let t: DOC.TEXT = d then
+                    out.append(t.text);
+                    pos = pos + t.text.length;
+                fi
+
+                if let concat: DOC.CONCAT = d then
+                    let i mut = concat.items.count - 1;
+                    while i >= 0 do
+                        cmds.add(RENDER_CMD(c.indent, c.flat, concat.items[i]));
+                        i = i - 1;
+                    od
+                fi
+
+                if let nest: DOC.NEST = d then
+                    cmds.add(RENDER_CMD(c.indent + nest.indent, c.flat, nest.doc));
+                fi
+
+                if let group: DOC.GROUP = d then
+                    let flat mut = c.flat;
+                    if !flat then
+                        flat = _fits(_width - pos, c.indent, group.doc, cmds);
+                    fi
+                    cmds.add(RENDER_CMD(c.indent, flat, group.doc));
+                fi
+
+                if isa DOC.LINE(d) then
+                    if c.flat then
+                        out.append(' ');
+                        pos = pos + 1;
+                    else
+                        pos = _newline(out, c.indent);
+                    fi
+                fi
+
+                if isa DOC.SOFT_LINE(d) then
+                    if !c.flat then
+                        pos = _newline(out, c.indent);
+                    fi
+                fi
+
+                if isa DOC.HARD_LINE(d) then
+                    pos = _newline(out, c.indent);
+                fi
+            od
+
+            return out.to_string();
+        si
+
+        _newline(out: System.Text.StringBuilder, indent: int) -> int is
+            out.append('\n');
+
+            let i mut = 0;
+            while i < indent do
+                out.append(' ');
+                i = i + 1;
+            od
+
+            return indent;
+        si
+
+        // True if `doc` rendered flat, plus everything queued in `rest` up to
+        // the next break, stays within `width` columns. A HARD_LINE inside
+        // `doc` returns false so any group containing a forced break is laid
+        // out broken; a break reached in `rest` ends the line and returns true.
+        _fits(width: int, indent: int, doc: DOC, rest: LIST[RENDER_CMD]) -> bool is
+            let remaining mut = width;
+
+            let local = LIST[RENDER_CMD]();
+            local.add(RENDER_CMD(indent, true, doc));
+
+            while local.count > 0 do
+                if remaining < 0 then
+                    return false;
+                fi
+
+                let c = local[local.count - 1];
+                local.remove_at(local.count - 1);
+
+                let d = c.doc;
+
+                if let t: DOC.TEXT = d then
+                    remaining = remaining - t.text.length;
+                fi
+
+                if let concat: DOC.CONCAT = d then
+                    let i mut = concat.items.count - 1;
+                    while i >= 0 do
+                        local.add(RENDER_CMD(c.indent, true, concat.items[i]));
+                        i = i - 1;
+                    od
+                fi
+
+                if let nest: DOC.NEST = d then
+                    local.add(RENDER_CMD(c.indent + nest.indent, true, nest.doc));
+                fi
+
+                if let group: DOC.GROUP = d then
+                    local.add(RENDER_CMD(c.indent, true, group.doc));
+                fi
+
+                if isa DOC.LINE(d) then
+                    remaining = remaining - 1;
+                fi
+
+                if isa DOC.HARD_LINE(d) then
+                    return false;
+                fi
+            od
+
+            let rest_index mut = rest.count - 1;
+            let pending = LIST[RENDER_CMD]();
+
+            do
+                if remaining < 0 then
+                    return false;
+                fi
+
+                if pending.count == 0 /\ rest_index < 0 then
+                    return true;
+                fi
+
+                let c =
+                    if pending.count > 0 then
+                        pending[pending.count - 1]
+                    else
+                        rest[rest_index]
+                    fi;
+
+                if pending.count > 0 then
+                    pending.remove_at(pending.count - 1);
+                else
+                    rest_index = rest_index - 1;
+                fi
+
+                let d = c.doc;
+
+                if let t: DOC.TEXT = d then
+                    remaining = remaining - t.text.length;
+                fi
+
+                if let concat: DOC.CONCAT = d then
+                    let i mut = concat.items.count - 1;
+                    while i >= 0 do
+                        pending.add(RENDER_CMD(c.indent, c.flat, concat.items[i]));
+                        i = i - 1;
+                    od
+                fi
+
+                if let nest: DOC.NEST = d then
+                    pending.add(RENDER_CMD(c.indent + nest.indent, c.flat, nest.doc));
+                fi
+
+                if let group: DOC.GROUP = d then
+                    pending.add(RENDER_CMD(c.indent, c.flat, group.doc));
+                fi
+
+                if isa DOC.LINE(d) then
+                    if c.flat then
+                        remaining = remaining - 1;
+                    else
+                        return true;
+                    fi
+                fi
+
+                if isa DOC.SOFT_LINE(d) then
+                    if !c.flat then
+                        return true;
+                    fi
+                fi
+
+                if isa DOC.HARD_LINE(d) then
+                    return true;
+                fi
+            od
+        si
+    si
+si

--- a/src/syntax/process/printer/formatter.ghul
+++ b/src/syntax/process/printer/formatter.ghul
@@ -1,0 +1,707 @@
+namespace Syntax.Process.Printer is
+    use Collections;
+
+    use Trees;
+    use Source;
+
+    use Lexical.TRIVIA;
+    use Lexical.TRIVIA_KIND;
+
+    // The ghūl code formatter.
+    //
+    // Extends the plain GHUL printer (which the diagnostics path uses via
+    // Node.to_string and must not be disturbed) and redirects its output
+    // primitives into a DOC tree, so DOC_RENDERER can lay the result out
+    // against a column budget. Comments and blank lines collected by the
+    // tokenizer as TRIVIA are interleaved back in by source position.
+    //
+    // Selected visits are overridden to introduce soft breaks (GROUP/LINE)
+    // where wrapping should happen; everything else inherits the printer's
+    // structural layout unchanged.
+    class FORMATTER: GHUL is
+        _builder: DOC_BUILDER;
+        _width: int;
+
+        _trivia: LIST[TRIVIA];
+        _trivia_index: int;
+
+        // Source line of the furthest content emitted so far. Drives
+        // trailing-comment detection: a comment starting on a line we have
+        // already passed trails that line rather than leading the next node.
+        _last_line: int;
+
+        // True between opening a block and emitting its first real content;
+        // suppresses a blank line immediately inside a block.
+        _at_block_start: bool;
+
+        init(trivia: Iterable[TRIVIA], width: int) is
+            super.init();
+
+            _width = width;
+            _builder = DOC_BUILDER();
+
+            _trivia = LIST[TRIVIA]();
+            if trivia? then
+                for t in trivia do
+                    _trivia.add(t);
+                od
+            fi
+        si
+
+        // Format a parsed file (or any node) and return the rendered text.
+        format(node: Node) -> string is
+            node.accept(self);
+            flush_remaining();
+
+            let text = DOC_RENDERER(_width).render(_builder.build());
+
+            // Strip trailing whitespace from every line (blank lines pick up
+            // indentation from the renderer) and end with a single newline.
+            let result = System.Text.StringBuilder();
+            let first mut = true;
+            for line in text.split(['\n']) do
+                if !first then
+                    result.append('\n');
+                fi
+                result.append(line.trim_end());
+                first = false;
+            od
+
+            return "{result.to_string().trim_end()}\n";
+        si
+
+        // --- output primitives, redirected into the DOC builder ---
+
+        write(value: string) is
+            if value? /\ value.length > 0 then
+                _at_block_start = false;
+            fi
+            _builder.text(value);
+        si
+
+        write(c: char) is
+            _at_block_start = false;
+            _builder.text("{c}");
+        si
+
+        write_line() is
+            flush_trailing_comments();
+            _builder.hard_line();
+        si
+
+        indent() is
+            _builder.begin_nest(4);
+            _at_block_start = true;
+        si
+
+        outdent() is
+            _builder.end_nest();
+        si
+
+        write_indent() is si
+
+        // --- line tracking ---
+
+        location(location: LOCATION) is
+            note(location);
+        si
+
+        note(location: LOCATION) is
+            if location? /\ location.start_line > _last_line then
+                _last_line = location.start_line;
+            fi
+        si
+
+        // --- trivia interleaving ---
+
+        _has_trivia: bool => _trivia_index < _trivia.count;
+
+        _peek: TRIVIA => _trivia[_trivia_index];
+
+        _consume() is
+            _trivia_index = _trivia_index + 1;
+        si
+
+        // Emit any trivia positioned strictly before `limit` (a LOCATION.start
+        // value) that is not a trailing comment of an already-emitted line.
+        flush_leading(limit: int) is
+            while _has_trivia /\ _peek.location.start < limit do
+                let t = _peek;
+
+                if t.is_blank_line then
+                    if !_at_block_start then
+                        _builder.hard_line();
+                    fi
+                    _consume();
+                else
+                    emit_comment(t);
+                    _builder.hard_line();
+                    _at_block_start = false;
+                    _consume();
+                fi
+            od
+        si
+
+        // Emit comments that start on a line we have already emitted: they
+        // trail that line. Called from write_line, before the newline.
+        flush_trailing_comments() is
+            while
+                _has_trivia /\
+                _peek.is_comment /\
+                _peek.location.start_line <= _last_line
+            do
+                _builder.text(" ");
+                emit_comment(_peek);
+                _consume();
+            od
+        si
+
+        // Emit everything left over (file-trailing comments).
+        flush_remaining() is
+            while _has_trivia do
+                let t = _peek;
+                if t.is_comment then
+                    emit_comment(t);
+                    _builder.hard_line();
+                fi
+                _consume();
+            od
+        si
+
+        emit_comment(t: TRIVIA) is
+            note(t.location);
+
+            if t.kind == TRIVIA_KIND.BLOCK_COMMENT /\ t.text? then
+                let lines = t.text.split(['\n']);
+                let first mut = true;
+                for line in lines do
+                    if !first then
+                        _builder.hard_line();
+                    fi
+                    _builder.text(line);
+                    first = false;
+                od
+            elif t.text? then
+                _builder.text(t.text);
+            fi
+        si
+
+        // --- definition / statement lists: leading-trivia interleaving ---
+
+        visit(definitions: Definitions.LIST) is
+            for d in definitions do
+                flush_leading(d.location.start);
+
+                d.accept(self);
+
+                if isa Variables.VARIABLE(d) then
+                    let variable = cast Variables.VARIABLE(d);
+                    if
+                        variable.name? /\
+                        variable.name.name? /\
+                        variable.name.name.starts_with("$")
+                    then
+                        write_line(";");
+                    fi
+                fi
+            od
+        si
+
+        visit(list: Statements.LIST) is
+            for s in list do
+                flush_leading(s.location.start);
+                s.accept(self);
+            od
+        si
+
+        visit(block: Bodies.BLOCK) is
+            write_line("is");
+            indent();
+            block.statements.accept(self);
+            if block.location? then
+                flush_leading(block.location.end);
+            fi
+            outdent();
+            write("si");
+        si
+
+        // --- visits the plain printer never implemented ---
+
+        visit(let_in: Expressions.LET_IN) is
+            note(let_in.location);
+            write("let ");
+            let_in.variables.accept(self);
+            write(" in ");
+            let_in.expression.accept(self);
+        si
+
+        visit(recurse: Expressions.RECURSE) is
+            note(recurse.location);
+            write("rec");
+        si
+
+        // --- faithfulness fix: an `if ... fi` in expression position is
+        //     Expressions.STATEMENT wrapping Statements.IF. The inherited
+        //     visit renders the statement form — `;`-terminated branch
+        //     bodies plus a trailing `;` — which is invalid in expression
+        //     position. Render the expression form instead. ---
+
+        visit(statement: Expressions.STATEMENT) is
+            note(statement.location);
+
+            if let if_statement: Statements.IF = statement.statement then
+                emit_if_expression(if_statement);
+            else
+                statement.statement.accept(self);
+            fi
+        si
+
+        // --- faithfulness fix: the inherited visit(Statements.IF) ignores a
+        //     branch binding, so `if let v = e then` renders as a bare `else`
+        //     with the binding dropped. ---
+
+        visit(if_statement: Statements.IF) is
+            note(if_statement.location);
+
+            let first mut = true;
+            for branch in if_statement.branches do
+                if branch.binding? then
+                    if first then
+                        write("if let ");
+                    else
+                        write("elif let ");
+                    fi
+                    branch.binding.accept(self);
+                    write_line(" then");
+                elif branch.condition? then
+                    if first then
+                        write("if ");
+                    else
+                        write("elif ");
+                    fi
+                    branch.condition.accept(self);
+                    write_line(" then");
+                else
+                    write_line("else");
+                fi
+
+                indent();
+                branch.body.accept(self);
+                outdent();
+
+                first = false;
+            od
+
+            write_line("fi");
+        si
+
+        // --- faithfulness fix: the inherited visit(Statements.FOR) emits
+        //     `for` with a trailing newline, stranding it on its own line. ---
+
+        visit(for_statement: Statements.FOR) is
+            note(for_statement.location);
+
+            write("for ");
+            for_statement.variable.accept(self);
+            write(" in ");
+            for_statement.expression.accept(self);
+            write_line(" do");
+
+            indent();
+            for_statement.body.accept(self);
+            outdent();
+
+            write_line("od");
+        si
+
+        emit_if_expression(if_statement: Statements.IF) is
+            _builder.begin_group();
+
+            let first mut = true;
+            for branch in if_statement.branches do
+                if !first then
+                    _builder.line();
+                fi
+
+                if branch.binding? then
+                    if first then
+                        write("if let ");
+                    else
+                        write("elif let ");
+                    fi
+                    branch.binding.accept(self);
+                    write(" then");
+                elif branch.condition? then
+                    if first then
+                        write("if ");
+                    else
+                        write("elif ");
+                    fi
+                    branch.condition.accept(self);
+                    write(" then");
+                else
+                    write("else");
+                fi
+
+                _builder.begin_nest(4);
+                _builder.line();
+                emit_branch_value(branch.body);
+                _builder.end_nest();
+
+                first = false;
+            od
+
+            _builder.line();
+            write("fi");
+            _builder.end_group();
+        si
+
+        // Emit an if-expression branch body. The branch's value is its last
+        // statement; if that is an expression statement, emit the bare
+        // expression (no `;`). Any leading statements render normally.
+        emit_branch_value(body: Statements.LIST) is
+            let statements = LIST[Statements.Statement]();
+            for s in body do
+                statements.add(s);
+            od
+
+            let i mut = 0;
+            while i < statements.count do
+                let s = statements[i];
+                if i == statements.count - 1 /\ isa Statements.EXPRESSION(s) then
+                    let expression_statement = cast Statements.EXPRESSION(s);
+                    expression_statement.expression.accept(self);
+                else
+                    s.accept(self);
+                fi
+                i = i + 1;
+            od
+        si
+
+        // --- faithfulness fix: string interpolation. The inherited visit
+        //     runs each literal fragment through visit(STRING), which wraps
+        //     it in quotes — producing invalid nested-string output. Emit the
+        //     literal fragments as raw escaped text instead. ---
+
+        visit(interpolation: Expressions.STRING_INTERPOLATION) is
+            note(interpolation.location);
+
+            write(cast char(34));
+
+            for fragment in interpolation.values do
+                if fragment.is_expression then
+                    write('{');
+                    fragment.expression.accept(self);
+                    if fragment.alignment? then
+                        write(',');
+                        fragment.alignment.accept(self);
+                    fi
+                    if fragment.format? then
+                        write(':');
+                        write(fragment.format);
+                    fi
+                    write('}');
+                else
+                    emit_interpolation_literal(fragment);
+                fi
+            od
+
+            write(cast char(34));
+        si
+
+        emit_interpolation_literal(fragment: Expressions.INTERPOLATION_FRAGMENT) is
+            let literal = cast Expressions.Literals.STRING(fragment.expression);
+
+            if !literal? then
+                return;
+            fi
+
+            for c in literal.value_string do
+                if c == '{' then
+                    write('{');
+                    write('{');
+                elif c == '}' then
+                    write('}');
+                    write('}');
+                else
+                    write_escape_char(c);
+                fi
+            od
+        si
+
+        // --- faithfulness fix: the inherited write_escape_char renders
+        //     control characters via string.format("X", ci), which returns
+        //     the literal "X" (no placeholder), mangling e.g. '\n' to '\X'.
+        //     Emit the escapes the tokenizer actually understands. ---
+
+        write_escape_char(c: char) is
+            let ci = cast int(c);
+
+            if c == '\n' then
+                write("\\");
+                write('n');
+            elif ci == 9 then
+                write("\\");
+                write('t');
+            elif ci == 13 then
+                write("\\");
+                write('r');
+            elif ci == 34 then
+                write("\\");
+                write(cast char(34));
+            elif ci == 92 then
+                write("\\\\");
+            elif ci < 32 then
+                write("\\");
+                write("{(ci >> 6) ∩ 7}");
+                write("{(ci >> 3) ∩ 7}");
+                write("{ci ∩ 7}");
+            else
+                write(c);
+            fi
+        si
+
+        // --- faithfulness fix: a lambda's argument list must be parenthesised
+        //     when the lambda has an explicit return type, otherwise
+        //     `arg: T -> U => body` reparses as arg-of-function-type `T -> U`. ---
+
+        visit(function: Expressions.FUNCTION) is
+            note(function.location);
+
+            let explicit_return = !isa TypeExpressions.INFER(function.type_expression);
+
+            if explicit_return then
+                write("(");
+            fi
+
+            let first mut = true;
+            for a in function.arguments do
+                if !first then
+                    write(", ");
+                fi
+                a.accept(self);
+                first = false;
+            od
+
+            if explicit_return then
+                write(") -> ");
+                function.type_expression.accept(self);
+            fi
+
+            write(" ");
+            function.body.accept(self);
+        si
+
+        // --- faithfulness fix: an unresolved AMBIGUOUS_EXPRESSION (a parse-
+        //     time `x[y]` that could be a generic application or an index)
+        //     has the same surface syntax either way. The plain printer emits
+        //     a debug `(ambiguous ... or ...)` form, which is not valid ghūl. ---
+
+        visit(ambiguous: Expressions.AMBIGUOUS_EXPRESSION) is
+            note(ambiguous.location);
+
+            if ambiguous.left? then
+                ambiguous.left.accept(self);
+                write(".");
+            fi
+
+            ambiguous.identifier.accept(self);
+            write("[");
+            ambiguous.type_arguments.accept(self);
+            write("]");
+        si
+
+        // --- faithfulness fix: STRUCT printed as `struct`, not `trait` ---
+
+        visit(`struct: Definitions.STRUCT) is
+            write("struct ");
+            `struct.name.accept(self);
+
+            if `struct.arguments? then
+                write("[");
+                `struct.arguments.accept(self);
+                write("]");
+            fi
+
+            `struct.modifiers.accept(self);
+            write_line(" is");
+            indent();
+            `struct.body.accept(self);
+            outdent();
+            write_line("si");
+        si
+
+        // --- faithfulness fix: a body-less property (a field) is terminated
+        //     with `;` and a newline, which the plain printer omits ---
+
+        visit(property: Definitions.PROPERTY) is
+            if property.name? then
+                property.name.accept(self);
+            fi
+
+            if
+                property.type_expression? /\
+                !isa TypeExpressions.INFER(property.type_expression)
+            then
+                write(": ");
+                property.type_expression.accept(self);
+            fi
+
+            if property.modifiers? /\ !property.modifiers.is_empty then
+                write(" ");
+                emit_modifiers(property.modifiers);
+            fi
+
+            if !property.read_body? /\ !property.assign_body? then
+                write_line(";");
+                return;
+            fi
+
+            let out_again = indent_property(property.read_body?, property.assign_body?);
+
+            if property.read_body? then
+                property.read_body.accept(self);
+                if property.assign_body? then
+                    write_line(",");
+                else
+                    after_body(property.read_body);
+                fi
+            else
+                write(" ");
+            fi
+
+            if property.assign_body? then
+                write("= ");
+                property.assign_argument.accept(self);
+                property.assign_body.accept(self);
+                after_body(property.assign_body);
+            fi
+
+            if out_again then
+                outdent();
+            fi
+        si
+
+        // Emit modifiers without the trailing space the inherited
+        // Modifiers.LIST visit appends (which would strand a space before a
+        // following `;`).
+        emit_modifiers(modifiers: Modifiers.LIST) is
+            let first mut = true;
+
+            if modifiers.access_modifier? then
+                modifiers.access_modifier.accept(self);
+                first = false;
+            fi
+
+            if modifiers.storage_class? then
+                if !first then
+                    write(" ");
+                fi
+                modifiers.storage_class.accept(self);
+                first = false;
+            fi
+        si
+
+        // --- wrapping: call argument lists and function parameter lists ---
+
+        visit(call: Expressions.CALL) is
+            note(call.location);
+            call.function.accept(self);
+            write("(");
+            emit_argument_list(call.arguments);
+            write(")");
+        si
+
+        visit(function: Definitions.FUNCTION) is
+            function.name.accept(self);
+            write("(");
+            emit_parameter_list(function.arguments);
+            write(")");
+
+            if !isa TypeExpressions.INFER(function.type_expression) then
+                write(" -> ");
+                function.type_expression.accept(self);
+            fi
+
+            if function.modifiers? /\ !function.modifiers.is_empty then
+                write(" ");
+                emit_modifiers(function.modifiers);
+            fi
+
+            if function.body? then
+                write(" ");
+                function.body.accept(self);
+            fi
+
+            after_body(function.body);
+        si
+
+        emit_parameter_list(parameters: Variables.LIST) is
+            if !_has_parameters(parameters) then
+                return;
+            fi
+
+            _builder.begin_group();
+            _builder.begin_nest(4);
+            _builder.soft_line();
+
+            let first mut = true;
+            for p in parameters do
+                if !first then
+                    _builder.text(",");
+                    _builder.line();
+                fi
+                p.accept(self);
+                first = false;
+            od
+
+            _builder.end_nest();
+            _builder.soft_line();
+            _builder.end_group();
+        si
+
+        _has_parameters(parameters: Variables.LIST) -> bool is
+            if !parameters? then
+                return false;
+            fi
+            for p in parameters do
+                return true;
+            od
+            return false;
+        si
+
+        emit_argument_list(arguments: Expressions.LIST) is
+            if !_has_arguments(arguments) then
+                return;
+            fi
+
+            _builder.begin_group();
+            _builder.begin_nest(4);
+            _builder.soft_line();
+
+            let first mut = true;
+            for a in arguments do
+                if !first then
+                    _builder.text(",");
+                    _builder.line();
+                fi
+                a.accept(self);
+                first = false;
+            od
+
+            _builder.end_nest();
+            _builder.soft_line();
+            _builder.end_group();
+        si
+
+        _has_arguments(arguments: Expressions.LIST) -> bool is
+            if !arguments? then
+                return false;
+            fi
+            for a in arguments do
+                return true;
+            od
+            return false;
+        si
+    si
+si

--- a/unit-tests/src/syntax/process/printer/doc_renderer_tests.ghul
+++ b/unit-tests/src/syntax/process/printer/doc_renderer_tests.ghul
@@ -1,0 +1,118 @@
+namespace Syntax.Process.Printer.UnitTests is
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    use Syntax.Process.Printer.DOC;
+    use Syntax.Process.Printer.DOC_BUILDER;
+    use Syntax.Process.Printer.DOC_RENDERER;
+
+    // Tests for the layout engine: DOC_BUILDER assembles a DOC tree,
+    // DOC_RENDERER lays it out against a column budget. A GROUP renders
+    // flat when its flat form fits the budget, otherwise broken.
+    class DOC_RENDERER_TESTS is
+        @test()
+
+        init() is si
+
+        render(doc: DOC, width: int) -> string =>
+            DOC_RENDERER(width).render(doc);
+
+        plain_text_is_emitted_verbatim() is
+            @test()
+
+            let b = DOC_BUILDER();
+            b.text("hello");
+
+            Assert.are_equal("hello", render(b.build(), 100));
+        si
+
+        a_group_that_fits_renders_flat() is
+            @test()
+
+            let b = DOC_BUILDER();
+            b.begin_group();
+            b.text("a");
+            b.line();
+            b.text("b");
+            b.end_group();
+
+            Assert.are_equal("a b", render(b.build(), 100));
+        si
+
+        a_group_that_exceeds_the_budget_breaks() is
+            @test()
+
+            let b = DOC_BUILDER();
+            b.begin_group();
+            b.text("aaa");
+            b.line();
+            b.text("bbb");
+            b.end_group();
+
+            Assert.are_equal("aaa\nbbb", render(b.build(), 4));
+        si
+
+        a_broken_group_indents_its_nested_content() is
+            @test()
+
+            let b = DOC_BUILDER();
+            b.begin_group();
+            b.text("(");
+            b.begin_nest(2);
+            b.soft_line();
+            b.text("x");
+            b.end_nest();
+            b.soft_line();
+            b.text(")");
+            b.end_group();
+
+            Assert.are_equal("(x)", render(b.build(), 100));
+            Assert.are_equal("(\n  x\n)", render(b.build(), 1));
+        si
+
+        a_hard_line_forces_the_enclosing_group_to_break() is
+            @test()
+
+            let b = DOC_BUILDER();
+            b.begin_group();
+            b.text("a");
+            b.hard_line();
+            b.text("b");
+            b.end_group();
+
+            // Fits the budget, but the hard line breaks the group anyway.
+            Assert.are_equal("a\nb", render(b.build(), 100));
+        si
+
+        a_soft_line_is_empty_when_flat() is
+            @test()
+
+            let b = DOC_BUILDER();
+            b.begin_group();
+            b.text("a");
+            b.soft_line();
+            b.text("b");
+            b.end_group();
+
+            Assert.are_equal("ab", render(b.build(), 100));
+        si
+
+        nested_groups_break_independently() is
+            @test()
+
+            let b = DOC_BUILDER();
+            b.begin_group();
+            b.text("outer");
+            b.line();
+            b.begin_group();
+            b.text("x");
+            b.line();
+            b.text("y");
+            b.end_group();
+            b.end_group();
+
+            // Budget fits the inner group flat but not the outer: the outer
+            // breaks, the inner stays flat.
+            Assert.are_equal("outer\nx y", render(b.build(), 6));
+        si
+    si
+si


### PR DESCRIPTION
Enhancements:
- New `--format` CLI flag reformats ghūl source files to a single fixed
  style (derived from the compiler's own source) and writes the result
  to stdout.
- New analysis-mode `#FORMAT#` command reformats a supplied buffer, for
  editor "format document" support.

Technical:
- Layout engine — a Wadler/Prettier-style document IR (`DOC`) plus a
  width-budget renderer that chooses flat vs. broken layout per group,
  trading line length against vertical space.
- The tokenizer now collects comments and blank lines as trivia, carried
  on `SOURCE_FILE`, so the formatter can interleave them back by source
  position.
- The formatter is a new visitor; the existing AST printer is left
  untouched, since it backs `Node.to_string` (diagnostics and hover).
  Round-trip faithfulness gaps in the inherited printer are fixed in the
  formatter: `struct` keyword, body-less field `;`, `let ... in` / `rec`,
  string interpolation, ambiguous `x[y]` expressions, control-character
  escapes, lambda argument parens, and `if` in expression position.
