### PR TITLE
Isolate format-command parsing and fix parameterless-lambda parens

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.12.20",
+      "version": "0.12.21",
       "commands": [
         "ghul-compiler"
       ],

--- a/analysis-tests/src/protocol/analyser_process.ghul
+++ b/analysis-tests/src/protocol/analyser_process.ghul
@@ -358,6 +358,16 @@ namespace Analysis.Protocol is
             send_edit_files([EDIT_FILE(path, source)]);
         si
 
+        // Send `#FORMAT#` for a single file — path then form-feed-terminated
+        // source. Mirrors ghul-vsce's requester.ts:sendDocumentFormatting.
+        send_format(path: string, source: string) is
+            write("#FORMAT#\n");
+            write("{path}\n");
+            write(source);
+            write("{FORM_FEED}");
+            flush();
+        si
+
         send_compile() is
             write("#COMPILE#\n");
             flush();

--- a/analysis-tests/src/tests/format_isolation_tests.ghul
+++ b/analysis-tests/src/tests/format_isolation_tests.ghul
@@ -1,0 +1,59 @@
+namespace Analysis.Tests is
+    use Collections.LIST;
+
+    use Analysis.Protocol.ANALYSER_PROCESS;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    // A FORMAT request parses the supplied buffer into a throwaway logger,
+    // so it must succeed regardless of the analyser's live diagnostics
+    // state. Before the parse was isolated, FORMAT consulted the shared
+    // logger's global any_errors flag and silently echoed the buffer back
+    // unchanged whenever the project had a semantic error anywhere.
+    class FORMAT_ISOLATION_TESTS is
+        @test()
+
+        init() is si
+
+        // A buffer that parses cleanly but fails semantically — missing_symbol
+        // is undefined — indented with eight spaces per level.
+        misformatted_source: string =>
+            "namespace Bad is\n        class C is\n                run() -> int => missing_symbol;\n        si\nsi\n";
+
+        format_succeeds_when_the_project_has_a_semantic_error() is
+            @test()
+
+            let use analyser = ANALYSER_PROCESS();
+
+            analyser.send_edit("bad.ghul", misformatted_source);
+
+            let edit_diagnostics = analyser.read_response();
+            Assert.are_equal("DIAGNOSTICS", edit_diagnostics.header);
+
+            // Precondition: the buffer genuinely has a semantic error, so the
+            // shared logger holds one when the FORMAT request arrives.
+            let user_diagnostics = LIST(edit_diagnostics.user_diagnostics);
+            Assert.is_true(
+                user_diagnostics.count > 0,
+                "expected a semantic error from the EDIT\n--- analyser stderr ---\n{analyser.stderr_capture}"
+            );
+
+            let edit_partial_done = analyser.read_response();
+            Assert.are_equal("PARTIAL DONE", edit_partial_done.header);
+
+            analyser.send_format("bad.ghul", misformatted_source);
+
+            let response = analyser.read_response();
+            Assert.are_equal("FORMAT", response.header);
+
+            // The buffer must come back reindented to four spaces, not echoed
+            // back unchanged at its original eight-space indentation.
+            let lines = LIST[string](response.lines);
+            Assert.is_true(
+                lines.count > 1,
+                "FORMAT returned no body\n--- analyser stderr ---\n{analyser.stderr_capture}"
+            );
+            Assert.are_equal("    class C is", lines[1]);
+        si
+    si
+si

--- a/src/analysis/command_handlers.ghul
+++ b/src/analysis/command_handlers.ghul
@@ -1036,17 +1036,21 @@ namespace Analysis is
             let result mut = source;
 
             try
-                IoC.CONTAINER.instance.logger.clear(path, false);
+                // Parse into a throwaway logger so a format request never
+                // mutates the analyser's shared diagnostics store or its
+                // speculation state stack.
+                let format_logger = Logging.DIAGNOSTICS_STORE();
 
                 let source_file =
                     _compiler.parse(
                         path,
                         IO.StringReader(source),
                         _build_flags,
-                        false
+                        false,
+                        format_logger
                     );
 
-                if !IoC.CONTAINER.instance.logger.any_errors then
+                if !format_logger.any_errors then
                     let formatter =
                         Syntax.Process.Printer.FORMATTER(source_file.trivia, 100);
 
@@ -1104,12 +1108,17 @@ namespace Analysis is
             let formatted mut = "";
 
             try
-                IoC.CONTAINER.instance.logger.clear(path, false);
+                // Parse into a throwaway logger so a format request never
+                // mutates the analyser's shared diagnostics store or its
+                // speculation state stack.
+                let format_logger = Logging.DIAGNOSTICS_STORE();
 
                 let source_file =
-                    _compiler.parse(path, IO.StringReader(source), _build_flags, false);
+                    _compiler.parse(
+                        path, IO.StringReader(source), _build_flags, false, format_logger
+                    );
 
-                if !IoC.CONTAINER.instance.logger.any_errors then
+                if !format_logger.any_errors then
                     let root = cast Syntax.Trees.Definitions.LIST(source_file.definition);
 
                     if root? then

--- a/src/compiler/compiler.ghul
+++ b/src/compiler/compiler.ghul
@@ -155,7 +155,20 @@ namespace Compiler is
             self.source_files.add_range(source_files);
         si
 
