### PR TITLE
Rename the nullable terminology to optional

### DIFF
--- a/integration-tests/execution/cast-generic-argument-type/ghulflags
+++ b/integration-tests/execution/cast-generic-argument-type/ghulflags
@@ -1,1 +1,1 @@
- --no-warn-non-nullable
+ --no-warn-non-optional

--- a/integration-tests/execution/if-let/ghulflags
+++ b/integration-tests/execution/if-let/ghulflags
@@ -1,1 +1,1 @@
---dotnet --no-warn-non-nullable
+--dotnet --no-warn-non-optional

--- a/integration-tests/execution/nested-short-circuit-bool-operators/ghulflags
+++ b/integration-tests/execution/nested-short-circuit-bool-operators/ghulflags
@@ -1,1 +1,1 @@
---dotnet  --no-warn-non-nullable
+--dotnet  --no-warn-non-optional

--- a/integration-tests/execution/non-nullable-by-default-disabled/ghulflags
+++ b/integration-tests/execution/non-nullable-by-default-disabled/ghulflags
@@ -1,1 +1,1 @@
---no-warn-non-nullable
+--no-warn-non-optional

--- a/integration-tests/execution/non-nullable-by-default-disabled/test.ghul
+++ b/integration-tests/execution/non-nullable-by-default-disabled/test.ghul
@@ -1,5 +1,5 @@
 // Same program as `non-nullable-by-default`, but the build sets
-// `--no-warn-non-nullable` — so none of the patterns flagged in the
+// `--no-warn-non-optional` — so none of the patterns flagged in the
 // comments below produce a diagnostic. The opt-out test.
 
 use IO.Std.write_line;
@@ -12,19 +12,19 @@ class BOX is
     si
 si
 
-// expression-bodied function returning `null` for a non-nullable
+// expression-bodied function returning `null` for a non-optional
 // `BOX` return type — warns at the `null`
 absent_box() -> BOX => null;
 
 entry() is
-    // `null` into a non-nullable typed `let` — warns
+    // `null` into a non-optional typed `let` — warns
     let a: BOX = null;
 
-    // `null` into a non-nullable assignment — warns
+    // `null` into a non-optional assignment — warns
     let b mut = BOX("b");
     b = null;
 
-    // a nullable target accepts `null` cleanly — no warning
+    // an optional target accepts `null` cleanly — no warning
     let maybe: BOX? = null;
 
     // a `BOX?` the flow analysis has proven present — no warning

--- a/integration-tests/execution/non-nullable-by-default/test.ghul
+++ b/integration-tests/execution/non-nullable-by-default/test.ghul
@@ -8,19 +8,19 @@ class BOX is
     si
 si
 
-// expression-bodied function returning `null` for a non-nullable
+// expression-bodied function returning `null` for a non-optional
 // `BOX` return type — warns at the `null`
 absent_box() -> BOX => null;
 
 entry() is
-    // `null` into a non-nullable typed `let` — warns
+    // `null` into a non-optional typed `let` — warns
     let a: BOX = null;
 
-    // `null` into a non-nullable assignment — warns
+    // `null` into a non-optional assignment — warns
     let b mut = BOX("b");
     b = null;
 
-    // a nullable target accepts `null` cleanly — no warning
+    // an optional target accepts `null` cleanly — no warning
     let maybe: BOX? = null;
 
     // a `BOX?` the flow analysis has proven present — no warning

--- a/integration-tests/execution/non-nullable-by-default/warn.expected
+++ b/integration-tests/execution/non-nullable-by-default/warn.expected
@@ -1,3 +1,3 @@
-test.ghul: 13,24..13,28: warn: null where a non-nullable BOX is expected
-test.ghul: 17,18..17,22: warn: null where a non-nullable BOX is expected
-test.ghul: 21,9..21,13: warn: null where a non-nullable BOX is expected
+test.ghul: 13,24..13,28: warn: null where a non-optional BOX is expected
+test.ghul: 17,18..17,22: warn: null where a non-optional BOX is expected
+test.ghul: 21,9..21,13: warn: null where a non-optional BOX is expected

--- a/integration-tests/execution/nullable-reference-type/ghulflags
+++ b/integration-tests/execution/nullable-reference-type/ghulflags
@@ -1,1 +1,1 @@
- --no-warn-non-nullable
+ --no-warn-non-optional

--- a/integration-tests/execution/ref-call-through-struct-ref/ghulflags
+++ b/integration-tests/execution/ref-call-through-struct-ref/ghulflags
@@ -1,1 +1,1 @@
---dotnet  --no-warn-non-nullable
+--dotnet  --no-warn-non-optional

