### PR TITLE
Provide signature help for calls of function-typed values

### DIFF
--- a/analysis-tests/fixtures/lambda-signature/main.ghul
+++ b/analysis-tests/fixtures/lambda-signature/main.ghul
@@ -1,0 +1,16 @@
+namespace LambdaSignature is
+    apply(transform: (int) -> int, value: int) -> int => transform(value);
+
+    run(act: (int) -> void, value: int) is
+        act(value);
+    si
+
+    combine(pick: (int, string) -> bool, value: int) -> bool => pick(value, "x");
+
+    entry() is
+        let direct = apply(n => n + 1, 10);
+        let stored = (n: int) -> int => n * 2;
+        let viavar = stored(7);
+        let inline = ((n: int) -> int => n + 1)(3);
+    si
+si

--- a/analysis-tests/src/tests/lambda_signature_tests.ghul
+++ b/analysis-tests/src/tests/lambda_signature_tests.ghul
@@ -1,0 +1,143 @@
+namespace Analysis.Tests is
+    use Collections.LIST;
+
+    use IO.File;
+    use IO.Path;
+
+    use Analysis.Protocol.ANALYSER_PROCESS;
+    use Analysis.Protocol.EDIT_FILE;
+    use Analysis.Protocol.RESPONSE;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    // SIGNATURE coverage for callees that are anonymous functions: a
+    // let-bound lambda, a function-typed parameter, an inline-invoked
+    // lambda. These resolve to a value of function type rather than to
+    // a FUNCTION_GROUP symbol, so signature help is derived from the
+    // function type. The named-function case is kept as a regression
+    // guard that the function-group path still works.
+    //
+    // The wire frame is: best-signature-index, current-parameter-index,
+    // then one tab-separated line per overload (label, then a field per
+    // parameter) — see SIGNATURE_HANDLER and response-handler.ts.
+    class LAMBDA_SIGNATURE_TESTS is
+        @test()
+
+        init() is si
+
+        load() -> string is
+            let path = Path.combine(fixture_dir("lambda-signature"), "main.ghul");
+            assert File.exists(path) else "fixture missing: {path}";
+            return File.read_all_text(path);
+        si
+
+        prime(analyser: ANALYSER_PROCESS, source: string) is
+            analyser.send_edit_files([EDIT_FILE("main.ghul", source)]);
+            analyser.read_response();
+            analyser.read_response();
+            analyser.send_edit("main.ghul", source);
+            analyser.read_response();
+            analyser.read_response();
+        si
+
+        // Query SIGNATURE at a position and return the body lines.
+        signature_at(analyser: ANALYSER_PROCESS, line: int, column: int) -> LIST[string] is
+            analyser.send_signature("main.ghul", line, column);
+
+            let response = analyser.read_query_response();
+            Assert.are_equal("SIGNATURE", response.header);
+
+            return LIST[string](response.lines);
+        si
+
+        named_function_with_lambda_argument_shows_function_group_signature() is
+            @test()
+
+            let use analyser = ANALYSER_PROCESS();
+            prime(analyser, load());
+
+            // inside the lambda argument of `apply(n => n + 1, 10)`
+            let inside_lambda = signature_at(analyser, 11, 28);
+            Assert.is_true(inside_lambda.count >= 3, "no signature returned: {inside_lambda.count} lines");
+            Assert.is_true(
+                inside_lambda[2].starts_with("apply("),
+                "expected apply(...) signature, got: {inside_lambda[2]}"
+            );
+            Assert.are_equal("0", inside_lambda[1], "expected current parameter 0");
+
+            // at the second argument `10`
+            let second_argument = signature_at(analyser, 11, 40);
+            Assert.are_equal("1", second_argument[1], "expected current parameter 1");
+        si
+
+        call_of_let_bound_lambda_shows_function_type_signature() is
+            @test()
+
+            let use analyser = ANALYSER_PROCESS();
+            prime(analyser, load());
+
+            // `stored(7)` — stored is a local bound to `(n: int) -> int => n * 2`
+            let lines = signature_at(analyser, 13, 29);
+
+            Assert.is_true(lines.count >= 3, "no signature returned: {lines.count} lines");
+
+            let fields = LIST[string](lines[2].split(['\t']));
+            Assert.are_equal("(int) -> int", fields[0]);
+            Assert.are_equal(2, fields.count, "expected one parameter field");
+            Assert.are_equal("int", fields[1]);
+        si
+
+        call_of_function_typed_parameter_shows_function_type_signature() is
+            @test()
+
+            let use analyser = ANALYSER_PROCESS();
+            prime(analyser, load());
+
+            // `act(value)` inside run() — act is a parameter of type (int) -> void
+            let lines = signature_at(analyser, 5, 13);
+
+            Assert.is_true(lines.count >= 3, "no signature returned: {lines.count} lines");
+
+            let fields = LIST[string](lines[2].split(['\t']));
+            Assert.are_equal("(int) -> void", fields[0]);
+            Assert.are_equal("int", fields[1]);
+        si
+
+        call_of_multi_argument_function_value_tracks_parameter() is
+            @test()
+
+            let use analyser = ANALYSER_PROCESS();
+            prime(analyser, load());
+
+            // `pick(value, "x")` — pick is a parameter of type (int, string) -> bool
+            let first = signature_at(analyser, 8, 70);
+            Assert.is_true(first.count >= 3, "no signature returned: {first.count} lines");
+
+            let fields = LIST[string](first[2].split(['\t']));
+            Assert.are_equal("(int, string) -> bool", fields[0]);
+            Assert.are_equal("int", fields[1]);
+            Assert.are_equal("string", fields[2]);
+            Assert.are_equal("0", first[1], "expected current parameter 0");
+
+            // at the second argument `"x"`
+            let second = signature_at(analyser, 8, 77);
+            Assert.are_equal("1", second[1], "expected current parameter 1");
+        si
+
+        inline_invoked_anonymous_function_shows_function_type_signature() is
+            @test()
+
+            let use analyser = ANALYSER_PROCESS();
+            prime(analyser, load());
+
+            // `((n: int) -> int => n + 1)(3)` — the callee is the lambda itself
+            let lines = signature_at(analyser, 14, 49);
+
+            Assert.is_true(lines.count >= 3, "no signature returned: {lines.count} lines");
+
+            let fields = LIST[string](lines[2].split(['\t']));
+            Assert.are_equal("(int) -> int", fields[0]);
+            Assert.are_equal("int", fields[1]);
+        si
+    si
+si

