### PR TITLE
Add edit-classification skip-rate telemetry

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.12.31",
+      "version": "0.12.32",
       "commands": [
         "ghul-compiler"
       ],

--- a/analysis-profiler/src/workload.ghul
+++ b/analysis-profiler/src/workload.ghul
@@ -36,19 +36,52 @@ namespace Analysis.Profiler is
         stats: STATS => _stats;
 
         execute() is
+            let started = System.DateTime.now;
+
             _log("cold initial EDIT — {_corpus.file_count} files, {_corpus.total_lines} lines");
             _cold_edit();
 
             _log("cold whole-project COMPILE");
             _cold_compile();
 
-            _log("single-file EDIT bursts (typing simulation)");
-            _typing();
+            // PROFILE_MIN_SECONDS keeps the steady-state EDIT/query phases
+            // looping until that many seconds have elapsed, so the analyser's
+            // 60s periodic per-pass TIMERS dump has time to fire. Unset (the
+            // default) runs each phase once.
+            let min_seconds = _min_seconds();
+            let pass mut = 0;
 
-            _log("interactive queries — HOVER / DEFINITION / COMPLETE / SIGNATURE");
-            _queries();
+            do
+                pass = pass + 1;
+
+                _log("single-file EDIT bursts (typing simulation) — pass {pass}");
+                _typing();
+
+                _log("interactive queries — HOVER / DEFINITION / COMPLETE / SIGNATURE — pass {pass}");
+                _queries();
+
+                if System.DateTime.now.subtract(started).total_seconds >= min_seconds then
+                    break;
+                fi
+            od
 
             _log("workload complete");
+        si
+
+        _min_seconds() -> double static is
+            let raw = System.Environment.get_environment_variable("PROFILE_MIN_SECONDS");
+
+            if string.is_null_or_white_space(raw) then
+                return 0.0D;
+            fi
+
+            let result mut = 0.0D;
+
+            if double.try_parse(raw, result ref) then
+                return result;
+            fi
+
+            return 0.0D;
         si
 
         _cold_edit() is

--- a/src/analysis/command_handlers.ghul
+++ b/src/analysis/command_handlers.ghul
@@ -387,6 +387,19 @@ namespace Analysis is
                 debug_always("PARSE caught: {ex.get_type()} {ex.message}");
             yrt
 
+            // Classify this EDIT for the stats dump: interface-preserving (a
+            // following COMPILE can be skipped) vs interface-affecting.
+            let edit_class_timer =
+                if _is_interface_changed then
+                    "edit-interface-affecting"
+                else
+                    "edit-interface-preserving"
+                fi;
+
+            if want_timer then
+                _timers.start(edit_class_timer);
+            fi
+
             try
                 writer.write_line("DIAGNOSTICS");
 
@@ -419,6 +432,7 @@ namespace Analysis is
 
                 if want_timer then
                     _timers.finish("edit-single");
+                    _timers.finish(edit_class_timer);
                 fi
 
                 let compile_needed =
@@ -470,8 +484,17 @@ namespace Analysis is
                     writer.write_line("DIAGNOSTICS");
 
                     if !_compiler.is_full_compile_needed then
+                        // No interface-affecting edit pending — the rebuild is
+                        // skipped. Timed under `compile-skipped` so the
+                        // skipped-vs-run split shows in the stats dump.
+                        _timers.start("compile-skipped");
+
                         IoC.CONTAINER.instance.logger.write_all_diagnostics(writer, IoC.CONTAINER.instance.logger_formatter);
+
+                        _timers.finish("compile-skipped");
                     else
+                        _timers.start("compile-run");
+
                         Semantic.Types.NAMED.clear_cache();
 
                         for i in _source_files do
@@ -499,6 +522,8 @@ namespace Analysis is
                         _watchdog.note_full_compile();
 
                         _compiler.is_full_compile_needed = false;
+
+                        _timers.finish("compile-run");
                     fi
                 fi
 


### PR DESCRIPTION
Technical:

- The analyser counts and times two classifications in the `--show-analysis-stats` dump: each single-file EDIT as interface-preserving or interface-affecting, and each COMPILE as skipped or run. This measures how often the debounced whole-project COMPILE is skipped in real editing, and the time saved.
- `analysis-profiler` honours a `PROFILE_MIN_SECONDS` environment variable that loops the steady-state workload until that many seconds have elapsed, so the analyser's 60-second periodic stats dump fires during a profiling run.