--- a/integration-tests/il/property-definition/ghulflags
+++ b/integration-tests/il/property-definition/ghulflags
@@ -1,1 +1,1 @@
---dotnet -S --no-warn-non-nullable
+--dotnet -S --no-warn-non-optional

--- a/integration-tests/il/property-il-names/ghulflags
+++ b/integration-tests/il/property-il-names/ghulflags
@@ -1,1 +1,1 @@
---dotnet -S --no-warn-non-nullable
+--dotnet -S --no-warn-non-optional

--- a/integration-tests/parse/function-nesting-error-1/ghulflags
+++ b/integration-tests/parse/function-nesting-error-1/ghulflags
@@ -1,1 +1,1 @@
---type-check  --no-warn-non-nullable
+--type-check  --no-warn-non-optional

--- a/integration-tests/parse/incomplete-function-10/ghulflags
+++ b/integration-tests/parse/incomplete-function-10/ghulflags
@@ -1,1 +1,1 @@
---type-check  --no-warn-non-nullable
+--type-check  --no-warn-non-optional

--- a/integration-tests/parse/incomplete-function-9/ghulflags
+++ b/integration-tests/parse/incomplete-function-9/ghulflags
@@ -1,1 +1,1 @@
---type-check  --no-warn-non-nullable
+--type-check  --no-warn-non-optional

--- a/integration-tests/parse/return-expression-1/ghulflags
+++ b/integration-tests/parse/return-expression-1/ghulflags
@@ -1,1 +1,1 @@
---type-check  --no-warn-non-nullable
+--type-check  --no-warn-non-optional

--- a/integration-tests/parse/return-expression-2/ghulflags
+++ b/integration-tests/parse/return-expression-2/ghulflags
@@ -1,1 +1,1 @@
---type-check  --no-warn-non-nullable
+--type-check  --no-warn-non-optional

--- a/integration-tests/semantic/cross-namespace-function-groups-operators/ghulflags
+++ b/integration-tests/semantic/cross-namespace-function-groups-operators/ghulflags
@@ -1,1 +1,1 @@
---type-check  --no-warn-non-nullable
+--type-check  --no-warn-non-optional

--- a/integration-tests/semantic/generic-inheritance/ghulflags
+++ b/integration-tests/semantic/generic-inheritance/ghulflags
@@ -1,2 +1,2 @@
 --type-check  --no-warn-definite-assignment
- --no-warn-non-nullable
+ --no-warn-non-optional

--- a/integration-tests/semantic/generic-overrides/ghulflags
+++ b/integration-tests/semantic/generic-overrides/ghulflags
@@ -1,2 +1,2 @@
 --type-check  --no-warn-definite-assignment
- --no-warn-non-nullable
+ --no-warn-non-optional

--- a/integration-tests/semantic/generic-type-compatibility/ghulflags
+++ b/integration-tests/semantic/generic-type-compatibility/ghulflags
@@ -1,1 +1,1 @@
---type-check  --no-warn-non-nullable
+--type-check  --no-warn-non-optional

--- a/integration-tests/semantic/has-value-struct-1/ghulflags
+++ b/integration-tests/semantic/has-value-struct-1/ghulflags
@@ -1,1 +1,1 @@
- --no-warn-non-nullable
+ --no-warn-non-optional

--- a/integration-tests/semantic/nullable-errors/err.expected
+++ b/integration-tests/semantic/nullable-errors/err.expected
@@ -1,2 +1,2 @@
 test.ghul: 17,14..17,15: error: no static overload found for take_int(BOX?), tried take_int(n: int) -> Ghul.int
-test.ghul: 3,18..3,20: error: a nullable type parameter requires a `class` or `struct` constraint
+test.ghul: 3,18..3,20: error: an optional type parameter requires a `class` or `struct` constraint

--- a/integration-tests/semantic/reference-type-outside-function-arguments/ghulflags
+++ b/integration-tests/semantic/reference-type-outside-function-arguments/ghulflags
@@ -1,1 +1,1 @@
---dotnet --no-warn-non-nullable
+--dotnet --no-warn-non-optional

--- a/integration-tests/semantic/statement-expression-if-6/ghulflags
+++ b/integration-tests/semantic/statement-expression-if-6/ghulflags
@@ -1,1 +1,1 @@
---type-check --no-warn-non-nullable
+--type-check --no-warn-non-optional