--- a/src/analysis/command_handlers.ghul
+++ b/src/analysis/command_handlers.ghul
@@ -641,20 +641,18 @@ namespace Analysis is
                     writer.write_line("SIGNATURE");
                     written_header = true;
 
-                    let results = find_signatures(path, target_line, target_column);                    
+                    let results = find_signatures(path, target_line, target_column);
 
                     if results? then
-                        writer.write_line("{results.best_result_index}");
+                        writer.write_line("{results.best_signature_index}");
                         writer.write_line("{results.current_parameter_index}");
 
-                        for symbol in results.results do
-                            if !symbol? then
+                        for signature in results.signatures do
+                            if !signature? then
                                 continue;
                             fi
 
-                            let line = get_function_doc_for(symbol);
-
-                            writer.write_line(line);
+                            writer.write_line(format_signature(signature));
                         od
                     fi
                 fi
@@ -674,22 +672,23 @@ namespace Analysis is
             writer.flush();
         si
 
-        get_function_doc_for(function: Semantic.Symbols.Function) -> string is
+        // One wire line per overload: the label, then a tab-separated
+        // field per parameter. Mirrors response-handler.ts handleSignature.
+        format_signature(signature: Syntax.Process.SIGNATURE) -> string is
             let result = System.Text.StringBuilder();
 
-            result
-                .append(function.short_description);
+            result.append(signature.description);
 
-            for i in 0..function.arguments.count do
+            for parameter_description in signature.parameter_descriptions do
                 result
                     .append('\t')
-                    .append(function.get_short_argument_description(i));
+                    .append(parameter_description);
             od
 
             return result.to_string();
         si
 
-        find_signatures(path: string, target_line: int, target_column: int) -> Semantic.OVERLOAD_MATCHES_RESULT is
+        find_signatures(path: string, target_line: int, target_column: int) -> Syntax.Process.SIGNATURE_HELP_RESULT? is
             let i = _source_file_lookup.find_source_file(path);
 
             return _signature_help.find_signatures(i.definition, target_line, target_column);

