### PR TITLE
Hover shows the declared optional type of a narrowed variable

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.12.17",
+      "version": "0.12.19",
       "commands": [
         "ghul-compiler"
       ],

--- a/analysis-tests/fixtures/optional-narrowing-hover/optional-narrowing-hover.ghul
+++ b/analysis-tests/fixtures/optional-narrowing-hover/optional-narrowing-hover.ghul
@@ -1,0 +1,27 @@
+namespace OptionalNarrowingHover is
+    use IO.Std;
+
+    // In-branch optional narrowing: the parameter `x` is declared
+    // `string?` but is narrowed to non-optional `string` inside the
+    // `if x?` then-branch.
+    describe(x: string?) -> int is
+        if x? then
+            return x.length;
+        fi
+        return 0;
+    si
+
+    // Divergent-guard narrowing: after the guard returns, `y` is
+    // known to be non-optional `string` for the rest of the method.
+    guarded(y: string?) -> int is
+        if !y? then
+            return -1;
+        fi
+        return y.length;
+    si
+
+    entry() is
+        Std.write_line("{describe("hello")}");
+        Std.write_line("{guarded("world")}");
+    si
+si

--- a/analysis-tests/src/tests/optional_narrowing_hover_tests.ghul
+++ b/analysis-tests/src/tests/optional_narrowing_hover_tests.ghul
@@ -1,0 +1,112 @@
+namespace Analysis.Tests is
+    use Collections.LIST;
+
+    use IO.File;
+
+    use Analysis.Protocol.ANALYSER_PROCESS;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    // HOVER on a local/parameter whose optionalness is refined by
+    // flow-sensitive narrowing. A `T?` parameter narrowed to
+    // non-optional `T` inside an `if x?` branch (or after a divergent
+    // `if !x? then return fi` guard) should HOVER as `T` at the
+    // narrowed use site, mirroring what NARROWING_HOVER_TESTS pins for
+    // `isa`-based type narrowing.
+    class OPTIONAL_NARROWING_HOVER_TESTS is
+        @test()
+
+        init() is si
+
+        load_fixture() -> string is
+            let path = fixture_path("optional-narrowing-hover/optional-narrowing-hover.ghul");
+
+            assert File.exists(path) else "fixture missing: {path}";
+
+            return File.read_all_text(path);
+        si
+
+        prime(analyser: ANALYSER_PROCESS, source: string) is
+            analyser.send_edit("optional-narrowing-hover.ghul", source);
+
+            let diagnostics = analyser.read_response();
+            Assert.are_equal("DIAGNOSTICS", diagnostics.header);
+
+            let user_diagnostics = LIST(diagnostics.user_diagnostics);
+            Assert.are_equal(
+                0,
+                user_diagnostics.count,
+                diagnostics_summary("EDIT had unexpected diagnostics", user_diagnostics)
+            );
+
+            let partial_done = analyser.read_response();
+            Assert.are_equal("PARTIAL DONE", partial_done.header);
+        si
+
+        hover_description(analyser: ANALYSER_PROCESS, line: int, column: int) -> string is
+            analyser.send_hover("optional-narrowing-hover.ghul", line, column);
+            let response = analyser.read_query_response();
+            Assert.are_equal("HOVER", response.header);
+            let lines = LIST[string](response.lines);
+            if lines.count == 0 then
+                return "";
+            fi
+            return lines[0];
+        si
+
+        assert_hover_contains(actual: string, expected_substring: string, where: string, analyser: ANALYSER_PROCESS) is
+            Assert.is_true(
+                actual? /\ actual.contains(expected_substring),
+                "{where}: expected HOVER to contain '{expected_substring}', got '{actual}'.\n--- analyser stderr ---\n{analyser.stderr_capture}"
+            );
+        si
+
+        assert_hover_lacks(actual: string, forbidden_substring: string, where: string, analyser: ANALYSER_PROCESS) is
+            Assert.is_false(
+                actual? /\ actual.contains(forbidden_substring),
+                "{where}: expected HOVER NOT to contain '{forbidden_substring}', got '{actual}'.\n--- analyser stderr ---\n{analyser.stderr_capture}"
+            );
+        si
+
+        // HOVER on the parameter declaration `describe(x: string?)`
+        // shows the declared optional type; nothing is narrowed here.
+        hover_on_param_decl__shows_declared_optional() is
+            @test()
+
+            let source = load_fixture();
+            let use analyser = ANALYSER_PROCESS();
+            prime(analyser, source);
+
+            let description = hover_description(analyser, 7, 14);
+            assert_hover_contains(description, "x: Ghul.string?", "hover on `x` parameter decl", analyser);
+        si
+
+        // `return x.length;` inside `if x?` — HOVER on the narrowed
+        // use of `x` shows non-optional `string`, not `string?`.
+        hover_on_narrowed_use_in_optional_branch__shows_non_optional() is
+            @test()
+
+            let source = load_fixture();
+            let use analyser = ANALYSER_PROCESS();
+            prime(analyser, source);
+
+            let description = hover_description(analyser, 9, 20);
+            assert_hover_contains(description, "x: Ghul.string", "hover on narrowed `x` in `if x?` branch", analyser);
+            assert_hover_lacks(description, "x: Ghul.string?", "hover on narrowed `x` in `if x?` branch", analyser);
+        si
+
+        // `return y.length;` after `if !y? then return fi` — HOVER on
+        // `y` shows non-optional `string`. Divergent-guard narrowing.
+        hover_on_narrowed_use_after_divergent_guard__shows_non_optional() is
+            @test()
+
+            let source = load_fixture();
+            let use analyser = ANALYSER_PROCESS();
+            prime(analyser, source);
+
+            let description = hover_description(analyser, 20, 16);
+            assert_hover_contains(description, "y: Ghul.string", "hover on narrowed `y` after divergent guard", analyser);
+            assert_hover_lacks(description, "y: Ghul.string?", "hover on narrowed `y` after divergent guard", analyser);
+        si
+    si
+si