--- a/src/compiler/build_flags.ghul
+++ b/src/compiler/build_flags.ghul
@@ -18,13 +18,13 @@ namespace Compiler is
         want_warn_implicit_mutable_let: bool public;
 
         // The definite-return / definite-assignment / possible-null-
-        // dereference / non-nullable-by-default flow warnings are on
+        // dereference / non-optional-by-default flow warnings are on
         // by default; these opt-outs suppress them (see the
         // `--no-warn-*` driver flags).
         no_warn_definite_return: bool public;
         no_warn_definite_assignment: bool public;
         no_warn_null_deref: bool public;
-        no_warn_non_nullable: bool public;
+        no_warn_non_optional: bool public;
         ignore_errors: bool public;
         exclude_runtime_symbols: bool public;
         is_test_run: bool public;

--- a/src/driver/main.ghul
+++ b/src/driver/main.ghul
@@ -297,8 +297,8 @@ namespace Driver is
                     flags.no_warn_definite_assignment = true;
                 elif s =~ "--no-warn-null-deref" then
                     flags.no_warn_null_deref = true;
-                elif s =~ "--no-warn-non-nullable" then
-                    flags.no_warn_non_nullable = true;
+                elif s =~ "--no-warn-non-optional" then
+                    flags.no_warn_non_optional = true;
                 elif s.starts_with('-') then
                     Std.error.write_line("warning: ignoring unknown option: {s}");
                 elif SOURCE_FILE_CATEGORIZER.is_ghul(s) then

--- a/src/semantic/lookups/innate_symbol_lookup.ghul
+++ b/src/semantic/lookups/innate_symbol_lookup.ghul
@@ -12,7 +12,7 @@ namespace Semantic.Lookups is
         get_array_type(type: Type) -> Type;
 
         // The value-type `T?` — OPTION[type] (System.Nullable[type]).
-        get_nullable_type(type: Type) -> Type;
+        get_optional_type(type: Type) -> Type;
 
         get_pointer_type(type: Type) -> Type;
 

--- a/src/semantic/lookups/lazy_innate_symbol_lookup.ghul
+++ b/src/semantic/lookups/lazy_innate_symbol_lookup.ghul
@@ -16,7 +16,7 @@ namespace Semantic.Lookups is
         
         get_array_type(type: Type) -> Type => _lookup.value.get_array_type(type);
 
-        get_nullable_type(type: Type) -> Type => _lookup.value.get_nullable_type(type);
+        get_optional_type(type: Type) -> Type => _lookup.value.get_optional_type(type);
 
         get_pointer_type(type: Type) -> Type => _lookup.value.get_pointer_type(type);
 

--- a/src/semantic/lookups/reflection_innate_symbol_lookup.ghul
+++ b/src/semantic/lookups/reflection_innate_symbol_lookup.ghul
@@ -75,7 +75,7 @@ namespace Semantic.Lookups is
         get_array_type(type: Type) -> Type =>
             _ghul_symbol_lookup.get_array_type(type);
 
-        get_nullable_type(type: Type) -> Type is
+        get_optional_type(type: Type) -> Type is
             let classy = cast Semantic.Symbols.Classy(_symbol_table.get_symbol(_type_source.get_type("System.Nullable`1")));
 
             return Types.OPTION(LOCATION.internal, classy, LIST[Type]([type]));

--- a/src/semantic/lookups/stubs_innate_symbol_lookup.ghul
+++ b/src/semantic/lookups/stubs_innate_symbol_lookup.ghul
@@ -26,7 +26,7 @@ namespace Semantic.Lookups is
         
         get_array_type(type: Types.Type) -> Type => _ghul_symbol_lookup.get_array_type(type);
 
-        get_nullable_type(type: Types.Type) -> Type;
+        get_optional_type(type: Types.Type) -> Type;
 
         get_pointer_type(type: Types.Type) -> Type => _ghul_symbol_lookup.get_pointer_type(type);
 

--- a/src/semantic/symbols/generic_constraint_checker.ghul
+++ b/src/semantic/symbols/generic_constraint_checker.ghul
@@ -10,7 +10,7 @@ namespace Semantic.Symbols is
     // Type variables, sentinels and unresolved or error types are not
     // checkable: the conservative answer is that the constraint holds,
     // so no false positive is reported. `option` enforcement is
-    // deferred to nullable-types support.
+    // deferred to optional-types support.
     class GENERIC_CONSTRAINT_CHECKER is
         init() is si
 

--- a/src/semantic/types/generic.ghul
+++ b/src/semantic/types/generic.ghul
@@ -390,7 +390,7 @@ namespace Semantic.Types is
         si
 
         to_string() -> string =>