--- a/src/syntax/process/signature_help.ghul
+++ b/src/syntax/process/signature_help.ghul
@@ -1,9 +1,40 @@
 namespace Syntax.Process is
-        
+
     use Logging;
     use Source;
 
     use Semantic.Types.Type;
+
+    // One overload presented to the IDE's signature-help popup: a label
+    // for the whole call and a description per parameter. Built either
+    // from an overload-resolved FUNCTION_GROUP member or, when the callee
+    // is a value of function type (a let-bound lambda, a function-typed
+    // parameter, a directly-invoked anonymous function), from the
+    // function type itself.
+    class SIGNATURE is
+        description: string public;
+        parameter_descriptions: Collections.List[string] public;
+
+        init(description: string, parameter_descriptions: Collections.List[string]) is
+            self.description = description;
+            self.parameter_descriptions = parameter_descriptions;
+        si
+    si
+
+    class SIGNATURE_HELP_RESULT is
+        signatures: Collections.List[SIGNATURE] public;
+        best_signature_index: int public;
+        current_parameter_index: int public;
+
+        init(
+            signatures: Collections.List[SIGNATURE],
+            best_signature_index: int
+        ) is
+            self.signatures = signatures;
+            self.best_signature_index = best_signature_index;
+            self.current_parameter_index = 0;
+        si
+    si
 
     class SIGNATURE_HELP: ScopedVisitor is
         _overload_resolver: Semantic.OVERLOAD_RESOLVER;
@@ -11,7 +42,7 @@ namespace Syntax.Process is
         _target_line: int;
         _target_column: int;
 