--- a/integration-tests/semantic/nullable-errors/err.expected
+++ b/integration-tests/semantic/nullable-errors/err.expected
@@ -1,2 +1,2 @@
-test.ghul: 17,14..17,15: error: no static overload found for take_int(BOX?), tried take_int(n: int) -> Ghul.int
+test.ghul: 20,14..20,15: error: no static overload found for take_int(BOX?), tried take_int(n: int) -> Ghul.int
 test.ghul: 3,18..3,20: error: an optional type parameter requires a `class` or `struct` constraint

--- a/integration-tests/semantic/nullable-errors/test.ghul
+++ b/integration-tests/semantic/nullable-errors/test.ghul
@@ -11,8 +11,11 @@ take_int(n: int) -> int => n;
 
 entry() is
     // a `BOX?` is not assignable where a plain `int` is expected;
-    // the diagnostic renders the nullable type with its `?` suffix.
-    let b: BOX? = BOX();
+    // the diagnostic renders the optional type with its `?` suffix.
+    // `b` is left at `null` so flow analysis cannot narrow away the
+    // `?` — a non-null initializer would, and the use-site type
+    // would then render as the narrowed `BOX`.
+    let b: BOX? = null;
 
     take_int(b);
 si

--- a/src/ir/values/load/symbol.ghul
+++ b/src/ir/values/load/symbol.ghul
@@ -28,6 +28,16 @@ namespace IR.Values.Load is
                 symbol_as_typed.type
             fi;
 
+        // Pin the snapshotted type to a flow-narrowed form. Used
+        // when optional-narrowing establishes the loaded variable is
+        // non-null at this use site: the load *is* of the
+        // non-optional type, even though the symbol's declared type
+        // still carries `?`. Mirrors how `isa`-narrowing reaches the
+        // snapshot via a mutated `symbol.type` at construction time.
+        narrow_snapshot_type(narrowed: Type) is
+            _snapshot_type = narrowed;
+        si
+
         from: Value;
 
         init(from: Value, symbol: SymbolBase) is

--- a/src/semantic/types/named.ghul
+++ b/src/semantic/types/named.ghul
@@ -216,6 +216,18 @@ namespace Semantic.Types is
             return result;
         si
 
+        as_non_optional() -> Type is
+            if !_is_optional then
+                return self;
+            fi
+
+            let result = cast NAMED(memberwise_clone());
+
+            result._is_optional = false;
+
+            return result;
+        si
+
         to_string() -> string =>
             if symbol? then
                 if _is_optional then

--- a/src/semantic/types/type.ghul
+++ b/src/semantic/types/type.ghul
@@ -175,6 +175,14 @@ namespace Semantic.Types is
         // by NAMED; the base covers sentinels, which are left as-is.
         as_optional() -> Type => self;
 