-        parse(path: string, reader: IO.TextReader, build_flags: BUILD_FLAGS, is_internal_file: bool) -> SOURCE_FILE is
+        parse(path: string, reader: IO.TextReader, build_flags: BUILD_FLAGS, is_internal_file: bool) -> SOURCE_FILE =>
+            parse(path, reader, build_flags, is_internal_file, logger);
+
+        // Parsing into an explicitly-supplied logger lets a caller (the
+        // analysis-mode format handlers) parse without touching the shared
+        // diagnostics store: a throwaway logger keeps parse diagnostics and
+        // the speculation state stack isolated from the live analyser state.
+        parse(
+            path: string,
+            reader: IO.TextReader,
+            build_flags: BUILD_FLAGS,
+            is_internal_file: bool,
+            logger: Logger
+        ) -> SOURCE_FILE is
             let tokenizer = Lexical.TOKENIZER(
                 logger,
                 path,

--- a/src/syntax/process/printer/formatter.ghul
+++ b/src/syntax/process/printer/formatter.ghul
@@ -462,15 +462,20 @@ namespace Syntax.Process.Printer is
         si
 
         // --- faithfulness fix: a lambda's argument list must be parenthesised
-        //     when the lambda has an explicit return type, otherwise
-        //     `arg: T -> U => body` reparses as arg-of-function-type `T -> U`. ---
+        //     unless it is a single argument with an inferred return type —
+        //     the only paren-free lambda form. A bare empty list (`=> body`)
+        //     or a bare multi-argument list does not reparse as a lambda, and
+        //     an explicit return type needs the parens or `arg: T -> U`
+        //     reparses as an argument of function type `T -> U`. ---
 
         visit(function: Expressions.FUNCTION) is
             note(function.location);
 
             let explicit_return = !isa TypeExpressions.INFER(function.type_expression);
 
-            if explicit_return then
+            let parenthesise = explicit_return \/ function.arguments.count != 1;
+
+            if parenthesise then
                 write("(");
             fi
 
@@ -483,8 +488,12 @@ namespace Syntax.Process.Printer is
                 first = false;
             od
 
+            if parenthesise then
+                write(")");
+            fi
+
             if explicit_return then
-                write(") -> ");
+                write(" -> ");
                 function.type_expression.accept(self);
             fi
 

--- a/unit-tests/src/syntax/process/printer/formatter_lambda_tests.ghul
+++ b/unit-tests/src/syntax/process/printer/formatter_lambda_tests.ghul
@@ -1,0 +1,65 @@
+namespace Syntax.Process.Printer.UnitTests is
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    use Syntax.Process.Printer.FORMATTER;
+
+    // FORMATTER renders a lambda's argument list parenthesised unless it
+    // is a single argument with an inferred return type — the only
+    // paren-free lambda form. A bare empty list (`=> body`) or a bare
+    // multi-argument list does not reparse as a lambda.
+    class FORMATTER_LAMBDA_TESTS is
+        @test()
+
+        init() is si
+
+        format(node: Trees.Node) -> string =>
+            FORMATTER(Collections.LIST[Lexical.TRIVIA](), 100).format(node);
+
+        identifier(name: string) -> Trees.Expressions.Expression =>
+            Trees.Expressions.IDENTIFIER(
+                Source.LOCATION.internal,
+                Trees.Identifiers.Identifier(Source.LOCATION.internal, name)
+            );
+
+        lambda(arguments: Collections.Iterable[Trees.Expressions.Expression])
+            -> Trees.Expressions.FUNCTION
+        =>
+            Trees.Expressions.FUNCTION(
+                Source.LOCATION.internal,
+                Trees.Expressions.LIST(Source.LOCATION.internal, arguments),
+                Trees.TypeExpressions.INFER(Source.LOCATION.internal),
+                Trees.Bodies.EXPRESSION(
+                    Source.LOCATION.internal,
+                    Trees.Expressions.Literals.INTEGER(Source.LOCATION.internal, "42")
+                ),
+                false
+            );
+
+        a_parameterless_lambda_keeps_its_parentheses() is
+            @test()
+
+            Assert.are_equal(
+                "() => 42\n",
+                format(lambda(Collections.LIST[Trees.Expressions.Expression]()))
+            );
+        si
+
+        a_single_argument_lambda_is_not_parenthesised() is
+            @test()
+
+            Assert.are_equal(
+                "x => 42\n",
+                format(lambda([identifier("x")]))
+            );
+        si
+
+        a_multi_argument_lambda_is_parenthesised() is
+            @test()
+
+            Assert.are_equal(
+                "(x, y) => 42\n",
+                format(lambda([identifier("x"), identifier("y")]))
+            );
+        si
+    si
+si


### PR DESCRIPTION
Bugs fixed:
- The analysis-mode `#FORMAT#` / `#FORMATRANGE#` handlers parsed the supplied buffer against the analyser's shared compiler logger: they cleared the file's live diagnostics, wrote parse-only diagnostics into the shared store with no compile to repopulate it, gated formatting on the store-wide `any_errors` flag (so a format request silently echoed the buffer back unchanged whenever any project file had an error), and could leave the speculation-state stack unbalanced. `COMPILER.parse` gains an overload taking an explicit logger, and the format handlers now parse into a throwaway diagnostics store, so a format request no longer touches analyser state.
- The formatter dropped the parentheses from a parameterless lambda (`() => x` rendered as `=> x`) and from a multi-argument lambda, both of which then fail to reparse. Only a single-argument lambda with an inferred return type is legal paren-free.
