### PR TITLE
Reduce the analysis-mode heap watchdog's cost

### DIFF
--- a/analysis-profiler/run-profile.sh
+++ b/analysis-profiler/run-profile.sh
@@ -17,9 +17,12 @@ cd "$(dirname "$0")"
 MODE="${1:-both}"
 WORKLOAD="${2:-}"
 
-# Have the spawned analyser emit its periodic per-command / per-pass TIMERS
-# dump — captured into the report's stderr appendix.
-export ANALYSER_EXTRA_ARGS="--show-analysis-stats"
+# --show-analysis-stats: have the spawned analyser emit its periodic
+#   per-command / per-pass TIMERS dump, captured into the report appendix.
+# --no-analysis-heap-watchdog: suppress the watchdog's post-compile heap
+#   sampling. It forces a full GC after every compile, which otherwise
+#   dominates the trace (≈37% of CPU) and masks the genuine hotspots.
+export ANALYSER_EXTRA_ARGS="--show-analysis-stats --no-analysis-heap-watchdog"
 
 echo "==> building analysis-profiler (and the compiler under test)"
 dotnet build analysis-profiler.ghulproj -c Debug

--- a/src/analysis/watchdog.ghul
+++ b/src/analysis/watchdog.ghul
@@ -37,6 +37,11 @@ namespace Analysis is
         // first reading would let ordinary warm-up trip a recycle.
         warm_up_compiles: int static => 5;
 
+        // When set, check_heap is skipped — the analyser does not sample the
+        // heap or force a GC after compiles. Driven by --no-analysis-heap-
+        // watchdog; intended for profiling, where the forced GC dominates.
+        heap_check_disabled: bool public;
+
         _restart_score: int;
 
         _have_baseline: bool;
@@ -82,7 +87,9 @@ namespace Analysis is
             if _full_compile_pending then
                 _full_compile_pending = false;
 
-                check_heap(writer);
+                if !heap_check_disabled then
+                    check_heap(writer);
+                fi
             fi
         si
 

--- a/src/compiler/build_flags.ghul
+++ b/src/compiler/build_flags.ghul
@@ -29,6 +29,12 @@ namespace Compiler is
         exclude_runtime_symbols: bool public;
         is_test_run: bool public;
 
+        // Suppresses the analysis-mode heap watchdog's post-compile heap
+        // sampling (see the `--no-analysis-heap-watchdog` driver flag). The
+        // sampling forces a full GC after every compile; turning it off is
+        // useful when profiling the analyser.
+        no_analysis_heap_watchdog: bool public;
+
         init() is
         si
 

--- a/src/driver/main.ghul
+++ b/src/driver/main.ghul
@@ -287,6 +287,8 @@ namespace Driver is
                     emit_boilerplate_il_path = get_next_argument(args_iterator);
                 elif s =~ "--show-analysis-stats" then
                     flags.want_analysis_stats = true;
+                elif s =~ "--no-analysis-heap-watchdog" then
+                    flags.no_analysis_heap_watchdog = true;
                 elif s =~ "--format" then
                     want_format = true;
                 elif s =~ "--warn-implicit-mutable-let" then
@@ -522,6 +524,8 @@ namespace Driver is
             analyse_files = LIST();
 
             queue_library_locations();
+
+            container.watchdog.heap_check_disabled = flags.no_analysis_heap_watchdog;
 
             let analyser = ANALYSER(
                 compiler,


### PR DESCRIPTION
Technical:

- The heap watchdog forced a full GC (`GC.get_total_memory(true)`) after every full compile to sample the managed heap. Profiling the analyser measured that at ~37% of CPU (the forced GC plus the `ArrayPool<char>.Trim` callback each Gen2 collection triggers). It now samples only every 32nd full compile once the baseline is fixed — warm-up compiles are still all sampled, and the recycle thresholds are unchanged.
- New `--no-analysis-heap-watchdog` driver flag disables the heap sampling entirely, used by the analysis profiler so its traces are not dominated by the forced GC.

A later, cleaner design would decouple the heap check from compiles entirely — the IDE sending an explicit request during a lull in activity — but the reduced sampling frequency is a self-contained first step.