### PR TITLE
Sample the analysis-mode heap watchdog less often

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.12.24",
+      "version": "0.12.25",
       "commands": [
         "ghul-compiler"
       ],

--- a/src/analysis/watchdog.ghul
+++ b/src/analysis/watchdog.ghul
@@ -31,6 +31,12 @@ namespace Analysis is
         // How often to echo a heap reading to the log (every Nth full compile).
         heap_log_interval: int static => 32;
 
+        // Once the baseline is fixed, the heap is sampled only every Nth full
+        // compile, not after every one — check_heap forces a full GC, too
+        // costly to run that often. Warm-up compiles (before the baseline is
+        // fixed) are always sampled: the baseline is their high-water reading.
+        heap_check_interval: int static => 32;
+
         // Full compiles to let pass before the baseline is fixed. The analyser's
         // working set climbs over the first compiles as the JIT and caches fill
         // — growth that is not a leak — so anchoring the baseline to the cold
@@ -87,11 +93,17 @@ namespace Analysis is
             if _full_compile_pending then
                 _full_compile_pending = false;
 
-                if !heap_check_disabled then
+                if !heap_check_disabled /\ should_check_heap() then
                     check_heap(writer);
                 fi
             fi
         si
+
+        // Whether this full compile should sample the heap. Every compile
+        // during warm-up — the baseline needs every reading — then only every
+        // heap_check_interval compiles, to keep the forced GC infrequent.
+        should_check_heap() -> bool =>
+            !_have_baseline \/ _compile_count % heap_check_interval == 0;
 
         check_heap(writer: IO.TextWriter) is
             let heap = System.GC.get_total_memory(true);

--- a/unit-tests/src/analysis/watchdog_tests.ghul
+++ b/unit-tests/src/analysis/watchdog_tests.ghul
@@ -136,5 +136,49 @@ namespace Analysis.UnitTests is
             // 900 MB: 600 MB above the baseline and over 2x.
             assert watchdog.is_heap_over_limit(mb(900));
         si
+
+        given_a_new_watchdog__should_check_heap__is_true() is
+            @test()
+
+            let watchdog = WATCHDOG();
+
+            // No baseline fixed yet: every warm-up compile must be sampled so
+            // the baseline can be the high-water reading across the window.
+            assert watchdog.should_check_heap();
+        si
+
+        given_the_baseline_is_fixed__should_check_heap__is_false_off_the_interval() is
+            @test()
+
+            let watchdog = WATCHDOG();
+
+            // Warm-up fixes the baseline.
+            for i in 0..WATCHDOG.warm_up_compiles do
+                complete_compile(watchdog, mb(300));
+            od
+
+            // One more compile — the count is not a multiple of the interval,
+            // so this compile is not sampled (no forced GC).
+            watchdog.note_full_compile();
+
+            assert !watchdog.should_check_heap();
+        si
+
+        given_the_baseline_is_fixed__should_check_heap__is_true_on_the_interval() is
+            @test()
+
+            let watchdog = WATCHDOG();
+
+            for i in 0..WATCHDOG.warm_up_compiles do
+                complete_compile(watchdog, mb(300));
+            od
+
+            // Advance the compile count to land exactly on the interval.
+            for i in WATCHDOG.warm_up_compiles..WATCHDOG.heap_check_interval do
+                watchdog.note_full_compile();
+            od
+
+            assert watchdog.should_check_heap();
+        si
     si
 si


### PR DESCRIPTION
Technical:

- The analysis-mode heap watchdog forced a full GC (`GC.get_total_memory(true)`) after **every** full compile to sample the managed heap. Profiling the analyser measured that at ~37% of CPU — the forced collection plus the `ArrayPool<char>.Trim` callback each Gen2 collection triggers.
- It now samples only every 32nd full compile once the baseline is fixed. Warm-up compiles are still all sampled (the baseline is their high-water reading), and the recycle thresholds are unchanged — a heap leak is still detected, just on a coarser cadence.
- Follows up #1330, which added `--no-analysis-heap-watchdog` to disable the sampling entirely for profiling.