### PR TITLE
Add range formatting

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.12.16",
+      "version": "0.12.17",
       "commands": [
         "ghul-compiler"
       ],

--- a/src/analysis/analyser.ghul
+++ b/src/analysis/analyser.ghul
@@ -70,6 +70,7 @@ namespace Analysis is
             let rename_request_handler = RENAME_REQUEST_HANDLER(watchdog, symbol_use_locations, full_compiler);
             let restart_handler = RESTART_HANDLER(watchdog);
             let format_handler = FORMAT_HANDLER(compiler, build_flags);
+            let format_range_handler = FORMATRANGE_HANDLER(compiler, build_flags);
 
             _despatcher.add_handler(
                 "EDIT", file_edited_handler
@@ -121,6 +122,10 @@ namespace Analysis is
 
             _despatcher.add_handler(
                 "FORMAT", format_handler
+            );
+
+            _despatcher.add_handler(
+                "FORMATRANGE", format_range_handler
             );
         si
 

--- a/src/analysis/command_handlers.ghul
+++ b/src/analysis/command_handlers.ghul
@@ -1062,4 +1062,198 @@ namespace Analysis is
             writer.flush();
         si
     si
+
+    // Reformats just the run of definitions/statements covering a requested
+    // range. The request frame is the path, the range (start/end line and
+    // column, 1-based), then the buffer contents (form-feed terminated). The
+    // response is the whole-line span actually replaced followed by the
+    // reformatted text; a `0 0` span means nothing was formatted (the buffer
+    // is left untouched).
+    class FORMATRANGE_HANDLER: CommandHandler is
+        _compiler: COMPILER;
+        _build_flags: BUILD_FLAGS;
+
+        init(compiler: COMPILER, build_flags: BUILD_FLAGS) is
+            _compiler = compiler;
+            _build_flags = build_flags;
+        si
+
+        handle(reader: IO.TextReader, writer: IO.TextWriter) is
+            let path = reader.read_line();
+            let start_line = System.Convert.to_int32(reader.read_line());
+            let start_column = System.Convert.to_int32(reader.read_line());
+            let end_line = System.Convert.to_int32(reader.read_line());
+            let end_column = System.Convert.to_int32(reader.read_line());
+
+            let buffer = System.Text.StringBuilder();
+
+            do
+                let c = reader.read();
+                if c < 0 \/ c == 12 then
+                    break;
+                fi
+                buffer.append(cast char(c));
+            od
+
+            let source = buffer.to_string();
+
+            let response_start_line mut = 0;
+            let response_start_column mut = 0;
+            let response_end_line mut = 0;
+            let response_end_column mut = 0;
+            let formatted mut = "";
+
+            try
+                IoC.CONTAINER.instance.logger.clear(path, false);
+
+                let source_file =
+                    _compiler.parse(path, IO.StringReader(source), _build_flags, false);
+
+                if !IoC.CONTAINER.instance.logger.any_errors then
+                    let root = cast Syntax.Trees.Definitions.LIST(source_file.definition);
+
+                    if root? then
+                        let locator =
+                            Syntax.Process.Printer.RANGE_LOCATOR(
+                                start_line, start_column, end_line, end_column
+                            );
+
+                        let target = locator.locate(root);
+
+                        if target? /\ target.node? then
+                            // the run's own leading indentation is not part of
+                            // the replaced span — continuation lines must be
+                            // re-indented back to it
+                            let continuation_indent = target.start_column - 1;
+
+                            let formatter =
+                                Syntax.Process.Printer.FORMATTER(
+                                    _trivia_in_lines(
+                                        source_file.trivia,
+                                        target.start_line,
+                                        target.end_line
+                                    ),
+                                    100 - continuation_indent
+                                );
+
+                            formatted =
+                                _reindent(formatter.format(target.node), continuation_indent);
+
+                            response_start_line = target.start_line;
+                            response_start_column = target.start_column;
+                            response_end_line = target.end_line;
+                            // exclusive end of the span to replace, one past
+                            // the run's last character (and any ';' the
+                            // statement node's location does not cover)
+                            response_end_column = _span_end_column(source, target) + 1;
+                        fi
+                    fi
+                fi
+            catch ex: Exception
+                debug_always("FORMATRANGE caught: {ex.get_type()} {ex.message}");
+            yrt
+
+            writer.write_line("FORMATRANGE");
+            writer.write_line(
+                "{response_start_line}\t{response_start_column}\t{response_end_line}\t{response_end_column}"
+            );
+            // trailing newline is protocol framing — the response parser drops
+            // the final line; the formatted span itself carries no newline
+            writer.write_line(formatted);
+            writer.write("{cast char(12)}");
+            writer.flush();
+        si
+
+        _trivia_in_lines(
+            trivia: Collections.Iterable[Lexical.TRIVIA],
+            start_line: int,
+            end_line: int
+        ) -> Collections.Iterable[Lexical.TRIVIA] is
+            let result = Collections.LIST[Lexical.TRIVIA]();
+
+            if trivia? then
+                for t in trivia do
+                    let line = t.location.start_line;
+                    if line >= start_line /\ line <= end_line then
+                        result.add(t);
+                    fi
+                od
+            fi
+
+            return result;
+        si
+
+        _char_index(source: string, line: int, column: int) -> int is
+            let i mut = 0;
+            let current_line mut = 1;
+            while current_line < line /\ i < source.length do
+                if source.get_chars(i) == '\n' then
+                    current_line = current_line + 1;
+                fi
+                i = i + 1;
+            od
+            return i + column - 1;
+        si
+
+        // The column of the run's last character to replace. A statement's
+        // trailing ';' is not part of its node location, so if one follows the
+        // run it is swallowed into the span — otherwise the formatted text
+        // (which re-emits the ';') would leave the original stranded.
+        _span_end_column(source: string, target: Syntax.Process.Printer.RANGE_TARGET) -> int is
+            let end_index = _char_index(source, target.end_line, target.end_column);
+
+            let scan mut = end_index + 1;
+            while
+                scan < source.length /\
+                (source.get_chars(scan) == ' ' \/ source.get_chars(scan) == '\t')
+            do
+                scan = scan + 1;
+            od
+
+            if scan < source.length /\ source.get_chars(scan) == ';' then
+                return target.end_column + (scan - end_index);
+            fi
+
+            return target.end_column;
+        si
+
+        // Re-indent the formatted run for splicing back at its original
+        // position: the first line goes in after the run's existing leading
+        // indentation (which is not part of the replaced span), so it stays
+        // bare; every later line is indented to that same depth. The trailing
+        // newline the formatter appends is dropped.
+        _reindent(body: string, continuation_indent: int) -> string is
+            let prefix = System.Text.StringBuilder();
+            let p mut = 0;
+            while p < continuation_indent do
+                prefix.append(' ');
+                p = p + 1;
+            od
+            let prefix_string = prefix.to_string();
+
+            let result = System.Text.StringBuilder();
+            let lines = Collections.LIST[string](body.split(['\n']));
+            let index mut = 0;
+
+            while index < lines.count do
+                let line = lines[index];
+
+                if index == lines.count - 1 /\ line.length == 0 then
+                    break;
+                fi
+
+                if index > 0 then
+                    result.append('\n');
+                    if line.length > 0 then
+                        result.append(prefix_string);
+                    fi
+                fi
+
+                result.append(line);
+                index = index + 1;
+            od
+
+            return result.to_string();
+        si
+    si
 si

--- a/src/syntax/process/printer/range_locator.ghul
+++ b/src/syntax/process/printer/range_locator.ghul
@@ -1,0 +1,131 @@
+namespace Syntax.Process.Printer is
+    use Collections;
+
+    use Trees;
+    use Source;
+
+    // A run of sibling AST nodes selected for range formatting — wrapped in a
+    // fresh list node ready to hand to FORMATTER — plus the source span they
+    // occupy. The line/column bounds let the caller confirm the run sits on
+    // lines of its own before replacing those lines wholesale.
+    class RANGE_TARGET is
+        node: Node;
+        start_line: int;
+        start_column: int;
+        end_line: int;
+        end_column: int;
+
+        init(
+            node: Node,
+            start_line: int,
+            start_column: int,
+            end_line: int,
+            end_column: int
+        ) is
+            self.node = node;
+            self.start_line = start_line;
+            self.start_column = start_column;
+            self.end_line = end_line;
+            self.end_column = end_column;
+        si
+    si
+
+    // Finds the smallest run of whole definitions or statements that covers a
+    // requested range. Descends through namespace and class/trait/struct/union
+    // bodies and into a function's statement body; a statement is a leaf — a
+    // block statement is formatted whole rather than split at the range.
+    class RANGE_LOCATOR is
+        _start: int;
+        _end: int;
+
+        init(start_line: int, start_column: int, end_line: int, end_column: int) is
+            _start = LOCATION.pair(start_line, start_column);
+            _end = LOCATION.pair(end_line, end_column);
+        si
+
+        _overlaps(location: LOCATION) -> bool =>
+            location? /\ location.start <= _end /\ location.end >= _start;
+
+        _contains(location: LOCATION) -> bool =>
+            location? /\ location.start <= _start /\ location.end >= _end;
+
+        locate(definitions: Definitions.LIST) -> RANGE_TARGET is
+            let overlapping = LIST[Definitions.Definition]();
+
+            for d in definitions do
+                if _overlaps(d.location) then
+                    overlapping.add(d);
+                fi
+            od
+
+            if overlapping.count == 1 /\ _contains(overlapping[0].location) then
+                let descended = _descend(overlapping[0]);
+                if descended? then
+                    return descended;
+                fi
+            fi
+
+            if overlapping.count == 0 then
+                return null;
+            fi
+
+            let first = overlapping[0].location;
+            let last = overlapping[overlapping.count - 1].location;
+
+            return RANGE_TARGET(
+                Definitions.LIST(first, overlapping),
+                first.start_line,
+                first.start_column,
+                last.end_line,
+                last.end_column
+            );
+        si
+
+        _descend(definition: Definitions.Definition) -> RANGE_TARGET is
+            let namespace_definition = cast Definitions.NAMESPACE(definition);
+            if namespace_definition? then
+                return locate(namespace_definition.body);
+            fi
+
+            let classy = cast Definitions.Classy(definition);
+            if classy? /\ classy.body? then
+                return locate(classy.body);
+            fi
+
+            let function_definition = cast Definitions.FUNCTION(definition);
+            if function_definition? then
+                let block = cast Bodies.BLOCK(function_definition.body);
+                if block? then
+                    return _locate_statements(block.statements);
+                fi
+            fi
+
+            return null;
+        si
+
+        _locate_statements(statements: Statements.LIST) -> RANGE_TARGET is
+            let overlapping = LIST[Statements.Statement]();
+
+            for s in statements do
+                if _overlaps(s.location) then
+                    overlapping.add(s);
+                fi
+            od
+
+            if overlapping.count == 0 then
+                return null;
+            fi
+
+            let first = overlapping[0].location;
+            let last = overlapping[overlapping.count - 1].location;
+
+            return RANGE_TARGET(
+                Statements.LIST(first, overlapping),
+                first.start_line,
+                first.start_column,
+                last.end_line,
+                last.end_column
+            );
+        si
+    si
+si


### PR DESCRIPTION
Enhancements:
- New analysis-mode `#FORMATRANGE` command reformats just the run of
  definitions or statements covering a requested range — for editor
  "format selection" support.

Technical:
- `RANGE_LOCATOR` snaps a requested range out to the smallest run of
  whole enclosing definitions or statements, descending through
  namespace and class bodies and into a function's statement body.
- The run is formatted by the existing `FORMATTER` and spliced back over
  its exact character span — extended over a trailing `;` the statement
  node's location does not cover — so code sharing the run's lines is
  never lost.