-            if is_nullable then
+            if is_optional then
                 "{symbol.to_string()}?";
             else
                 symbol.to_string();

--- a/src/semantic/types/generic_argument.ghul
+++ b/src/semantic/types/generic_argument.ghul
@@ -31,8 +31,8 @@ namespace Semantic.Types is
 
             if type_map.try_get_value(name, result ref) then
                 // A `T?` keeps its nullability across substitution.
-                if is_nullable then
-                    return result.as_nullable();
+                if is_optional then
+                    return result.as_optional();
                 else
                     return result;
                 fi
@@ -58,7 +58,7 @@ namespace Semantic.Types is
         si
 
         to_string() -> string =>
-            if is_nullable then
+            if is_optional then
                 "{symbol.name}?";
             else
                 symbol.name;

--- a/src/semantic/types/named.ghul
+++ b/src/semantic/types/named.ghul
@@ -20,11 +20,11 @@ namespace Semantic.Types is
         // Set when this reference type was written with a `?`
         // nullability annotation. Purely a rendering distinction for
         // now — `Foo` and `Foo?` remain mutually assignable.
-        _is_nullable: bool;
+        _is_optional: bool;
 
         symbol: Symbols.Symbol => _symbol;
 
-        is_nullable: bool => _is_nullable;
+        is_optional: bool => _is_optional;
 
         short_description: string =>
             if symbol? then
@@ -72,8 +72,8 @@ namespace Semantic.Types is
             if type_map.contains_key(name) then
                 // A flagged `T?` keeps its nullability when `T` is
                 // substituted — `T?` with `T := Foo` is `Foo?`.
-                if _is_nullable then
-                    type_map[name].as_nullable();
+                if _is_optional then
+                    type_map[name].as_optional();
                 else
                     type_map[name];
                 fi;
@@ -110,7 +110,7 @@ namespace Semantic.Types is
             // `null` is assignable to any reference type, and to a
             // type written `T?` — including a `class`-constrained
             // type variable, which otherwise reports is_value_type.
-            if other.is_null /\ (!is_value_type \/ _is_nullable) then
+            if other.is_null /\ (!is_value_type \/ _is_optional) then
                 return Types.MATCH.ASSIGNABLE;
             fi
 
@@ -200,25 +200,25 @@ namespace Semantic.Types is
             action(self);
         si
 
-        as_nullable() -> Type is
+        as_optional() -> Type is
             // A genuine value type carries optionality as OPTION[T],
             // never the reference flag. A type variable reports
             // is_value_type spuriously (every GenericArgument does),
             // so exclude it — a `class`-constrained `T?` is flagged.
-            if _is_nullable \/ (is_value_type /\ !is_type_variable) then
+            if _is_optional \/ (is_value_type /\ !is_type_variable) then
                 return self;
             fi
 
             let result = cast NAMED(memberwise_clone());
 
-            result._is_nullable = true;
+            result._is_optional = true;
 
             return result;
         si
 
         to_string() -> string =>
             if symbol? then
-                if _is_nullable then
+                if _is_optional then
                     "{symbol.qualified_name}?";
                 else
                     symbol.qualified_name;

--- a/src/semantic/types/option.ghul
+++ b/src/semantic/types/option.ghul
@@ -4,13 +4,13 @@ namespace Semantic.Types is
 
     // The value-type spelling of `T?` — System.Nullable[T], surfaced
     // under the ghūl name OPTION. A reference type's `T?` is a flagged
-    // NAMED instead (see NAMED.as_nullable); OPTION is value-type only.
+    // NAMED instead (see NAMED.as_optional); OPTION is value-type only.
     class OPTION: GENERIC is
         short_description: string => get_short_description(self);
 
         get_short_description(reference: GENERIC) -> string static => "{reference.arguments[0].short_description}?";
 
