### PR TITLE
Add #HOVERMAP# analyser command

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "0.12.37",
+      "version": "1.0.0",
       "commands": [
         "ghul-compiler"
       ],

--- a/analysis-protocol/src/analyser_process.ghul
+++ b/analysis-protocol/src/analyser_process.ghul
@@ -422,6 +422,16 @@ namespace Analysis.Protocol is
             flush();
         si
 
+        // Send `#HOVERMAP#` for a single file — the batch counterpart to
+        // #HOVER#. The analyser answers with a HOVERMAP frame: one
+        // tab-separated `startLine startColumn endLine endColumn description`
+        // row per recorded hover range. Drive an EDIT (and/or COMPILE) first.
+        send_hover_map(path: string) is
+            write("#HOVERMAP#\n");
+            write("{path}\n");
+            flush();
+        si
+
         send_definition(path: string, line: int, column: int) is
             write("#DEFINITION#\n");
             write("{path}\n");

--- a/analysis-tests/src/tests/hover_map_tests.ghul
+++ b/analysis-tests/src/tests/hover_map_tests.ghul
@@ -1,0 +1,144 @@
+namespace Analysis.Tests is
+    use Collections.LIST;
+
+    use IO.File;
+
+    use Analysis.Protocol.ANALYSER_PROCESS;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    // #HOVERMAP# dumps every recorded hover for a file in one frame:
+    // tab-separated `startLine  startColumn  endLine  endColumn  description`
+    // rows. It is the batch counterpart to position-by-position #HOVER#,
+    // built for the ghul.dev example pipeline. These tests drive an EDIT
+    // over the inference-hover fixture, then assert the dump's framing and
+    // that it carries resolved type information.
+    class HOVER_MAP_TESTS is
+        @test()
+
+        init() is si
+
+        load_fixture() -> string is
+            let path = fixture_path("inference-hover/inference-hover.ghul");
+
+            assert File.exists(path) else "fixture missing: {path}";
+
+            return File.read_all_text(path);
+        si
+
+        prime(analyser: ANALYSER_PROCESS, source: string) is
+            analyser.send_edit("inference-hover.ghul", source);
+
+            let diagnostics = analyser.read_response();
+            Assert.are_equal("DIAGNOSTICS", diagnostics.header);
+
+            let user_diagnostics = LIST(diagnostics.user_diagnostics);
+            Assert.are_equal(
+                0,
+                user_diagnostics.count,
+                diagnostics_summary("EDIT had unexpected diagnostics", user_diagnostics)
+            );
+
+            let partial_done = analyser.read_response();
+            Assert.are_equal("PARTIAL DONE", partial_done.header);
+        si
+
+        hover_map_rows(analyser: ANALYSER_PROCESS) -> LIST[string] is
+            analyser.send_hover_map("inference-hover.ghul");
+
+            let response = analyser.read_query_response();
+            Assert.are_equal("HOVERMAP", response.header);
+
+            return LIST[string](response.lines);
+        si
+
+        // The dump arrives as a HOVERMAP frame carrying many rows for a
+        // non-trivial file.
+        hover_map_returns_rows_for_file() is
+            @test()
+
+            let source = load_fixture();
+            let use analyser = ANALYSER_PROCESS();
+            prime(analyser, source);
+
+            let rows = hover_map_rows(analyser);
+
+            Assert.is_true(
+                rows.count > 0,
+                "HOVERMAP returned no rows\n--- analyser stderr ---\n{analyser.stderr_capture}"
+            );
+        si
+
+        // Every row is `startLine startColumn endLine endColumn description`
+        // — four non-negative integer coordinates then a description.
+        hover_map_rows_are_well_formed() is
+            @test()
+
+            let source = load_fixture();
+            let use analyser = ANALYSER_PROCESS();
+            prime(analyser, source);
+
+            let rows = hover_map_rows(analyser);
+
+            for row in rows do
+                let fields = LIST[string](row.split(['\t']));
+
+                Assert.are_equal(
+                    5,
+                    fields.count,
+                    "expected 5 tab-separated fields, got {fields.count}: '{row}'"
+                );
+
+                for i in 0..4 do
+                    let coordinate = System.Convert.to_int32(fields[i]);
+                    Assert.is_true(
+                        coordinate >= 0,
+                        "coordinate field {i} not a non-negative integer: '{row}'"
+                    );
+                od
+            od
+        si
+
+        // The dump carries resolved type information — inference-hover
+        // declares `let b = BOX(42)`, whose hover resolves to `BOX[Ghul.int]`.
+        hover_map_carries_resolved_types() is
+            @test()
+
+            let source = load_fixture();
+            let use analyser = ANALYSER_PROCESS();
+            prime(analyser, source);
+
+            let rows = hover_map_rows(analyser);
+
+            Assert.is_true(
+                rows | .any(row => row.contains("BOX[Ghul.int]")),
+                "HOVERMAP carried no `BOX[Ghul.int]` hover\n--- rows ---\n{rows | .to_string("\n")}\n--- analyser stderr ---\n{analyser.stderr_capture}"
+            );
+        si
+
+        // A call to an overloaded function records both the function
+        // group and the resolved member at the call-target's range. The
+        // dump must surface the resolved member — `write_line(value:
+        // string) -> void` — and never the bare `// function group`,
+        // matching what #HOVER# returns there.
+        hover_map_resolves_overloaded_calls() is
+            @test()
+
+            let source = load_fixture();
+            let use analyser = ANALYSER_PROCESS();
+            prime(analyser, source);
+
+            let rows = hover_map_rows(analyser);
+
+            Assert.is_true(
+                rows | .any(row => row.contains("write_line") /\ row.contains("-> Ghul.void")),
+                "HOVERMAP carried no resolved `write_line` overload\n--- rows ---\n{rows | .to_string("\n")}"
+            );
+
+            Assert.is_false(
+                rows | .any(row => row.contains("write_line") /\ row.contains("function group")),
+                "HOVERMAP carried `write_line` as an unresolved function group\n--- rows ---\n{rows | .to_string("\n")}"
+            );
+        si
+    si
+si

