### PR TITLE
Remove the post-checkout git hook

### DIFF
--- a/.git-hooks/install
+++ b/.git-hooks/install
@@ -1,3 +1,2 @@
 #!/bin/bash
 ln -sf $(realpath .git-hooks/pre-commit) .git/hooks/pre-commit
-ln -sf $(realpath .git-hooks/post-checkout) .git/hooks/post-checkout

--- a/.git-hooks/post-checkout
+++ b/.git-hooks/post-checkout
@@ -1,2 +1,0 @@
-#!/bin/bash
-.git-hooks/update-compiler-tool


### PR DESCRIPTION
Technical:
- Drop the `post-checkout` hook. It re-pinned `.config/dotnet-tools.json` to the latest published compiler on every checkout — file checkouts, `git worktree add` and rebase-internal checkouts included — dirtying the working tree where a manifest bump is unwanted. The `pre-commit` hook already re-pins on every commit, so the post-checkout copy was redundant.