-        _results: Semantic.OVERLOAD_MATCHES_RESULT?;
+        _results: SIGNATURE_HELP_RESULT?;
 
         init(
             logger: Logger,
@@ -25,7 +56,7 @@ namespace Syntax.Process is
             _overload_resolver = overload_resolver;
         si
 
-        find_signatures(root: Trees.Node, target_line: int, target_column: int) -> Semantic.OVERLOAD_MATCHES_RESULT? is
+        find_signatures(root: Trees.Node, target_line: int, target_column: int) -> SIGNATURE_HELP_RESULT? is
             _results = null;
 
             _target_line = target_line;
@@ -48,7 +79,7 @@ namespace Syntax.Process is
                 then
                     return;
                 fi
-                
+
                 _results = help_for(call);
 
                 if _results? then
@@ -75,9 +106,9 @@ namespace Syntax.Process is
                 then
                     return;
                 fi
-                
+
                 _results = help_for(`new);
-                
+
                 if _results? then
                     _results.current_parameter_index = get_current_parameter_index(`new.location, Collections.LIST[Trees.Expressions.Expression](`new.arguments));
                 fi
@@ -127,44 +158,32 @@ namespace Syntax.Process is
 
             return 0;
         si
-        
-        help_for(call: Trees.Expressions.CALL) -> Semantic.OVERLOAD_MATCHES_RESULT? is
+
+        help_for(call: Trees.Expressions.CALL) -> SIGNATURE_HELP_RESULT? is
             if _results? then
                 return null;
             fi
 
-            let load = cast IR.Values.Load.SYMBOL(call.function.value);
+            let callee = call.function.value;
 
-            if !load? then
+            if !callee? then
                 return null;
             fi
 
-            let function_group = cast Semantic.Symbols.FUNCTION_GROUP(load.symbol);
+            let function_group = function_group_of(callee);
 
-            if !function_group? then
-                return null;
+            if function_group? then
+                return help_for_function_group(function_group, argument_types_of(call.arguments));
             fi
 
-            let argument_types = Collections.LIST[Type]();
-
-            for a in call.arguments do                
-                if a? /\ a.value? /\ a.value.type? then
-                    argument_types.add(a.value.type);                    
-                else
-                    argument_types.add(Semantic.Types.ERROR());
-                fi
-            od
-
-            let overload_results = _overload_resolver.find_matches(function_group, argument_types);
-
-            if overload_results!.results.count == 0 then
-                return null;
+            if callee.has_type /\ callee.type? /\ callee.type.is_function then
+                return help_for_function_type(callee.type);
             fi
 
-            return overload_results;
+            return null;
         si
 
-        help_for(`new: Trees.Expressions.NEW) -> Semantic.OVERLOAD_MATCHES_RESULT? is
+        help_for(`new: Trees.Expressions.NEW) -> SIGNATURE_HELP_RESULT? is
             if _results? then
                 return null;
             fi
@@ -181,25 +200,112 @@ namespace Syntax.Process is
                 return null;
             fi
 
-            let function_group = cast Semantic.Symbols.FUNCTION_GROUP(symbol);
+            return help_for_function_group(
+                cast Semantic.Symbols.FUNCTION_GROUP(symbol),
+                argument_types_of(`new.arguments)
+            );
+        si
 
+        // The callee's IR value resolves to a named function only when
+        // it is a direct load of a FUNCTION_GROUP symbol. A load of a
+        // variable / parameter / field of function type does not — its
+        // signature comes from the function type instead.
+        function_group_of(callee: IR.Values.Value) -> Semantic.Symbols.FUNCTION_GROUP? is
+            let load = cast IR.Values.Load.SYMBOL(callee);
+
+            if !load? then
+                return null;
+            fi
+
+            return cast Semantic.Symbols.FUNCTION_GROUP(load.symbol);
+        si
+
+        argument_types_of(arguments: Trees.Expressions.LIST) -> Collections.LIST[Type] is
             let argument_types = Collections.LIST[Type]();
 
-            for a in `new.arguments do
+            for a in arguments do
                 if a? /\ a.value? /\ a.value.type? then
-                    argument_types.add(a.value.type);                    
+                    argument_types.add(a.value.type);
                 else
                     argument_types.add(Semantic.Types.ERROR());
                 fi
             od
 
+            return argument_types;
+        si
+
+        help_for_function_group(
+            function_group: Semantic.Symbols.FUNCTION_GROUP,
+            argument_types: Collections.LIST[Type]
+        ) -> SIGNATURE_HELP_RESULT? is
             let overload_results = _overload_resolver.find_matches(function_group, argument_types);
 
-            if overload_results!.results.count == 0 then
+            if !overload_results? \/ overload_results.results.count == 0 then
                 return null;
             fi
 
-            return overload_results;
-        si                
+            let signatures = Collections.LIST[SIGNATURE]();
+
+            for f in overload_results.results do
+                signatures.add(signature_for_function(f));
+            od
+
+            return SIGNATURE_HELP_RESULT(signatures, overload_results.best_result_index);
+        si
+
+        signature_for_function(function: Semantic.Symbols.Function) -> SIGNATURE is
+            let parameter_descriptions = Collections.LIST[string]();
+
+            for i in 0..function.arguments.count do
+                parameter_descriptions.add(function.get_short_argument_description(i));
+            od
+
+            return SIGNATURE(function.short_description, parameter_descriptions);
+        si
+
+        // Signature for a callee whose type is a function type. Function
+        // types carry no parameter names, so the label and parameter
+        // descriptions are the formal types alone: `(int, string) -> bool`.
+        help_for_function_type(function_type: Type) -> SIGNATURE_HELP_RESULT? is
+            let arguments = function_type.arguments;
+
+            if !arguments? then
+                return null;
+            fi
+
+            let formal_count =
+                if function_type.is_action then
+                    arguments.count;
+                else
+                    arguments.count - 1;
+                fi;
+
+            if formal_count < 0 then
+                return null;
+            fi
+
+            let parameter_descriptions = Collections.LIST[string]();
+
+            for i in 0..formal_count do
+                parameter_descriptions.add(arguments[i].short_description);
+            od
+
+            let label = System.Text.StringBuilder();
+
+            label.append('(');
+            parameter_descriptions | .append_to(label, ", ");
+            label.append(") -> ");
+
+            if function_type.is_action then
+                label.append("void");
+            else
+                label.append(arguments[arguments.count - 1].short_description);
+            fi
+
+            return SIGNATURE_HELP_RESULT(
+                Collections.LIST[SIGNATURE]([SIGNATURE(label.to_string(), parameter_descriptions)]),
+                0
+            );
+        si
     si
 si


### PR DESCRIPTION
Bugs fixed:

- Signature help (the IDE parameter popup) returned nothing when the callee was an anonymous function — a let-bound lambda, a function-typed parameter, or a directly-invoked lambda. Only calls of a named function group were handled; a callee whose IR value is a load of a variable / parameter / field of function type produced an empty SIGNATURE frame. Such calls now yield a type-derived signature (`(int, string) -> bool`, a field per formal type).