--- a/src/analysis/README.md
+++ b/src/analysis/README.md
@@ -10,3 +10,5 @@ The main components are:
 - `watchdog.ghul` – decides when the analyser should recycle: on a sustained burst of handler exceptions, or on managed-heap growth past a threshold. The heap is sampled on an explicit `#HEAPCHECK#` request (the IDE sends one during a lull in editing) and, as a fallback, periodically after compiles.
 
 Requests are written by the IDE as `#COMMAND#` followed by newline separated arguments. The compiler responds with a header line naming the command, optional result lines and finally a form feed character. The protocol is intentionally minimal but stable; if you extend it keep messages textual so older clients can ignore unknown lines.
+
+`#HOVERMAP#` is a batch variant of `#HOVER#`. Given a file path it dumps every recorded hover for that file as tab separated `startLine  startColumn  endLine  endColumn  description` rows — one row per source range — so a tool can collect a whole file's hovers in one frame instead of probing position by position. The caller is expected to have driven an `#EDIT#` (and/or `#COMPILE#`) first; unlike `#HOVER#` it never triggers a recompile of its own.

--- a/src/analysis/analyser.ghul
+++ b/src/analysis/analyser.ghul
@@ -60,6 +60,7 @@ namespace Analysis is
             let full_compiler: FULL_COMPILER = FULL_COMPILER(watchdog, compiler, file_edited_handler, timers);
 
             let hover_handler = HOVER_HANDLER(watchdog, timers, symbol_use_locations, full_compiler);
+            let hover_map_handler = HOVERMAP_HANDLER(watchdog, symbol_use_locations);
             let definition_handler = DEFINITION_HANDLER(watchdog, symbol_use_locations, full_compiler);
             let declaration_handler = DECLARATION_HANDLER(watchdog, symbol_use_locations, full_compiler);
             let completion_handler = COMPLETION_HANDLER(watchdog, completer, file_edited_handler, full_compiler);