+        // The non-optional form of this type. For a reference type
+        // carrying `?` this drops the flag; a no-op for everything
+        // else — value-type optionality is the distinct OPTION[T],
+        // and sentinels have no `?` form. Overridden by NAMED. Used
+        // when flow-sensitive narrowing establishes a variable is
+        // non-null at a use site.
+        as_non_optional() -> Type => self;
+
         =~(other: Type) -> bool => false;
 
         is_assignable_from(other: Type) -> bool

--- a/src/syntax/process/compile_expressions.ghul
+++ b/src/syntax/process/compile_expressions.ghul
@@ -4916,6 +4916,29 @@ namespace Syntax.Process is
                     else
                         identifier.value = symbol.load(identifier.location, null, _symbol_loader);
 
+                        // Optional-narrowing: when flow analysis has
+                        // established this variable is non-null here,
+                        // the load is of the non-optional type. Pin
+                        // that on the use-site node, matching how
+                        // `isa`-narrowing reaches the load via a
+                        // mutated `symbol.type`.
+                        if
+                            isa Semantic.Symbols.Variable(symbol) /\
+                            isa IR.Values.Load.SYMBOL(identifier.value) /\
+                            identifier.value.has_type /\
+                            identifier.value.type.is_optional
+                        then
+                            let variable = symbol;
+
+                            if _flow.is_non_null(variable) then
+                                let narrowed = identifier.value.type.as_non_optional();
+
+                                if narrowed? /\ !narrowed.is_optional then
+                                    (cast IR.Values.Load.SYMBOL(identifier.value)).narrow_snapshot_type(narrowed);
+                                fi
+                            fi
+                        fi
+
                         // HOVER reads a narrowed local's type off
                         // this use-site node, not the symbol — the
                         // symbol's `type` is restored after the walk.

--- a/unit-tests/src/semantic/types/named_optional_tests.ghul
+++ b/unit-tests/src/semantic/types/named_optional_tests.ghul
@@ -1,0 +1,68 @@
+namespace Semantic.Types.UnitTests is
+    use Collections.LIST;
+    use Collections.List;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    use Source.LOCATION;
+
+    use Semantic.Symbols.CLASS;
+    use Semantic.Types.NAMED;
+    use Semantic.Types.Type;
+
+    // Tests for NAMED's optionality transforms — `as_optional` (the
+    // `T?` form) and `as_non_optional` (its inverse). The latter is
+    // what optional-narrowing uses to re-type a use-site load once
+    // flow analysis has established the variable is non-null.
+    //
+    // `=~` deliberately ignores the optional flag (a NAMED `=~`
+    // compares only the underlying symbol), so these tests assert on
+    // `is_optional` and on reference identity rather than `=~`.
+    class NAMED_OPTIONAL_TESTS is
+        @test()
+
+        init() is si
+
+        loc() -> LOCATION => LOCATION("test.ghul", 1, 1, 1, 1);
+
+        empty_names() -> LIST[string] => LIST[string]();
+
+        // A plain (non-struct) class — a reference type, so its `T?`
+        // form carries the optional flag rather than wrapping in
+        // OPTION[T].
+        a_reference_class() -> CLASS =>
+            CLASS(loc(), loc(), null, "Foo", empty_names(), false, null);
+
+        as_non_optional__on_an_optional_reference__drops_the_flag() is
+            @test()
+
+            let bare = cast NAMED(a_reference_class().type);
+            Assert.is_false(bare.is_optional);
+
+            let optional = bare.as_optional();
+            Assert.is_true(optional.is_optional);
+
+            let non_optional = optional.as_non_optional();
+            Assert.is_false(non_optional.is_optional);
+        si
+
+        as_non_optional__on_an_already_non_optional_type__returns_self() is
+            @test()
+
+            let bare = cast NAMED(a_reference_class().type);
+
+            Assert.are_same(bare, bare.as_non_optional());
+        si
+
+        as_non_optional__preserves_the_underlying_symbol() is
+            @test()
+
+            let the_class = a_reference_class();
+            let optional = (cast NAMED(the_class.type)).as_optional();
+
+            let non_optional = cast NAMED(optional.as_non_optional());
+
+            Assert.are_same(the_class, non_optional.symbol);
+        si
+    si
+si


### PR DESCRIPTION
Bugs fixed:

- IDE hover over a variable narrowed to non-optional by flow analysis — inside an `if x?` branch, or after an `if !x? then return fi` guard — showed the declared `T?` type rather than the narrowed `T`. A use-site load of a flow-non-null variable is now typed `T`, matching how `isa`-narrowing already surfaces the refined type in hover.