### PR TITLE
Enlarge the speculative-lookahead token queue

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.12.29",
+      "version": "0.12.30",
       "commands": [
         "ghul-compiler"
       ],

--- a/src/compiler/compiler.ghul
+++ b/src/compiler/compiler.ghul
@@ -176,7 +176,12 @@ namespace Compiler is
                 is_internal_file
             );
 
-            let token_queue = Lexical.TOKEN_QUEUE(512);
+            // Speculative-lookahead ring buffer; a power of 2 (the
+            // queue masks indices with `size - 1`), sized generously so
+            // deep-but-finite speculation does not overflow it. A true
+            // speculation loop is caught separately by the tokenizer's
+            // backtrack-loop detector.
+            let token_queue = Lexical.TOKEN_QUEUE(2048);
 
             let token_lookahead = Lexical.TOKEN_LOOKAHEAD(
                 token_queue,


### PR DESCRIPTION
Technical:

- The parser's speculative-lookahead ring buffer was sized 512 token
  pairs — small enough that a valid but deeply-speculative construct
  could overflow it, producing a hard `token queue overflow`. Enlarged
  to 2048; it is a power-of-2 ring buffer and the extra entries cost
  negligible memory. A genuine speculation loop is still caught
  separately by the tokenizer's backtrack-loop detector.