### PR TITLE
Analysis-mode performance: heap-watchdog rework and a specialization copy

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.12.24",
+      "version": "0.12.28",
       "commands": [
         "ghul-compiler"
       ],

--- a/analysis-protocol/src/analyser_process.ghul
+++ b/analysis-protocol/src/analyser_process.ghul
@@ -397,6 +397,15 @@ namespace Analysis.Protocol is
             flush();
         si
 
+        // Ask the analyser to sample the heap (the VS Code extension sends
+        // this during a lull in editing). It answers with a HEAPCHECK frame —
+        // or, if the heap has grown past the recycle threshold, with RESTART
+        // and then exits.
+        send_heap_check() is
+            write("#HEAPCHECK#\n");
+            flush();
+        si
+
         // Block until the subprocess exits, up to timeout_ms. True if it exited.
         wait_for_exit(timeout_ms: int) -> bool =>
             _process.wait_for_exit(timeout_ms);

--- a/analysis-tests/src/tests/command_happy_path_tests.ghul
+++ b/analysis-tests/src/tests/command_happy_path_tests.ghul
@@ -228,5 +228,23 @@ namespace Analysis.Tests is
             let response = analyser.read_query_response();
             Assert.are_equal("RENAMEREQUEST", response.header);
         si
+
+        // HEAPCHECK asks the analyser to sample the heap. A small clean
+        // fixture is nowhere near the recycle threshold, so the analyser
+        // answers with a HEAPCHECK frame rather than recycling.
+        heap_check_should_respond() is
+            @test()
+
+            let (main_source, greeter_source) = load_fixture();
+
+            let use analyser = ANALYSER_PROCESS();
+
+            prime(analyser, main_source, greeter_source);
+
+            analyser.send_heap_check();
+
+            let response = analyser.read_response();
+            Assert.are_equal("HEAPCHECK", response.header);
+        si
     si
 si

--- a/src/analysis/README.md
+++ b/src/analysis/README.md
@@ -7,6 +7,6 @@ The main components are:
 - `analyser.ghul` – entry point that drives a `COMMAND_DESPATCHER` loop.
 - `command_despatcher.ghul` – waits for a command keyword, then invokes the matching handler.
 - `command_handlers.ghul` – implements individual requests such as `HOVER`, `DEFINITION` and `ANALYSE`. Each handler reads any additional arguments from the input stream and writes a response terminated by a form feed character (\f).
-- `watchdog.ghul` – tracks operation counts and can signal when the analyser should restart to recover from desynchronised input.
+- `watchdog.ghul` – decides when the analyser should recycle: on a sustained burst of handler exceptions, or on managed-heap growth past a threshold. The heap is sampled on an explicit `#HEAPCHECK#` request (the IDE sends one during a lull in editing) and, as a fallback, periodically after compiles.
 
 Requests are written by the IDE as `#COMMAND#` followed by newline separated arguments. The compiler responds with a header line naming the command, optional result lines and finally a form feed character. The protocol is intentionally minimal but stable; if you extend it keep messages textual so older clients can ignore unknown lines.

--- a/src/analysis/analyser.ghul
+++ b/src/analysis/analyser.ghul
@@ -69,6 +69,7 @@ namespace Analysis is
             let implementation_handler = IMPLEMENTATION_HANDLER(watchdog, symbol_use_locations, full_compiler);
             let rename_request_handler = RENAME_REQUEST_HANDLER(watchdog, symbol_use_locations, full_compiler);
             let restart_handler = RESTART_HANDLER(watchdog);
+            let heap_check_handler = HEAP_CHECK_HANDLER(watchdog);
             let format_handler = FORMAT_HANDLER(compiler, build_flags);
             let format_range_handler = FORMATRANGE_HANDLER(compiler, build_flags);
 