-        is_nullable: bool => true;
+        is_optional: bool => true;
 
         init(
             location: LOCATION,

--- a/src/semantic/types/type.ghul
+++ b/src/semantic/types/type.ghul
@@ -165,15 +165,15 @@ namespace Semantic.Types is
 
         // True for a reference type carrying an explicit `?`
         // nullability annotation, and for the value-type OPTION[T].
-        is_nullable: bool => false;
+        is_optional: bool => false;
 
         init() is
         si
 
         // The `T?` form of this type. A value type yields OPTION[T];
-        // a reference type yields itself flagged nullable. Overridden
+        // a reference type yields itself flagged optional. Overridden
         // by NAMED; the base covers sentinels, which are left as-is.
-        as_nullable() -> Type => self;
+        as_optional() -> Type => self;
 
         =~(other: Type) -> bool => false;
 

--- a/src/syntax/parsers/type_expressions/type_expression.ghul
+++ b/src/syntax/parsers/type_expressions/type_expression.ghul
@@ -215,7 +215,7 @@ namespace Syntax.Parsers.TypeExpressions is
                     context.next_token();
 
                 when Lexical.TOKEN.QUESTION:
-                    result = Trees.TypeExpressions.NULLABLE(result.location::context.location, result);
+                    result = Trees.TypeExpressions.OPTIONAL(result.location::context.location, result);
                     context.next_token();
 
                 when Lexical.TOKEN.ARROW_THIN:

--- a/src/syntax/process/clear_ast_state.ghul
+++ b/src/syntax/process/clear_ast_state.ghul
@@ -76,7 +76,7 @@ namespace Syntax.Process is
         visit(structured: TypeExpressions.Structured) is structured.clear(); si
         visit(array: TypeExpressions.ARRAY_) is array.clear(); si
         visit(pointer: TypeExpressions.POINTER) is pointer.clear(); si
-        visit(nullable: TypeExpressions.NULLABLE) is nullable.clear(); si
+        visit(optional: TypeExpressions.OPTIONAL) is optional.clear(); si
         visit(reference: TypeExpressions.REFERENCE) is reference.clear(); si
         visit(member: TypeExpressions.MEMBER) is member.clear(); si
         visit(named: TypeExpressions.NAMED) is named.clear(); si

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -37,12 +37,12 @@ namespace Syntax.Process is
         _will_generate_code: bool;
 
         // Definite-return / definite-assignment / possible-null-
-        // dereference / non-nullable-by-default flow warnings — on by
+        // dereference / non-optional-by-default flow warnings — on by
         // default, suppressed by the `--no-warn-*` flags.
         _warn_definite_return: bool;
         _warn_definite_assignment: bool;
         _warn_null_deref: bool;
-        _warn_non_nullable: bool;
+        _warn_non_optional: bool;
 
         _stub_depth: int;
         _keep_depth: int;
@@ -145,7 +145,7 @@ namespace Syntax.Process is
         si
 
         // Warn when a value is dereferenced through a `T?` receiver —
-        // a nullable reference or an OPTION[T] — that the flow
+        // an optional reference or an OPTION[T] — that the flow
         // analysis has not proven to hold a value here. Only a local
         // variable's null-state is flow-tracked, so other receiver
         // shapes (a field, a call result, an explicit `x!`) stay
@@ -158,7 +158,7 @@ namespace Syntax.Process is
 
             if
                 !receiver.value? \/ !receiver.value.type? \/
-                !receiver.value.type.is_nullable
+                !receiver.value.type.is_optional
             then
                 return;
             fi
@@ -172,33 +172,33 @@ namespace Syntax.Process is
             _logger.warn(receiver.location, "{target.name} may not hold a value here");
         si
 
-        // True iff `type` is a non-nullable reference type — the kind
-        // of slot the non-nullable-by-default check guards. Value
+        // True iff `type` is a non-optional reference type — the kind
+        // of slot the non-optional-by-default check guards. Value
         // types, `T?`, type variables, void and error/placeholder
         // types are all excluded.
-        _is_non_nullable_reference(type: Semantic.Types.Type) -> bool =>
+        _is_non_optional_reference(type: Semantic.Types.Type) -> bool =>
             type? /\ type.is_named /\
-            !type.is_value_type /\ !type.is_nullable /\
+            !type.is_value_type /\ !type.is_optional /\
             !type.is_type_variable /\ !type.is_void /\
             !type.is_error /\ !type.is_inferred;
 
-        // Non-nullable-by-default: warn when a `T?` local the flow
-        // analysis has not proven present reaches a non-nullable
+        // Non-optional-by-default: warn when a `T?` local the flow
+        // analysis has not proven present reaches a non-optional
         // reference slot. `x?` / `isa` / `if let` clear it; an
         // explicit `x!` is exempt — the user took responsibility. A
         // non-variable `T?` source — a call result, a field — is not
         // flow-tracked, so it stays silent rather than risk a false
         // positive. The bare `null` literal is handled separately, in
         // visit(NULL), via its constraint. On by default;
-        // `--no-warn-non-nullable` opts out. A warning, not an error,
+        // `--no-warn-non-optional` opts out. A warning, not an error,
         // during the migration; the end state is `T?` not
         // assignment-compatible with `T`.
-        _check_non_nullable(target: Semantic.Types.Type, source: Trees.Expressions.Expression, location: Source.LOCATION) is
-            if !_warn_non_nullable \/ !target? \/ !source? then
+        _check_non_optional(target: Semantic.Types.Type, source: Trees.Expressions.Expression, location: Source.LOCATION) is
+            if !_warn_non_optional \/ !target? \/ !source? then
                 return;
             fi
 
-            if !_is_non_nullable_reference(target) then
+            if !_is_non_optional_reference(target) then
                 return;
             fi
 
@@ -206,11 +206,11 @@ namespace Syntax.Process is
                 return;
             fi
 
-            if source.value.type.is_nullable /\ !isa Trees.Expressions.UNWRAP(source) then
+            if source.value.type.is_optional /\ !isa Trees.Expressions.UNWRAP(source) then
                 let v = try_get_narrowing_target(source);
 
                 if v? /\ !_flow.is_non_null(v) then
-                    _logger.warn(location, "{v.name} may not hold a value, but a non-nullable {target} is expected");
+                    _logger.warn(location, "{v.name} may not hold a value, but a non-optional {target} is expected");
                 fi
             fi
         si
@@ -347,7 +347,7 @@ namespace Syntax.Process is
             _warn_definite_return = !IoC.CONTAINER.instance.build_flags.no_warn_definite_return;
             _warn_definite_assignment = !IoC.CONTAINER.instance.build_flags.no_warn_definite_assignment;
             _warn_null_deref = !IoC.CONTAINER.instance.build_flags.no_warn_null_deref;
-            _warn_non_nullable = !IoC.CONTAINER.instance.build_flags.no_warn_non_nullable;
+            _warn_non_optional = !IoC.CONTAINER.instance.build_flags.no_warn_non_optional;
 
             IR.LABEL.reset_id();
             IR.LABEL.set_pass("E");
@@ -865,20 +865,20 @@ namespace Syntax.Process is
                 _flow.on_assignment(target_variable);
                 _flow.mark_assigned(target_variable);
 
-                // A non-nullable RHS leaves the target known to hold
+                // A non-optional RHS leaves the target known to hold
                 // a value — so `_field = arg; _field.method()` does
                 // not warn.
-                if _is_non_nullable_value(left.value) then
+                if _is_non_optional_value(left.value) then
                     _flow.mark_non_null(target_variable);
                 fi
             fi
         si
 
         // True iff `value` is statically known to hold a value — its
-        // type is settled and is not a nullable / null type.
-        _is_non_nullable_value(value: IR.Values.Value) -> bool =>
+        // type is settled and is not an optional / null type.
+        _is_non_optional_value(value: IR.Values.Value) -> bool =>
             value? /\ value.type? /\ value.type.is_settled /\
-            !value.type.is_null /\ !value.type.is_nullable;
+            !value.type.is_null /\ !value.type.is_optional;
         
         // Resolve the per-element members for a destructure (see
         // DESTRUCTURE_RESOLVER) and log an error against `location`
@@ -1068,7 +1068,7 @@ namespace Syntax.Process is
             else
                 assignment.left.value = assignment.right.value;
 
-                _check_non_nullable(lhs_type, assignment.right, assignment.right.location);
+                _check_non_optional(lhs_type, assignment.right, assignment.right.location);
             fi
 
             // Back-feed the RHS type as a constraint onto a
@@ -1314,7 +1314,7 @@ namespace Syntax.Process is
                         fi
                     fi
 
-                    _check_non_nullable(function.return_type, r.expression, r.expression.location);
+                    _check_non_optional(function.return_type, r.expression, r.expression.location);
 
                     return;
                 fi
@@ -1780,7 +1780,7 @@ namespace Syntax.Process is
                 Value.check_is_consumable_allow_void(_logger, expression.expression.location, expression.expression.value);
             fi
 
-            _check_non_nullable(function.return_type, expression.expression, expression.expression.location);
+            _check_non_optional(function.return_type, expression.expression, expression.expression.location);
 
             super.visit(expression);
         si
@@ -3807,13 +3807,13 @@ namespace Syntax.Process is
                 if left.right_value? then
                     left.value = symbol.store(left.location, null, left.right_value, _symbol_loader, true);
 
-                    // A non-nullable initializer leaves the local
+                    // A non-optional initializer leaves the local
                     // known to hold a value — even where its declared
                     // type is `T?` — so a following dereference does
                     // not warn.
                     if
                         isa Semantic.Symbols.Variable(symbol) /\
-                        _is_non_nullable_value(left.right_value)
+                        _is_non_optional_value(left.right_value)
                     then
                         _flow.mark_non_null(cast Semantic.Symbols.Variable(symbol));
                     fi
@@ -3964,7 +3964,7 @@ namespace Syntax.Process is
             // the declared type. An untyped `let` infers its type
             // from the initializer, so there is no slot to violate.
             if variable.type_expression? /\ variable.initializer? then
-                _check_non_nullable(
+                _check_non_optional(
                     variable.type_expression.type,
                     variable.initializer,
                     variable.initializer.location
@@ -5087,15 +5087,15 @@ namespace Syntax.Process is
                 `null.value = NULL(Semantic.Types.NULL());
             fi
 
-            // Non-nullable-by-default: the bare `null` literal flowing
-            // into a non-nullable reference slot. The constraint is
+            // Non-optional-by-default: the bare `null` literal flowing
+            // into a non-optional reference slot. The constraint is
             // the expected type, pushed by the parent context — a
             // typed `let`, an assignment, a `return`, a call argument,
             // an `if`/`else` branch — so this one check covers every
             // such site. A warning during the migration; `T?` not
             // being assignment-compatible with `T` is the end state.
-            if _warn_non_nullable /\ _is_non_nullable_reference(`null.constraint) then
-                _logger.warn(`null.location, "null where a non-nullable {`null.constraint} is expected");
+            if _warn_non_optional /\ _is_non_optional_reference(`null.constraint) then
+                _logger.warn(`null.location, "null where a non-optional {`null.constraint} is expected");
             fi
         si
 

--- a/src/syntax/process/condition_analysis.ghul
+++ b/src/syntax/process/condition_analysis.ghul
@@ -299,7 +299,7 @@ namespace Syntax.Process is
 
         // `x?` — the has-value test. On the true edge `x` is known to
         // hold a value; the false edge learns nothing (no narrowing
-        // the other way). Applies uniformly to a nullable reference
+        // the other way). Applies uniformly to an optional reference
         // and to an OPTION[T] value type.
         _analyze_has_value(has_value: Trees.Expressions.HAS_VALUE, in_env: NARROW_ENV) -> CONDITION_FACTS is
             let then_env = in_env.copy();

--- a/src/syntax/process/printer/base.ghul
+++ b/src/syntax/process/printer/base.ghul
@@ -214,8 +214,8 @@ namespace Syntax.Process.Printer is
             write(" ptr");
         si
 
-        visit(nullable: TypeExpressions.NULLABLE) is
-            nullable.element.accept(self);
+        visit(optional: TypeExpressions.OPTIONAL) is
+            optional.element.accept(self);
             write("?");
         si
 

--- a/src/syntax/process/resolve_type_expressions.ghul
+++ b/src/syntax/process/resolve_type_expressions.ghul
@@ -176,17 +176,17 @@ namespace Syntax.Process is
                     get_type_or_any(pointer.element.type));
         si
 
-        visit(nullable: Trees.TypeExpressions.NULLABLE) is
-            let element_type = get_type_or_any(nullable.element.type);
+        visit(optional: Trees.TypeExpressions.OPTIONAL) is
+            let element_type = get_type_or_any(optional.element.type);
 
             if element_type.is_error then
-                nullable.type = element_type;
+                optional.type = element_type;
             elif isa Semantic.Types.OPTION(element_type) then
                 // `T??` collapses — already a value-type optional.
-                nullable.type = element_type;
+                optional.type = element_type;
             elif element_type.is_void then
-                _logger.error(nullable.location, "void cannot be made nullable");
-                nullable.type = Semantic.Types.ERROR();
+                _logger.error(optional.location, "void cannot be made optional");
+                optional.type = Semantic.Types.ERROR();
             elif element_type.is_type_variable then
                 // `T?` lowers by the parameter's declared kind: a
                 // `struct` parameter to OPTION[T], a `class` one to a
@@ -195,20 +195,20 @@ namespace Syntax.Process is
                 let kind = element_type.symbol.constraint_kind;
 
                 if kind == Semantic.Symbols.TYPE_PARAMETER_CONSTRAINT_KIND.VALUE then
-                    nullable.type = _innate_symbol_lookup.get_nullable_type(element_type);
+                    optional.type = _innate_symbol_lookup.get_optional_type(element_type);
                 elif kind == Semantic.Symbols.TYPE_PARAMETER_CONSTRAINT_KIND.REFERENCE then
-                    nullable.type = element_type.as_nullable();
+                    optional.type = element_type.as_optional();
                 elif kind == Semantic.Symbols.TYPE_PARAMETER_CONSTRAINT_KIND.OPTION then
-                    // `T` is already a nullable type — `T?` adds nothing.
-                    nullable.type = element_type;
+                    // `T` is already an optional type — `T?` adds nothing.
+                    optional.type = element_type;
                 else
-                    _logger.error(nullable.location, "a nullable type parameter requires a `class` or `struct` constraint");
-                    nullable.type = Semantic.Types.ERROR();
+                    _logger.error(optional.location, "an optional type parameter requires a `class` or `struct` constraint");
+                    optional.type = Semantic.Types.ERROR();
                 fi
             elif element_type.is_value_type then
-                nullable.type = _innate_symbol_lookup.get_nullable_type(element_type);
+                optional.type = _innate_symbol_lookup.get_optional_type(element_type);
             else
-                nullable.type = element_type.as_nullable();
+                optional.type = element_type.as_optional();
             fi
         si
 

--- a/src/syntax/process/strictvisitor.ghul
+++ b/src/syntax/process/strictvisitor.ghul
@@ -128,8 +128,8 @@ namespace Syntax is
             throwNotImplemented("pointer", pointer);
         si
 
-        visit(nullable: TypeExpressions.NULLABLE) is
-            throwNotImplemented("nullable", nullable);
+        visit(optional: TypeExpressions.OPTIONAL) is
+            throwNotImplemented("optional", optional);
         si
 
         visit(reference: TypeExpressions.REFERENCE) is

--- a/src/syntax/process/visitor.ghul
+++ b/src/syntax/process/visitor.ghul
@@ -239,11 +239,11 @@ namespace Syntax is
         visit(pointer: TypeExpressions.POINTER) is
         si
 
-        pre(nullable: TypeExpressions.NULLABLE) -> bool is
+        pre(optional: TypeExpressions.OPTIONAL) -> bool is
             return false;
         si
 
-        visit(nullable: TypeExpressions.NULLABLE) is
+        visit(optional: TypeExpressions.OPTIONAL) is
         si
 
         pre(reference: TypeExpressions.REFERENCE) -> bool is

--- a/src/syntax/trees/type_expressions/optional.ghul
+++ b/src/syntax/trees/type_expressions/optional.ghul
@@ -1,7 +1,7 @@
 namespace Syntax.Trees.TypeExpressions is
     use Source;
 
-    class NULLABLE: Structured  is
+    class OPTIONAL: Structured  is
         init(location: LOCATION, element: TypeExpression) is
             super.init(location, element);
         si

--- a/unit-tests/src/semantic/symbols/generic_constraint_checker_tests.ghul
+++ b/unit-tests/src/semantic/symbols/generic_constraint_checker_tests.ghul
@@ -58,7 +58,7 @@ namespace Semantic.Symbols.UnitTests is
 
         The_option_constraint_is_not_yet_enforced() is
             @test()
-            // Phase 3 (nullable types) will enforce `option`; until
+            // Phase 3 (optional types) will enforce `option`; until
             // then it accepts any type argument.
             let checker = GENERIC_CONSTRAINT_CHECKER();
             Assert.is_true(checker.is_satisfied(TYPE_PARAMETER_CONSTRAINT_KIND.OPTION, reference_type()));

--- a/unit-tests/src/syntax/process/numeric_literal_classifier_tests.ghul
+++ b/unit-tests/src/syntax/process/numeric_literal_classifier_tests.ghul
@@ -55,7 +55,7 @@ namespace Syntax.Process.UnitTests is
         get_tuple_type(types: Collections.List[Type], names: Collections.List[string]) -> Type;
         get_function_type(types: Collections.List[Type]) -> Type;
         get_array_type(type: Type) -> Type;
-        get_nullable_type(type: Type) -> Type;
+        get_optional_type(type: Type) -> Type;
         get_pointer_type(type: Type) -> Type;
         get_reference_type(type: Type) -> Type;
         get_bool_type() -> Type => _bool;


### PR DESCRIPTION
Technical:
- `T?` is now described as an *optional* type throughout — in user-facing diagnostics, the CLI flag, and the compiler source. The two underlying mechanisms (a nullable reference and the value-type `System.Nullable[T]`, aliased `OPTION[T]`) are both kinds of optional; `null` remains the absent-value literal for references.
- The `--no-warn-non-nullable` flag is renamed to `--no-warn-non-optional`.

Re-raises #1321, which was merged into the wrong base branch.