@@ -83,6 +84,10 @@ namespace Analysis is
 
             _despatcher.add_handler(
                 "HOVER", hover_handler
+            );
+
+            _despatcher.add_handler(
+                "HOVERMAP", hover_map_handler
             );
 
             _despatcher.add_handler(

--- a/src/analysis/command_handlers.ghul
+++ b/src/analysis/command_handlers.ghul
@@ -72,6 +72,64 @@ namespace Analysis is
         si
     si
 
+    // Dumps every HOVER_USE recorded for one file as tab-separated rows:
+    //   startLine  startColumn  endLine  endColumn  description
+    // — one row per source range. Unlike #HOVER# it takes no position and
+    // never falls back to a recompile; the caller drives an EDIT (and/or
+    // COMPILE) first. It lets a batch consumer — the ghul.dev example
+    // pipeline — collect a file's hovers in one frame.
+    class HOVERMAP_HANDLER: CommandHandler is
+        _watchdog: WATCHDOG;
+        _symbol_use_locations: Semantic.SYMBOL_USE_LOCATIONS;
+
+        init(
+            watchdog: WATCHDOG,
+            symbol_use_locations: Semantic.SYMBOL_USE_LOCATIONS
+        )
+        is
+            _watchdog = watchdog;
+            _symbol_use_locations = symbol_use_locations;
+        si
+
+        handle(reader: IO.TextReader, writer: IO.TextWriter) is
+            IoC.CONTAINER.instance.want_tab_delimited_logger(writer);
+
+            let path = reader.read_line();
+
+            let written_header mut = false;
+
+            try
+                if !_watchdog.want_restart then
+                    writer.write_line("HOVERMAP");
+                    written_header = true;
+
+                    for entry in _symbol_use_locations.hover_uses_in_file(path) do
+                        let location = entry.location;
+
+                        writer.write_line(
+                            "{location.start_line}\t{location.start_column}\t"
+                            "{location.end_line}\t{location.end_column}\t"
+                            "{entry.value.description}"
+                        );
+                    od
+                fi
+            catch ex: Exception
+                debug_always("HOVERMAP caught: {ex.get_type()} {ex.message}");
+
+                _watchdog.request_restart();
+
+                if !written_header then
+                    writer.write_line("HOVERMAP");
+                fi
+            yrt
+
+            Std.error.flush();
+
+            writer.write("{cast char(12)}");
+            writer.flush();
+        si
+    si
+
     class DEFINITION_HANDLER: SymbolLocationHandler is
         _watchdog: WATCHDOG;
         _symbol_use_locations: Semantic.SYMBOL_USE_LOCATIONS;

--- a/src/semantic/symbol_use_locations.ghul
+++ b/src/semantic/symbol_use_locations.ghul
@@ -86,6 +86,35 @@ namespace Semantic is
             return best_match;
         si
 
+        // Every HOVER_USE recorded for one file, one per source range —
+        // powering #HOVERMAP#, a whole-file hover dump the ghul.dev
+        // example pipeline consumes offline instead of probing position
+        // by position with #HOVER#. Where several uses share a range (an
+        // overload group and the resolved member both record the
+        // call-target identifier) the resolved Function is preferred,
+        // mirroring find_hover_use so #HOVERMAP# and #HOVER# agree.
+        hover_uses_in_file(file_name: string) -> List[LOCATION_SEARCH_RESULT[HOVER_USE]] is
+            let best = Collections.MAP[LOCATION, HOVER_USE]();
+
+            for entry in _hover_info_map.file_entries(file_name) do
+                let current: HOVER_USE mut = default;
+
+                if !best.try_get_value(entry.location, current ref) then
+                    best[entry.location] = entry.value;
+                elif isa Symbols.Function(entry.value.symbol) then
+                    best[entry.location] = entry.value;
+                fi
+            od
+
+            let result = LIST[LOCATION_SEARCH_RESULT[HOVER_USE]]();
+
+            for kv in best do
+                result.add(LOCATION_SEARCH_RESULT[HOVER_USE](kv.key, kv.value));
+            od
+
+            return result;
+        si
+
         find_definition_from_use(file_name: string, line: int, column: int) -> Symbols.Symbol =>
             let matches = _symbol_use_map.find_all(file_name, line, column) in
             find_best_match(matches);
@@ -451,6 +480,33 @@ namespace Semantic is
             return result;
         si
         
+        // Every stored entry for one file. `put` records a multi-line
+        // location once per line it spans; each is yielded once, on its
+        // own start line. Several entries at the same location (e.g. an
+        // overload group and the resolved member) are all kept — the
+        // caller chooses between them.
+        file_entries(file_name: string) -> List[LOCATION_SEARCH_RESULT[T]] is
+            let result = LIST[LOCATION_SEARCH_RESULT[T]]();
+
+            let file = _get_file(file_name);
+
+            if !file? then
+                return result;
+            fi
+
+            for line_entry in file do
+                let line = line_entry.key;
+
+                for p in line_entry.value do
+                    if p.key.start_line == line then
+                        result.add(LOCATION_SEARCH_RESULT[T](p.key, p.value));
+                    fi
+                od
+            od
+
+            return result;
+        si
+
         _get_file(file_name: string) -> Collections.MAP[int, Collections.LIST[Pair[LOCATION,T]]]? =>
             if _file_name_to_file.contains_key(file_name) then
                 _file_name_to_file[file_name]


### PR DESCRIPTION
Technical:

- New `#HOVERMAP#` analysis-mode command — one tab-separated row per recorded hover in a file (start and end line/column, description), the batch counterpart to per-position `#HOVER#`.