@@ -118,6 +119,10 @@ namespace Analysis is
 
             _despatcher.add_handler(
                 "RESTART", restart_handler
+            );
+
+            _despatcher.add_handler(
+                "HEAPCHECK", heap_check_handler
             );
 
             _despatcher.add_handler(

--- a/src/analysis/command_handlers.ghul
+++ b/src/analysis/command_handlers.ghul
@@ -1004,6 +1004,29 @@ namespace Analysis is
         si
     si
 
+    // Handles #HEAPCHECK#: an explicit request to sample the heap. The VS Code
+    // extension sends one during a lull in editing, so the watchdog's forced
+    // GC lands outside the latency path of an interactive request rather than
+    // after every compile.
+    class HEAP_CHECK_HANDLER: CommandHandler is
+        _watchdog: WATCHDOG;
+
+        init(watchdog: WATCHDOG) is
+            _watchdog = watchdog;
+        si
+
+        handle(reader: IO.TextReader, writer: IO.TextWriter) is
+            // If the heap has grown past the recycle thresholds, check_heap
+            // writes a RESTART frame and exits; otherwise we ack so the
+            // client's request/response loop completes.
+            _watchdog.check_heap_on_request(writer);
+
+            writer.write_line("HEAPCHECK");
+            writer.write("{cast char(12)}");
+            writer.flush();
+        si
+    si
+
     // Reformats a single file. The request frame is the file path followed
     // by the buffer contents (form-feed terminated); the buffer is parsed
     // fresh — no symbol table, no dependence on prior EDIT state — and the

--- a/src/analysis/watchdog.ghul
+++ b/src/analysis/watchdog.ghul
@@ -31,6 +31,12 @@ namespace Analysis is
         // How often to echo a heap reading to the log (every Nth full compile).
         heap_log_interval: int static => 32;
 
+        // Once the baseline is fixed, the heap is sampled only every Nth full
+        // compile, not after every one — check_heap forces a full GC, too
+        // costly to run that often. Warm-up compiles (before the baseline is
+        // fixed) are always sampled: the baseline is their high-water reading.
+        heap_check_interval: int static => 32;
+
         // Full compiles to let pass before the baseline is fixed. The analyser's
         // working set climbs over the first compiles as the JIT and caches fill
         // — growth that is not a leak — so anchoring the baseline to the cold
@@ -49,6 +55,7 @@ namespace Analysis is
         _warm_up_peak_heap_bytes: long;
         _full_compile_pending: bool;
         _compile_count: int;
+        _compiles_since_heap_check: int;
 
         want_restart: bool;
 
@@ -70,6 +77,7 @@ namespace Analysis is
         note_full_compile() is
             _full_compile_pending = true;
             _compile_count = _compile_count + 1;
+            _compiles_since_heap_check = _compiles_since_heap_check + 1;
         si
 
         // Called by the despatcher after every command, once the handler has
@@ -87,13 +95,41 @@ namespace Analysis is
             if _full_compile_pending then
                 _full_compile_pending = false;
 
-                if !heap_check_disabled then
+                if !heap_check_disabled /\ should_check_heap() then
                     check_heap(writer);
                 fi
             fi
         si
 
+        // Whether the every-Nth-compile fallback should sample the heap now.
+        // Always during warm-up (the baseline needs every reading); afterwards
+        // once heap_check_interval compiles have passed since the last sample.
+        // An explicit #HEAPCHECK# resets that count (note_heap_sampled), so a
+        // recent IDE-driven check suppresses a redundant fallback sample.
+        should_check_heap() -> bool =>
+            !_have_baseline \/ _compiles_since_heap_check >= heap_check_interval;
+
+        // Record that the heap was just sampled — restarts the fallback
+        // interval. Called whenever check_heap runs, so both an explicit
+        // #HEAPCHECK# and a fallback sample reset it.
+        note_heap_sampled() is
+            _compiles_since_heap_check = 0;
+        si
+
+        // Sample the heap in response to an explicit IDE request — the VS Code
+        // extension sends one during a lull in editing, so the forced GC lands
+        // outside the latency path of an interactive request. The every-Nth-
+        // compile path above stays as a fallback for clients that never send
+        // it. Respects --no-analysis-heap-watchdog.
+        check_heap_on_request(writer: IO.TextWriter) is
+            if !heap_check_disabled then
+                check_heap(writer);
+            fi
+        si
+
         check_heap(writer: IO.TextWriter) is
+            note_heap_sampled();
+
             let heap = System.GC.get_total_memory(true);
 
             note_heap(heap);

--- a/src/semantic/symbols/function.ghul
+++ b/src/semantic/symbols/function.ghul
@@ -322,7 +322,9 @@ namespace Semantic.Symbols is
                 result.unspecialized_return_type = return_type;
             fi
             
-            let ra = Collections.LIST[Type](arguments);
+            // Pre-sized empty, filled by add: a LIST(arguments) copy would
+            // duplicate every element only for the loop to replace them.
+            let ra = Collections.LIST[Type](arguments.count);
 
             result.arguments = ra;
 
@@ -330,7 +332,9 @@ namespace Semantic.Symbols is
                 let a = arguments[i];
 
                 if a? then
-                    ra[i] = arguments[i].specialize(type_map);
+                    ra.add(a.specialize(type_map));
+                else
+                    ra.add(a);
                 fi
             od
 

--- a/src/semantic/symbols/function_group.ghul
+++ b/src/semantic/symbols/function_group.ghul
@@ -45,10 +45,12 @@ namespace Semantic.Symbols is
                 result
             );
 
