### PR TITLE
Buffer the analyser's stdin reads

### DIFF
--- a/src/driver/main.ghul
+++ b/src/driver/main.ghul
@@ -527,6 +527,23 @@ namespace Driver is
 
             container.watchdog.heap_check_disabled = flags.no_analysis_heap_watchdog;
 
+            // The analyser reads protocol frames and EDIT payloads from stdin a
+            // character at a time. Console.In (Std.`in`) buffers only 256 bytes,
+            // so a large EDIT payload costs thousands of read() syscalls. Read
+            // instead through a 256 KB buffer over the raw standard-input
+            // stream: that exceeds every compiler source file (largest ~230 KB,
+            // p99 ~44 KB), so a single-file EDIT is drained in one read() and a
+            // whole-project EDIT in few. A buffered read still returns as soon
+            // as any bytes are available — a fully-received request is never
+            // delayed waiting for the buffer to fill.
+            let analyser_input =
+                IO.StreamReader(
+                    Std.open_standard_input(),
+                    System.Text.UTF8Encoding(false),
+                    false,
+                    262144
+                );
+
             let analyser = ANALYSER(
                 compiler,
                 container.timers,
@@ -535,7 +552,7 @@ namespace Driver is
                 container.symbol_definition_locations,
                 container.completer,
                 container.signature_help,
-                Std.`in,
+                analyser_input,
                 Std.out,
                 analyse_files,
                 flags,


### PR DESCRIPTION
Stacked on #1330.

Technical:

- The analyser read protocol frames and EDIT payloads through `Console.In`, whose `StreamReader` buffers only 256 bytes — a large EDIT payload (a whole-project EDIT is ~1.9 MB) cost thousands of small `read()` syscalls. It now reads through a `StreamReader` with a 256 KB buffer over the raw standard-input stream, so the underlying `read()` is issued with a wide buffer. 256 KB exceeds every compiler source file (largest ~230 KB, p99 ~44 KB), so a single-file EDIT is drained in one `read()`.
- A buffered read returns as soon as any bytes are available, so a fully-received request is processed without delay — the synchronous request/response contract is unaffected.