### PR TITLE
Drop a redundant collection copy in generic specialization

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.12.24",
+      "version": "0.12.26",
       "commands": [
         "ghul-compiler"
       ],

--- a/src/semantic/symbols/function.ghul
+++ b/src/semantic/symbols/function.ghul
@@ -322,7 +322,9 @@ namespace Semantic.Symbols is
                 result.unspecialized_return_type = return_type;
             fi
             
-            let ra = Collections.LIST[Type](arguments);
+            // Pre-sized empty, filled by add: a LIST(arguments) copy would
+            // duplicate every element only for the loop to replace them.
+            let ra = Collections.LIST[Type](arguments.count);
 
             result.arguments = ra;
 
@@ -330,7 +332,9 @@ namespace Semantic.Symbols is
                 let a = arguments[i];
 
                 if a? then
-                    ra[i] = arguments[i].specialize(type_map);
+                    ra.add(a.specialize(type_map));
+                else
+                    ra.add(a);
                 fi
             od
 

--- a/src/semantic/symbols/function_group.ghul
+++ b/src/semantic/symbols/function_group.ghul
@@ -45,10 +45,12 @@ namespace Semantic.Symbols is
                 result
             );
 
-            result._functions = Collections.LIST[Function](_functions);
+            // Pre-sized empty, filled by add: a LIST(_functions) copy would
+            // duplicate every element only for the loop to overwrite them all.
+            result._functions = Collections.LIST[Function](_functions.count);
 
             for i in 0.._functions.count do
-                result._functions[i] = _functions[i].specialize_function(type_map, owner);
+                result._functions.add(_functions[i].specialize_function(type_map, owner));
             od
 
             return result;


### PR DESCRIPTION
Technical:

- `specialize_function` and `specialize_function_group` built the specialized argument / function list with `LIST(source)` — which copies every element — and then immediately overwrote all of them in the following loop. They now construct the list pre-sized and empty and fill it by `add`, so the originals are never copied.
- Generic specialization runs on every compile; profiling the analyser put collection construction and growth among the hottest operations.