-            result._functions = Collections.LIST[Function](_functions);
+            // Pre-sized empty, filled by add: a LIST(_functions) copy would
+            // duplicate every element only for the loop to overwrite them all.
+            result._functions = Collections.LIST[Function](_functions.count);
 
             for i in 0.._functions.count do
-                result._functions[i] = _functions[i].specialize_function(type_map, owner);
+                result._functions.add(_functions[i].specialize_function(type_map, owner));
             od
 
             return result;

--- a/unit-tests/src/analysis/watchdog_tests.ghul
+++ b/unit-tests/src/analysis/watchdog_tests.ghul
@@ -136,5 +136,72 @@ namespace Analysis.UnitTests is
             // 900 MB: 600 MB above the baseline and over 2x.
             assert watchdog.is_heap_over_limit(mb(900));
         si
+
+        given_a_new_watchdog__should_check_heap__is_true() is
+            @test()
+
+            let watchdog = WATCHDOG();
+
+            // No baseline fixed yet: every warm-up compile must be sampled so
+            // the baseline can be the high-water reading across the window.
+            assert watchdog.should_check_heap();
+        si
+
+        given_the_baseline_is_fixed__should_check_heap__is_false_off_the_interval() is
+            @test()
+
+            let watchdog = WATCHDOG();
+
+            // Warm-up fixes the baseline.
+            for i in 0..WATCHDOG.warm_up_compiles do
+                complete_compile(watchdog, mb(300));
+            od
+
+            // One more compile — fewer than heap_check_interval compiles
+            // since the last sample, so this compile is not sampled.
+            watchdog.note_full_compile();
+
+            assert !watchdog.should_check_heap();
+        si
+
+        given_the_baseline_is_fixed__should_check_heap__is_true_on_the_interval() is
+            @test()
+
+            let watchdog = WATCHDOG();
+
+            for i in 0..WATCHDOG.warm_up_compiles do
+                complete_compile(watchdog, mb(300));
+            od
+
+            // Advance to heap_check_interval compiles since the last sample.
+            for i in WATCHDOG.warm_up_compiles..WATCHDOG.heap_check_interval do
+                watchdog.note_full_compile();
+            od
+
+            assert watchdog.should_check_heap();
+        si
+
+        given_the_heap_was_just_sampled__should_check_heap__resets() is
+            @test()
+
+            let watchdog = WATCHDOG();
+
+            for i in 0..WATCHDOG.warm_up_compiles do
+                complete_compile(watchdog, mb(300));
+            od
+
+            // Drive past the interval — the fallback would now sample.
+            for i in 0..WATCHDOG.heap_check_interval do
+                watchdog.note_full_compile();
+            od
+
+            assert watchdog.should_check_heap();
+
+            // An explicit #HEAPCHECK# (or a fallback sample) restarts the
+            // count, so the next fallback is a full interval away.
+            watchdog.note_heap_sampled();
+
+            assert !watchdog.should_check_heap();
+        si
     si
 si


### PR DESCRIPTION
Supersedes #1332 and #1334 (folded in here).

Technical:

- The analysis-mode heap watchdog forced a full GC (`GC.get_total_memory(true)`) after **every** compile to sample the managed heap — profiling measured that at ~37% of analyser CPU (the forced collection plus the `ArrayPool<char>.Trim` callback each Gen2 collection triggers), and ~200 ms added to common-case interactive latency. It now samples:
  - on an explicit `#HEAPCHECK#` request — a new analysis-mode command the IDE sends during a lull in editing, so the forced GC stays off the latency path of interactive requests;
  - and, as a fallback for any client that does not send it, every 32nd compile once the baseline is fixed.
  An explicit check resets the fallback interval. Warm-up still samples every compile, and the recycle thresholds are unchanged.
- `specialize_function` / `specialize_function_group` built their specialized argument / function lists with `LIST(source)` — which copies every element — then immediately overwrote all of them; they now construct the list pre-sized and empty and fill it by `add`.

The matching ghul-vsce change (an idle timer that sends `#HEAPCHECK#`) is a separate PR. Follows #1330 (`--no-analysis-heap-watchdog`) and #1331 (stdin buffering), both merged.