### PR TITLE
Stop the analyser recycling on warm-up heap growth

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.12.19",
+      "version": "0.12.20",
       "commands": [
         "ghul-compiler"
       ],

--- a/src/analysis/watchdog.ghul
+++ b/src/analysis/watchdog.ghul
@@ -4,11 +4,14 @@ namespace Analysis is
     // Decides when the long-lived analyser should exit so the IDE can spawn a
     // fresh process. Two independent triggers:
     //
-    //  - heap growth: the managed heap is sampled after the first full compile
-    //    to fix a baseline, then after every later full compile. The compiler
-    //    retains state across compiles (ASTs, caches) that clear_symbols does
-    //    not all reclaim, so a steady climb is the expected leak signature.
-    //    A recycle returns that memory to a fresh process.
+    //  - heap growth: the managed heap is sampled after every full compile.
+    //    The first few readings are warm-up — the JIT, interned symbols and
+    //    reflection-metadata caches are still filling — so the baseline is not
+    //    fixed until that has settled: it is the high-water reading across the
+    //    first warm_up_compiles compiles. Past that, the compiler retains state
+    //    across compiles (ASTs, caches) that clear_symbols does not all
+    //    reclaim, so a steady climb is the expected leak signature, and a
+    //    recycle returns that memory to a fresh process.
     //
     //  - instability: a burst of exceptions escaping command handlers. Isolated
     //    failures decay away; a sustained run of them means the analyser's
@@ -28,10 +31,17 @@ namespace Analysis is
         // How often to echo a heap reading to the log (every Nth full compile).
         heap_log_interval: int static => 32;
 
+        // Full compiles to let pass before the baseline is fixed. The analyser's
+        // working set climbs over the first compiles as the JIT and caches fill
+        // — growth that is not a leak — so anchoring the baseline to the cold
+        // first reading would let ordinary warm-up trip a recycle.
+        warm_up_compiles: int static => 5;
+
         _restart_score: int;
 
         _have_baseline: bool;
         _baseline_heap_bytes: long;
+        _warm_up_peak_heap_bytes: long;
         _full_compile_pending: bool;
         _compile_count: int;
 
@@ -79,19 +89,34 @@ namespace Analysis is
         check_heap(writer: IO.TextWriter) is
             let heap = System.GC.get_total_memory(true);
 
+            note_heap(heap);
+
+            if is_heap_over_limit(heap) then
+                log_heap("heap", heap);
+                recycle(writer, "heap growth");
+            fi
+        si
+
+        // Fold one full-compile heap reading into the watchdog. Pure with
+        // respect to the system — the caller supplies the reading — so unit
+        // tests drive it directly. During warm-up it tracks the high-water
+        // reading and fixes the baseline to it once warm_up_compiles full
+        // compiles have completed.
+        note_heap(heap: long) is
             if !_have_baseline then
-                set_baseline(heap);
+                if heap > _warm_up_peak_heap_bytes then
+                    _warm_up_peak_heap_bytes = heap;
+                fi
+
+                if _compile_count >= warm_up_compiles then
+                    set_baseline(_warm_up_peak_heap_bytes);
+                fi
 
                 return;
             fi
 
             if _compile_count % heap_log_interval == 0 then
                 log_heap("heap", heap);
-            fi
-
-            if is_heap_over_limit(heap) then
-                log_heap("heap", heap);
-                recycle(writer, "heap growth");
             fi
         si
 

--- a/unit-tests/src/analysis/watchdog_tests.ghul
+++ b/unit-tests/src/analysis/watchdog_tests.ghul
@@ -8,6 +8,13 @@ namespace Analysis.UnitTests is
 
         mb(n: int) -> long => cast long(n) * 1024L * 1024L;
 
+        // One full compile as the despatcher drives it: count the compile,
+        // then fold in its heap reading.
+        complete_compile(watchdog: WATCHDOG, heap: long) is
+            watchdog.note_full_compile();
+            watchdog.note_heap(heap);
+        si
+
         given_a_new_watchdog__want_restart__should_be_false() is
             @test()
 
@@ -81,6 +88,53 @@ namespace Analysis.UnitTests is
 
             // 400 MB: 300 MB above the baseline and over 2x.
             assert watchdog.is_heap_over_limit(mb(400));
+        si
+
+        given_warm_up_incomplete__is_heap_over_limit__should_be_false() is
+            @test()
+
+            let watchdog = WATCHDOG();
+
+            // Fewer than warm_up_compiles full compiles: no baseline is fixed
+            // yet, so even a huge reading cannot trip a recycle.
+            complete_compile(watchdog, mb(100));
+            complete_compile(watchdog, mb(100));
+
+            assert !watchdog.is_heap_over_limit(mb(8000));
+        si
+
+        given_a_warm_up_climb__the_cold_first_reading_does_not_anchor_the_baseline() is
+            @test()
+
+            let watchdog = WATCHDOG();
+
+            // The heap climbs over warm-up as the JIT and caches fill — not a
+            // leak. Five compiles complete the warm-up window.
+            complete_compile(watchdog, mb(144));
+            complete_compile(watchdog, mb(220));
+            complete_compile(watchdog, mb(330));
+            complete_compile(watchdog, mb(428));
+            complete_compile(watchdog, mb(400));
+
+            // The baseline is the warm-up peak (428 MB), not the cold first
+            // reading (144 MB): a 500 MB heap is ordinary settle, not growth.
+            // Anchored to 144 MB it would be 356 MB over and past 2x — a
+            // spurious recycle.
+            assert !watchdog.is_heap_over_limit(mb(500));
+        si
+
+        given_warm_up_complete__heap_past_both_thresholds__should_be_over_limit() is
+            @test()
+
+            let watchdog = WATCHDOG();
+
+            // A flat warm-up fixes the baseline at 300 MB.
+            for i in 0..WATCHDOG.warm_up_compiles do
+                complete_compile(watchdog, mb(300));
+            od
+
+            // 900 MB: 600 MB above the baseline and over 2x.
+            assert watchdog.is_heap_over_limit(mb(900));
         si
     si
 si


### PR DESCRIPTION
Bugs fixed:

- The analysis-mode watchdog fixed its heap baseline on the first full compile, while the JIT and the symbol and reflection-metadata caches were still filling. Ordinary warm-up growth then read as a leak and tripped a recycle. The baseline is now the high-water heap reading across the first few full compiles, so only growth past a warmed-up working set counts.