### PR TITLE
Incremental body re-walk for interface-preserving analysis-mode edits

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "commands": [
         "ghul-compiler"
       ],

--- a/analysis-profiler/src/workload.ghul
+++ b/analysis-profiler/src/workload.ghul
@@ -15,8 +15,9 @@ namespace Analysis.Profiler is
     //  1. a cold whole-project EDIT (extension startup);
     //  2. a cold whole-project COMPILE;
     //  3. single-file EDIT bursts with a debounced COMPILE after each
-    //     (a typing session);
-    //  4. interactive HOVER / DEFINITION / COMPLETE / SIGNATURE queries.
+    //     (a typing session — interface-preserving edits);
+    //  4. interface-affecting single-file EDITs (each adds a declaration);
+    //  5. interactive HOVER / DEFINITION / COMPLETE / SIGNATURE queries.
     class PROFILE_RUN is
         _analyser: ANALYSER_PROCESS;
         _corpus: CORPUS;
@@ -56,6 +57,9 @@ namespace Analysis.Profiler is
 
                 _log("single-file EDIT bursts (typing simulation) — pass {pass}");
                 _typing();
+
+                _log("interface-affecting single-file EDITs — pass {pass}");
+                _interface_edits();
 
                 _log("interactive queries — HOVER / DEFINITION / COMPLETE / SIGNATURE — pass {pass}");
                 _queries();
@@ -139,6 +143,44 @@ namespace Analysis.Profiler is
                 let compile_done = _analyser.read_response();                   // FULL DONE
 
                 _stats["COMPILE — debounced (after edit burst)"].record(_elapsed_ms(compile_started));
+            od
+        si
+
+        // Interface-affecting single-file EDITs: each edit appends a new
+        // namespace-level function, so the file's interface signature
+        // changes every time. These take the full-rebuild path (the
+        // incremental body re-walk applies only to interface-preserving
+        // edits) — measured separately to confirm that path does not
+        // regress. One file is mutated, so successive edits stay self-
+        // contained and do not collide across the corpus.
+        _interface_edits() is
+            let edits mut = 6;
+
+            if _quick then
+                edits = 3;
+            fi
+
+            let counter mut = 0;
+
+            for f in _corpus.sample(1) do
+                for i in 0..edits do
+                    counter = counter + 1;
+
+                    let mutated =
+                        "{f.source}\n"
+                        "namespace ProfilerProbe is\n"
+                        "    probe_{counter}() is si\n"
+                        "si\n";
+
+                    let started = System.DateTime.now;
+
+                    _analyser.send_edit(f.path, mutated);
+
+                    let diagnostics = _analyser.read_response();    // DIAGNOSTICS
+                    let done = _analyser.read_response();           // PARTIAL DONE
+
+                    _stats["EDIT — single file (interface change)"].record(_elapsed_ms(started));
+                od
             od
         si
 

--- a/analysis-tests/src/tests/complete_fast_path_tests.ghul
+++ b/analysis-tests/src/tests/complete_fast_path_tests.ghul
@@ -11,9 +11,13 @@ namespace Analysis.Tests is
     use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
     // The COMPLETION_HANDLER fast path skips compile_all when the cursor
-    // file is already compiled through expressions (the common case: user
-    // typed, debounced EDIT ran, then COMPLETE arrived in the same file).
-    // The fallback to compile_all stays in place for the cross-file case.
+    // file is already compiled through expressions. An interface-preserving
+    // EDIT takes the incremental body re-walk, which never clear_symbols —
+    // so every file stays compiled through expressions and a COMPLETE fast
+    // paths whether or not it lands in the just-edited file. Only an
+    // interface-affecting EDIT triggers the whole-project rebuild, whose
+    // clear_symbols leaves the un-edited files no longer compiled through
+    // expressions, so a cross-file COMPLETE then falls back to compile_all.
     //
     // The wire protocol surfaces this directly: compile_all writes a
     // "DIAGNOSTICS" frame ahead of "COMPLETION", so a fast-path response
@@ -37,12 +41,12 @@ namespace Analysis.Tests is
             return File.read_all_text(path);
         si
 
-        prime(analyser: ANALYSER_PROCESS) is
-            let caller_source = load_caller();
+        // Initial two-file EDIT, then a single-file EDIT of `caller_source`.
+        prime(analyser: ANALYSER_PROCESS, caller_source: string) is
             let greeter_source = load_greeter();
 
             analyser.send_edit_files([
-                EDIT_FILE("caller.ghul", caller_source),
+                EDIT_FILE("caller.ghul", load_caller()),
                 EDIT_FILE("greeter.ghul", greeter_source)
             ]);
 
@@ -53,9 +57,6 @@ namespace Analysis.Tests is
             let initial_done = analyser.read_response();
             Assert.are_equal("PARTIAL DONE", initial_done.header);
 
-            // Single-file EDIT of caller — clears every file's
-            // compiled_through (clear_symbols), then sets only caller's
-            // back to "compile-expressions" via the build that follows.
             analyser.send_edit("caller.ghul", caller_source);
 
             let edit_diagnostics = analyser.read_response();
@@ -65,6 +66,20 @@ namespace Analysis.Tests is
             Assert.are_equal("PARTIAL DONE", edit_done.header);
         si
 
+        // caller with an extra namespace-level function — re-presenting it as
+        // a single-file EDIT changes caller's interface signature.
+        caller_with_interface_change() -> string =>
+            "namespace CompleteFastPath is\n"
+            "    use IO.Std;\n"
+            "\n"
+            "    entry() is\n"
+            "        let g = GREETER();\n"
+            "        Std.write_line(g.greet());\n"
+            "    si\n"
+            "\n"
+            "    extra() -> int => 42;\n"
+            "si\n";
+
         // COMPLETE in the file that was just edited — caller's expressions
         // are current, so the handler should skip compile_all and emit only
         // a "COMPLETION" frame (no leading "DIAGNOSTICS").
@@ -73,7 +88,7 @@ namespace Analysis.Tests is
 
             let use analyser = ANALYSER_PROCESS();
 
-            prime(analyser);
+            prime(analyser, load_caller());
 
             // "        Std.write_line(g.greet());" — column 26 lands on
             // the 'g' just after the dot, well inside the member node.
@@ -91,16 +106,43 @@ namespace Analysis.Tests is
             );
         si
 
-        // COMPLETE in a file other than the last-edited one — greeter's
-        // compiled_through was cleared by the EDIT of caller and not
-        // re-set, so the handler must fall back to compile_all. The wire
-        // gives that away as a "DIAGNOSTICS" frame preceding "COMPLETION".
-        completion_in_other_file_falls_back_to_compile_all() is
+        // COMPLETE in a file other than the last-edited one, after an
+        // interface-preserving EDIT of caller. The incremental body re-walk
+        // does not clear_symbols, so greeter is still compiled through
+        // expressions — the handler fast paths and emits only "COMPLETION".
+        completion_in_other_file_after_interface_preserving_edit_fast_paths() is
             @test()
 
             let use analyser = ANALYSER_PROCESS();
 
-            prime(analyser);
+            prime(analyser, load_caller());
+
+            analyser.send_completion("greeter.ghul", 4, 9);
+
+            let first = analyser.read_response();
+            Assert.are_equal(
+                "COMPLETION",
+                first.header,
+                "expected fast path (COMPLETION first); got '{first.header}'.\n"
+                "An interface-preserving EDIT takes the incremental re-walk,\n"
+                "which never clear_symbols — greeter should still be compiled\n"
+                "through expressions. A DIAGNOSTICS frame here means the EDIT\n"
+                "cleared cross-file compiled state when it should not have.\n"
+                "--- analyser stderr ---\n{analyser.stderr_capture}"
+            );
+        si
+
+        // COMPLETE in a file other than the last-edited one, after an
+        // interface-affecting EDIT of caller. The whole-project rebuild's
+        // clear_symbols left greeter no longer compiled through expressions,
+        // so the handler falls back to compile_all — a "DIAGNOSTICS" frame
+        // precedes "COMPLETION".
+        completion_in_other_file_after_interface_affecting_edit_falls_back() is
+            @test()
+
+            let use analyser = ANALYSER_PROCESS();
+
+            prime(analyser, caller_with_interface_change());
 
             analyser.send_completion("greeter.ghul", 4, 9);
 
@@ -109,9 +151,9 @@ namespace Analysis.Tests is
                 "DIAGNOSTICS",
                 first.header,
                 "expected fallback path (DIAGNOSTICS first then COMPLETION); got '{first.header}'.\n"
-                "If this asserts COMPLETION it means the fast path mis-fired —\n"
-                "either greeter's compiled_through wasn't cleared by the EDIT\n"
-                "of caller, or the predicate is reading stale state.\n"
+                "An interface-affecting EDIT of caller does a whole-project\n"
+                "rebuild; its clear_symbols should leave greeter not compiled\n"
+                "through expressions, forcing the COMPLETE fallback.\n"
                 "--- analyser stderr ---\n{analyser.stderr_capture}"
             );
 

--- a/analysis-tests/src/tests/incremental_edit_tests.ghul
+++ b/analysis-tests/src/tests/incremental_edit_tests.ghul
@@ -1,0 +1,525 @@
+namespace Analysis.Tests is
+    use Collections.LIST;
+
+    use Analysis.Protocol.ANALYSER_PROCESS;
+    use Analysis.Protocol.DIAGNOSTIC;
+    use Analysis.Protocol.EDIT_FILE;
+    use Analysis.Protocol.RESPONSE;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    // Targeted coverage for the incremental body re-walk — the default
+    // analysis-mode EDIT path for an interface-preserving single-file edit
+    // (splice the new bodies onto the retained AST, re-walk only the edited
+    // file, never clear_symbols). The whole `analysis-tests` suite already
+    // runs through this path; these tests probe the cases the design called
+    // out as load-bearing: locations after a line-shifting edit, cross-file
+    // correctness, and property / trait-default-method body splices.
+    //
+    // See docs/claude/incremental-body-rewalk.md.
+    class INCREMENTAL_EDIT_TESTS is
+        @test()
+
+        init() is si
+
+        // shift.ghul before the edit — `beta`'s body sits at lines 6-9.
+        shift_baseline() -> string =>
+            "namespace IncShift is\n"
+            "    alpha() -> int is\n"
+            "        return 1;\n"
+            "    si\n"
+            "\n"
+            "    beta() -> int is\n"
+            "        let value = 7;\n"
+            "        return value;\n"
+            "    si\n"
+            "si\n";
+
+        // shift.ghul after the edit — `alpha`'s body has grown by three
+        // lines, pushing `beta` down: `let value = 7;` is now line 10 and
+        // `return value;` line 11. The signatures are unchanged, so this is
+        // an interface-preserving edit and takes the incremental re-walk.
+        shift_edited() -> string =>
+            "namespace IncShift is\n"
+            "    alpha() -> int is\n"
+            "        let a = 1;\n"
+            "        let b = 2;\n"
+            "        let c = 3;\n"
+            "        return a + b + c;\n"
+            "    si\n"
+            "\n"
+            "    beta() -> int is\n"
+            "        let value = 7;\n"
+            "        return value;\n"
+            "    si\n"
+            "si\n";
+
+        // HOVER inside a body that an earlier body's edit pushed down: the
+        // re-walk must record the use at its *new* line. `value` on line 11
+        // would have been line 8 before the edit — a non-empty hover there
+        // proves the spliced body's locations are current.
+        hover_in_a_body_below_an_edited_body_resolves_after_a_line_shift() is
+            @test()
+
+            let use analyser = ANALYSER_PROCESS();
+
+            edit_and_drain(analyser, "shift.ghul", shift_baseline());
+            edit_and_drain(analyser, "shift.ghul", shift_edited());
+
+            // `        return value;` — `value` spans cols 16-20; col 17 is
+            // inside it.
+            analyser.send_hover("shift.ghul", 11, 17);
+
+            let response = analyser.read_query_response();
+            Assert.are_equal("HOVER", response.header);
+
+            let lines = LIST[string](response.lines);
+            Assert.is_true(
+                lines.count > 0 /\ !string.is_null_or_white_space(lines[0]),
+                "HOVER on `value` at its post-shift line returned an empty "
+                "body — the incremental re-walk did not record the use at "
+                "its current coordinates.\n--- analyser stderr ---\n"
+                "{analyser.stderr_capture}"
+            );
+        si
+
+        // DEFINITION across the same shifted body: jumping from the use of
+        // `value` to its `let` must land on the declaration's *post-shift*
+        // line (10), not its pre-edit line (7).
+        definition_in_a_body_below_an_edited_body_resolves_after_a_line_shift() is
+            @test()
+
+            let use analyser = ANALYSER_PROCESS();
+
+            edit_and_drain(analyser, "shift.ghul", shift_baseline());
+            edit_and_drain(analyser, "shift.ghul", shift_edited());
+
+            analyser.send_definition("shift.ghul", 11, 17);
+
+            let response = analyser.read_query_response();
+            Assert.are_equal("DEFINITION", response.header);
+
+            let lines = LIST[string](response.lines);
+            Assert.are_equal(
+                1,
+                lines.count,
+                "DEFINITION on `value` expected exactly one location, got "
+                "{lines.count}.\nlines: {lines}\n--- analyser stderr ---\n"
+                "{analyser.stderr_capture}"
+            );
+
+            // <uri>\t<startLine>\t<startCol>\t<endLine>\t<endCol>
+            let fields = LIST[string](lines[0].split(['\t']));
+            Assert.is_true(
+                fields.count >= 2,
+                "malformed DEFINITION location line: '{lines[0]}'"
+            );
+            Assert.is_true(
+                fields[0].ends_with("shift.ghul"),
+                "DEFINITION should point into shift.ghul, got: '{lines[0]}'"
+            );
+            Assert.are_equal(
+                "10",
+                fields[1],
+                "DEFINITION on `value` should land on the post-shift "
+                "declaration line 10, got start line '{fields[1]}' — the "
+                "re-walked body's declaration kept a stale location.\n"
+                "--- analyser stderr ---\n{analyser.stderr_capture}"
+            );
+        si
+
+        base_baseline() -> string =>
+            "namespace IncCross is\n"
+            "    class BASE is\n"
+            "        init() is si\n"
+            "\n"
+            "        value() -> int is\n"
+            "            return 1;\n"
+            "        si\n"
+            "    si\n"
+            "si\n";
+
+        // BASE.value's body changed; its signature is not.
+        base_body_edited() -> string =>
+            "namespace IncCross is\n"
+            "    class BASE is\n"
+            "        init() is si\n"
+            "\n"
+            "        value() -> int is\n"
+            "            return 2;\n"
+            "        si\n"
+            "    si\n"
+            "si\n";
+
+        // BASE.value gained a parameter — an interface change.
+        base_signature_edited() -> string =>
+            "namespace IncCross is\n"
+            "    class BASE is\n"
+            "        init() is si\n"
+            "\n"
+            "        value(n: int) -> int is\n"
+            "            return n;\n"
+            "        si\n"
+            "    si\n"
+            "si\n";
+
+        derived_source() -> string =>
+            "namespace IncCross is\n"
+            "    class DERIVED: BASE is\n"
+            "        init() is super.init(); si\n"
+            "\n"
+            "        doubled() -> int => value() * 2;\n"
+            "    si\n"
+            "si\n";
+
+        // A derived class in another file is unaffected by a body-only edit
+        // to its base — the incremental path does not re-walk it and its
+        // retained symbols stay valid — but an interface change to the base
+        // must re-surface in it on the next COMPILE.
+        body_only_edit_to_a_base_leaves_a_cross_file_derived_class_clean() is
+            @test()
+
+            let use analyser = ANALYSER_PROCESS();
+
+            analyser.send_edit_files([
+                EDIT_FILE("base.ghul", base_baseline()),
+                EDIT_FILE("derived.ghul", derived_source())
+            ]);
+            drain_edit(analyser);
+
+            // Body-only edit to base.ghul — interface-preserving, so the
+            // incremental re-walk runs and derived.ghul is left untouched
+            // and clean.
+            analyser.send_edit("base.ghul", base_body_edited());
+            Assert.are_equal(
+                0,
+                count_diagnostics_for(analyser, "derived.ghul"),
+                "a body-only edit to BASE should leave the cross-file "
+                "DERIVED clean\n--- analyser stderr ---\n"
+                "{analyser.stderr_capture}"
+            );
+
+            // Signature edit to base.ghul — interface-affecting. The EDIT
+            // itself compiles expressions only for the edited file; the
+            // broken `value()` call in DERIVED surfaces on the COMPILE that
+            // follows (the EDIT's PARTIAL DONE reports COMPILE needed).
+            analyser.send_edit("base.ghul", base_signature_edited());
+            drain_edit(analyser);
+
+            analyser.send_compile();
+            Assert.is_true(
+                count_compile_diagnostics_for(analyser, "derived.ghul") > 0,
+                "a COMPILE after a signature edit to BASE should surface "
+                "the broken call in DERIVED\n--- analyser stderr ---\n"
+                "{analyser.stderr_capture}"
+            );
+        si
+
+        prop_baseline() -> string =>
+            "namespace IncProp is\n"
+            "    class HOLDER is\n"
+            "        init() is si\n"
+            "\n"
+            "        prefix() -> string => \"v\";\n"
+            "\n"
+            "        suffix() -> string => \"w\";\n"
+            "\n"
+            "        label: string => prefix();\n"
+            "    si\n"
+            "si\n";
+
+        // The property getter's expression body changed — it now calls a
+        // different sibling method. The property's name and type are not,
+        // so this is interface-preserving and the synthesised accessor's
+        // body must re-resolve the call through the splice.
+        prop_edited() -> string =>
+            "namespace IncProp is\n"
+            "    class HOLDER is\n"
+            "        init() is si\n"
+            "\n"
+            "        prefix() -> string => \"v\";\n"
+            "\n"
+            "        suffix() -> string => \"w\";\n"
+            "\n"
+            "        label: string => suffix();\n"
+            "    si\n"
+            "si\n";
+
+        // A property getter is a synthesised accessor function; editing its
+        // expression body must re-walk cleanly through the splice (the
+        // accessor body and the property's read_body are kept in sync).
+        property_getter_body_edit_re_walks_clean() is
+            @test()
+
+            let use analyser = ANALYSER_PROCESS();
+
+            analyser.send_edit("prop.ghul", prop_baseline());
+            let baseline_diagnostics = diagnostics_for(analyser, "prop.ghul");
+            Assert.are_equal(
+                0,
+                baseline_diagnostics.count,
+                "{diagnostics_summary("prop.ghul baseline EDIT", baseline_diagnostics)}"
+                "\n--- analyser stderr ---\n{analyser.stderr_capture}"
+            );
+
+            analyser.send_edit("prop.ghul", prop_edited());
+            let edited_diagnostics = diagnostics_for(analyser, "prop.ghul");
+            Assert.are_equal(
+                0,
+                edited_diagnostics.count,
+                "editing a property getter body should re-walk clean — the "
+                "call to `prefix()` inside it must still resolve.\n"
+                "{diagnostics_summary("prop.ghul after edit", edited_diagnostics)}"
+                "\n--- analyser stderr ---\n{analyser.stderr_capture}"
+            );
+        si
+
+        trait_baseline() -> string =>
+            "namespace IncTrait is\n"
+            "    trait GREETER is\n"
+            "        base_word() -> string => \"hi\";\n"
+            "\n"
+            "        greeting() -> string => base_word();\n"
+            "    si\n"
+            "\n"
+            "    class POLITE: GREETER is\n"
+            "        init() is si\n"
+            "    si\n"
+            "si\n";
+
+        // A trait default method's body changed; signatures are not.
+        trait_edited() -> string =>
+            "namespace IncTrait is\n"
+            "    trait GREETER is\n"
+            "        base_word() -> string => \"hello\";\n"
+            "\n"
+            "        greeting() -> string => base_word();\n"
+            "    si\n"
+            "\n"
+            "    class POLITE: GREETER is\n"
+            "        init() is si\n"
+            "    si\n"
+            "si\n";
+
+        // A trait default method is an ordinary FUNCTION with a body; an
+        // interface-preserving edit to one re-walks through the splice like
+        // any other method body.
+        trait_default_method_body_edit_re_walks_clean() is
+            @test()
+
+            let use analyser = ANALYSER_PROCESS();
+
+            edit_and_drain(analyser, "trait.ghul", trait_baseline());
+
+            analyser.send_edit("trait.ghul", trait_edited());
+            Assert.are_equal(
+                0,
+                count_diagnostics_for(analyser, "trait.ghul"),
+                "editing a trait default method body should re-walk clean\n"
+                "--- analyser stderr ---\n{analyser.stderr_capture}"
+            );
+        si
+
+        index_baseline() -> string =>
+            "namespace IncIndex is\n"
+            "    use Collections.LIST;\n"
+            "\n"
+            "    class STORE is\n"
+            "        _items: LIST[int];\n"
+            "\n"
+            "        init() is\n"
+            "            _items = LIST[int]();\n"
+            "            _items.add(0);\n"
+            "        si\n"
+            "\n"
+            "        [i: int]: int is\n"
+            "            return _items[i];\n"
+            "        si,\n"
+            "        = v is\n"
+            "            _items[i] = v;\n"
+            "        si\n"
+            "    si\n"
+            "si\n";
+
+        // The indexer getter body changed; the indexer signature
+        // (`[i: int]: int`) and the setter are not — interface-preserving.
+        index_getter_edited() -> string =>
+            "namespace IncIndex is\n"
+            "    use Collections.LIST;\n"
+            "\n"
+            "    class STORE is\n"
+            "        _items: LIST[int];\n"
+            "\n"
+            "        init() is\n"
+            "            _items = LIST[int]();\n"
+            "            _items.add(0);\n"
+            "        si\n"
+            "\n"
+            "        [i: int]: int is\n"
+            "            return _items[i] * 2;\n"
+            "        si,\n"
+            "        = v is\n"
+            "            _items[i] = v;\n"
+            "        si\n"
+            "    si\n"
+            "si\n";
+
+        // The indexer setter body changed; the signature and getter are not.
+        index_setter_edited() -> string =>
+            "namespace IncIndex is\n"
+            "    use Collections.LIST;\n"
+            "\n"
+            "    class STORE is\n"
+            "        _items: LIST[int];\n"
+            "\n"
+            "        init() is\n"
+            "            _items = LIST[int]();\n"
+            "            _items.add(0);\n"
+            "        si\n"
+            "\n"
+            "        [i: int]: int is\n"
+            "            return _items[i] * 2;\n"
+            "        si,\n"
+            "        = v is\n"
+            "            _items[i] = v * 2;\n"
+            "        si\n"
+            "    si\n"
+            "si\n";
+
+        // An indexer's getter and setter are each a synthesised accessor
+        // function — `add_accessors_for_properties` lifts them into sibling
+        // FUNCTION nodes, so they pair and splice like any method body.
+        // Editing each in turn must re-walk clean.
+        indexer_getter_and_setter_body_edits_re_walk_clean() is
+            @test()
+
+            let use analyser = ANALYSER_PROCESS();
+
+            analyser.send_edit("index.ghul", index_baseline());
+            let baseline_diagnostics = diagnostics_for(analyser, "index.ghul");
+            Assert.are_equal(
+                0,
+                baseline_diagnostics.count,
+                "{diagnostics_summary("index.ghul baseline (cold full build)", baseline_diagnostics)}"
+                "\n--- analyser stderr ---\n{analyser.stderr_capture}"
+            );
+
+            analyser.send_edit("index.ghul", index_getter_edited());
+            let getter_diagnostics = diagnostics_for(analyser, "index.ghul");
+            Assert.are_equal(
+                0,
+                getter_diagnostics.count,
+                "editing an indexer getter body should re-walk clean.\n"
+                "{diagnostics_summary("index.ghul after getter edit", getter_diagnostics)}"
+                "\n--- analyser stderr ---\n{analyser.stderr_capture}"
+            );
+
+            analyser.send_edit("index.ghul", index_setter_edited());
+            let setter_diagnostics = diagnostics_for(analyser, "index.ghul");
+            Assert.are_equal(
+                0,
+                setter_diagnostics.count,
+                "editing an indexer setter body should re-walk clean.\n"
+                "{diagnostics_summary("index.ghul after setter edit", setter_diagnostics)}"
+                "\n--- analyser stderr ---\n{analyser.stderr_capture}"
+            );
+        si
+
+        // Body-edit a plain method with an explicitly-typed argument. The
+        // re-walk must process the body only — re-resolving the retained
+        // argument declaration poisons it ("set type twice"). This is the
+        // case the pre-BODY_REWALKER suite never exercised, which is how the
+        // whole-file re-walk shipped broken.
+        method_with_typed_argument_body_edit_re_walks_clean() is
+            @test()
+
+            let use analyser = ANALYSER_PROCESS();
+
+            analyser.send_edit(
+                "probe.ghul",
+                "namespace IncProbe is\n"
+                "    run(x: int) -> int is\n"
+                "        return x;\n"
+                "    si\n"
+                "si\n"
+            );
+            drain_edit(analyser);
+
+            analyser.send_edit(
+                "probe.ghul",
+                "namespace IncProbe is\n"
+                "    run(x: int) -> int is\n"
+                "        return x + 1;\n"
+                "    si\n"
+                "si\n"
+            );
+            let probe_diagnostics = diagnostics_for(analyser, "probe.ghul");
+            Assert.are_equal(
+                0,
+                probe_diagnostics.count,
+                "{diagnostics_summary("probe.ghul after typed-arg method body edit", probe_diagnostics)}"
+                "\n--- analyser stderr ---\n{analyser.stderr_capture}"
+            );
+        si
+
+        // Send a single-file EDIT and discard its DIAGNOSTICS + PARTIAL DONE.
+        edit_and_drain(analyser: ANALYSER_PROCESS, path: string, source: string) is
+            analyser.send_edit(path, source);
+            drain_edit(analyser);
+        si
+
+        // Read an EDIT's DIAGNOSTICS + PARTIAL DONE frames, discarding both.
+        drain_edit(analyser: ANALYSER_PROCESS) is
+            let diagnostics = analyser.read_response();
+            Assert.are_equal("DIAGNOSTICS", diagnostics.header);
+
+            let partial_done = analyser.read_response();
+            Assert.are_equal("PARTIAL DONE", partial_done.header);
+        si
+
+        // Read an EDIT's DIAGNOSTICS + PARTIAL DONE; return the count of
+        // user diagnostics whose path ends with `file_name`.
+        count_diagnostics_for(analyser: ANALYSER_PROCESS, file_name: string) -> int =>
+            diagnostics_for(analyser, file_name).count;
+
+        // Read an EDIT's DIAGNOSTICS + PARTIAL DONE; return the user
+        // diagnostics whose path ends with `file_name`.
+        diagnostics_for(analyser: ANALYSER_PROCESS, file_name: string) -> LIST[DIAGNOSTIC] is
+            let diagnostics = analyser.read_response();
+            Assert.are_equal("DIAGNOSTICS", diagnostics.header);
+
+            let result = LIST[DIAGNOSTIC]();
+
+            for d in diagnostics.user_diagnostics do
+                if d.path.ends_with(file_name) then
+                    result.add(d);
+                fi
+            od
+
+            let partial_done = analyser.read_response();
+            Assert.are_equal("PARTIAL DONE", partial_done.header);
+
+            return result;
+        si
+
+        // Read a COMPILE's DIAGNOSTICS + FULL DONE; return the count of
+        // user diagnostics whose path ends with `file_name`.
+        count_compile_diagnostics_for(analyser: ANALYSER_PROCESS, file_name: string) -> int is
+            let diagnostics = analyser.read_response();
+            Assert.are_equal("DIAGNOSTICS", diagnostics.header);
+
+            let count mut = 0;
+
+            for d in diagnostics.user_diagnostics do
+                if d.path.ends_with(file_name) then
+                    count = count + 1;
+                fi
+            od
+
+            let full_done = analyser.read_response();
+            Assert.are_equal("FULL DONE", full_done.header);
+
+            return count;
+        si
+    si
+si

--- a/src/analysis/command_handlers.ghul
+++ b/src/analysis/command_handlers.ghul
@@ -347,6 +347,12 @@ namespace Analysis is
 
         _is_interface_changed: bool;
 
+        // The pre-edit SOURCE_FILE of the most recent parse, stashed by
+        // parse_and_add_file. For an interface-preserving single-file EDIT the
+        // incremental body re-walk splices the new bodies onto it (its symbols
+        // are still valid). Null on a cold / first-parse EDIT.
+        _retained: SOURCE_FILE?;
+
         file_names: Iterable[string] => _source_files_by_path.keys;
 
         iterator: Collections.Iterator[SOURCE_FILE]
@@ -382,6 +388,8 @@ namespace Analysis is
 
             let previous = find_source_file(path);
 
+            _retained = previous;
+
             let source_file = _compiler.parse(path, reader, _build_flags.want_compile_up_to_expressions, _build_flags.want_compile_expressions, is_internal_file);
             _source_files_by_path[path] = source_file;
 
@@ -401,11 +409,58 @@ namespace Analysis is
                 _is_interface_changed = true;
             fi
         si
-        
+
+        // The incremental body re-walk for an interface-preserving single-file
+        // EDIT: keep the retained AST registered, splice the freshly-parsed
+        // bodies onto it, refresh its locations from the fresh parse, and
+        // re-walk only the edited file. Returns false — restoring the fresh
+        // parse as the registered file — if the parses do not pair or the
+        // location refresh desyncs, so the caller falls back to a full rebuild.
+        try_incremental_build(writer: IO.TextWriter) -> bool is
+            let retained = _retained;
+
+            if !retained? then
+                return false;
+            fi
+
+            let edited_path = retained.file_name;
+            let donor = _source_files_by_path[edited_path];
+
+            // Keep the retained AST as the registered file; the fresh parse is
+            // only a body donor.
+            _source_files_by_path[edited_path] = retained;
+
+            let pairing = Syntax.FUNCTION_PAIRING(retained.definition, donor.definition);
+
+            let pairs = pairing.pairs;
+
+            if !pairs? then
+                _source_files_by_path[edited_path] = donor;
+                return false;
+            fi
+
+            Syntax.BODY_SPLICE.apply(pairs);
+
+            if !Syntax.Process.LOCATION_REFRESH.apply(retained.definition, donor.definition) then
+                _source_files_by_path[edited_path] = donor;
+                return false;
+            fi
+
+            IoC.CONTAINER.instance.logger.clear(edited_path, true);
+            IoC.CONTAINER.instance.logger.start_analysis();
+
+            _compiler.rewalk_bodies(retained);
+
+            IoC.CONTAINER.instance.logger.write_all_diagnostics(writer, IoC.CONTAINER.instance.logger_formatter);
+
+            return true;
+        si
+
         handle(reader: IO.TextReader, writer: IO.TextWriter) is
             IoC.CONTAINER.instance.want_tab_delimited_logger(writer);
 
             _is_interface_changed = false;
+            _retained = null;
 
             for i in _source_files_by_path.values do
                 i.want_compile_expressions = false;
@@ -458,25 +513,35 @@ namespace Analysis is
                 _timers.start(edit_class_timer);
             fi
 
+            // An interface-preserving single-file EDIT takes the incremental
+            // body re-walk instead of the whole-project rebuild.
+            let incremental_eligible =
+                !_is_interface_changed /\
+                paths.count == 1 /\
+                _retained? /\
+                _retained.interface_signature?;
+
             try
                 writer.write_line("DIAGNOSTICS");
 
                 Semantic.Types.NAMED.clear_cache();
 
                 if !_watchdog.want_restart then
-                    for i in _source_files_by_path.values do
-                        i.want_compile_up_to_expressions = true;
+                    if !(incremental_eligible /\ try_incremental_build(writer)) then
+                        for i in _source_files_by_path.values do
+                            i.want_compile_up_to_expressions = true;
 
-                        IoC.CONTAINER.instance.logger.clear_global_declaration_diagnostics(i.file_name);
-                    od
+                            IoC.CONTAINER.instance.logger.clear_global_declaration_diagnostics(i.file_name);
+                        od
 
-                    IoC.CONTAINER.instance.logger.start_analysis();
+                        IoC.CONTAINER.instance.logger.start_analysis();
 
-                    _compiler.clear_symbols();
-                    _compiler.queue(self);
-                    _compiler.build();
+                        _compiler.clear_symbols();
+                        _compiler.queue(self);
+                        _compiler.build();
 
-                    IoC.CONTAINER.instance.logger.write_all_diagnostics(writer, IoC.CONTAINER.instance.logger_formatter);
+                        IoC.CONTAINER.instance.logger.write_all_diagnostics(writer, IoC.CONTAINER.instance.logger_formatter);
+                    fi
                 fi
 
             catch ex: Exception

--- a/src/compiler/compiler.ghul
+++ b/src/compiler/compiler.ghul
@@ -283,6 +283,86 @@ namespace Compiler is
             od
         si
 
+        // Incremental body re-walk: re-process only the edited file's new
+        // function bodies, after its donor bodies have been spliced in by the
+        // analysis-mode EDIT handler. Every pass runs body-scoped — through
+        // BODY_DECLARER for declare-symbols, BODY_REWALKER for the rest — so
+        // the retained interface (arguments, signatures, indexer / property
+        // parameters) is never re-processed. Re-resolving a retained,
+        // already-typed argument would poison it ("set type twice"); the
+        // bodies are leaves, so processing them alone is also sufficient.
+        // resolve-uses / resolve-ancestors / resolve-overrides are skipped —
+        // they do not visit body interiors and the interface is unchanged.
+        // See docs/claude/incremental-body-rewalk.md.
+        rewalk_bodies(source_file: SOURCE_FILE) is
+            source_file.want_compile_up_to_expressions = true;
+            source_file.want_compile_expressions = true;
+
+            let flags = container.build_flags;
+            let symbol_table = container.symbol_table;
+
+            let body_declarer = Syntax.Process.BODY_DECLARER(
+                logger,
+                container.stable_symbols,
+                symbol_table,
+                container.namespaces,
+                container.declare_symbols
+            );
+
+            // body-scoped declare-symbols
+            let mark = symbol_table.mark_scope_stack();
+
+            try
+                source_file.definition.walk(body_declarer);
+            catch e: Exception
+                logger.exception(source_file.definition.location, e, "caught exception declaring bodies in incremental re-walk of {source_file}");
+            finally
+                symbol_table.release_scope_stack(mark);
+                container.namespaces.pop_all_namespaces();
+            yrt
+
+            rewalk_pass(source_file, container.resolve_type_expressions);
+            rewalk_pass(source_file, container.resolve_explicit_types);
+
+            if flags.want_assembler \/ flags.want_executable then
+                rewalk_pass(source_file, container.record_type_argument_uses);
+            fi
+
+            logger.set_is_compiling_expressions(true);
+
+            rewalk_pass(source_file, container.compile_expressions);
+
+            if flags.want_warn_implicit_mutable_let then
+                rewalk_pass(source_file, container.warn_implicit_mutable_let);
+            fi
+
+            logger.set_is_compiling_expressions(false);
+        si
+
+        // Run one body-visiting pass over the edited file's bodies only,
+        // driven by BODY_REWALKER, under a scope-stack mark/release.
+        rewalk_pass(source_file: SOURCE_FILE, pass: Syntax.Visitor) is
+            let symbol_table = container.symbol_table;
+            let mark = symbol_table.mark_scope_stack();
+
+            let rewalker = Syntax.Process.BODY_REWALKER(
+                logger,
+                container.stable_symbols,
+                symbol_table,
+                container.namespaces,
+                pass
+            );
+
+            try
+                source_file.definition.walk(rewalker);
+            catch e: Exception
+                logger.exception(source_file.definition.location, e, "caught exception in incremental re-walk of {source_file}");
+            finally
+                symbol_table.release_scope_stack(mark);
+                container.namespaces.pop_all_namespaces();
+            yrt
+        si
+
         conditional_compilation_pass(source_file: SOURCE_FILE) -> bool is
             let definition = source_file.definition;
 

--- a/src/syntax/process/body_declarer.ghul
+++ b/src/syntax/process/body_declarer.ghul
@@ -1,0 +1,49 @@
+namespace Syntax.Process is
+    use Logging;
+
+    use Trees;
+
+    // Walks the edited file's declaration skeleton, entering the retained
+    // scopes, and re-declares each function's body through DECLARE_SYMBOLS —
+    // the declare-symbols half of the incremental body re-walk.
+    //
+    // The interface declarations are not re-declared: ScopedVisitor's
+    // inherited `pre`/`visit` for namespace / class / trait / … only *enter*
+    // the retained scopes (a lookup, not a fresh declaration), so the
+    // retained interface symbols are kept and declare-symbols' non-idempotency
+    // is never exercised. Only the new body subtrees get fresh block scopes
+    // and locals.
+    class BODY_DECLARER: ScopedVisitor is
+        _declare_symbols: DECLARE_SYMBOLS;
+
+        init(
+            logger: Logger,
+            stable_symbols: Semantic.STABLE_SYMBOLS,
+            symbol_table: Semantic.SYMBOL_TABLE,
+            namespaces: Semantic.NAMESPACES,
+            declare_symbols: DECLARE_SYMBOLS
+        ) is
+            super.init(logger, stable_symbols, symbol_table, namespaces);
+
+            _declare_symbols = declare_symbols;
+        si
+
+        // At a function: enter its retained scope, declare the new body, and
+        // return true so the skeleton walk does not also descend the body.
+        // `visit(function)` (inherited) leaves the scope.
+        pre(function: Trees.Definitions.FUNCTION) -> bool is
+            enter_scope(function);
+
+            _declare_symbols.declare_body(function);
+
+            return true;
+        si
+
+        // Property and indexer accessor bodies are reached through the
+        // synthesised sibling `$get_`/`$set_` (and `get_`/`set_`) FUNCTION
+        // nodes, so the declaration node itself is not descended.
+        pre(property: Trees.Definitions.PROPERTY) -> bool => true;
+
+        pre(indexer: Trees.Definitions.INDEXER) -> bool => true;
+    si
+si

--- a/src/syntax/process/body_rewalker.ghul
+++ b/src/syntax/process/body_rewalker.ghul
@@ -1,0 +1,61 @@
+namespace Syntax.Process is
+    use Logging;
+
+    use Trees;
+
+    // Drives one body-visiting pass over only the new body subtrees of an
+    // incrementally re-walked file. Walks the declaration skeleton entering
+    // the retained scopes (inherited ScopedVisitor behaviour); at each
+    // function it gives the pass its per-function frame —
+    // `pre`/`visit(function)`, which enter and leave the retained function
+    // scope and set up any per-function state such as compile-expressions'
+    // flow analysis — but then walks only `function.body`.
+    //
+    // The retained interface — arguments, return type, indexer / property
+    // parameters — is therefore never re-processed. That is both the point
+    // of an incremental re-walk and a correctness requirement: re-resolving
+    // an already-typed retained argument poisons it ("set type twice").
+    class BODY_REWALKER: ScopedVisitor is
+        _pass: Visitor;
+
+        init(
+            logger: Logger,
+            stable_symbols: Semantic.STABLE_SYMBOLS,
+            symbol_table: Semantic.SYMBOL_TABLE,
+            namespaces: Semantic.NAMESPACES,
+            pass: Visitor
+        ) is
+            super.init(logger, stable_symbols, symbol_table, namespaces);
+
+            _pass = pass;
+        si
+
+        // Run the pass over this function's body only. `_pass.pre(function)`
+        // enters the retained function scope and sets up the pass's
+        // per-function state; `function.body.walk` keeps the walk inside the
+        // body; `_pass.visit(function)` tears that down and leaves the scope.
+        // Returning true stops this skeleton walk descending the function.
+        pre(function: Trees.Definitions.FUNCTION) -> bool is
+            if function.body? then
+                _pass.pre(function);
+                function.body.walk(_pass);
+                _pass.visit(function);
+            fi
+
+            return true;
+        si
+
+        // `_pass.visit(function)` already left the function scope; this
+        // skeleton walker never entered it, so its own visit(function) must
+        // do nothing rather than leave an enclosing scope.
+        visit(function: Trees.Definitions.FUNCTION) is
+        si
+
+        // Property and indexer accessor bodies are reached through the
+        // synthesised sibling get_/set_ FUNCTION nodes, so the declaration
+        // node itself is not descended.
+        pre(property: Trees.Definitions.PROPERTY) -> bool => true;
+
+        pre(indexer: Trees.Definitions.INDEXER) -> bool => true;
+    si
+si

--- a/src/syntax/process/body_splice.ghul
+++ b/src/syntax/process/body_splice.ghul
@@ -1,0 +1,32 @@
+namespace Syntax is
+    use Collections.LIST;
+
+    // Splices freshly-parsed (donor) function bodies onto the retained AST's
+    // function nodes, for the incremental body re-walk. The retained FUNCTION
+    // node — its symbol, its node→scope association — is kept untouched; only
+    // the body child is replaced.
+    class BODY_SPLICE is
+        // For each retained↔donor pair, give the retained function the
+        // donor's body. A property accessor's body is also referenced by its
+        // PROPERTY node's read_body / assign_body field (the resolve passes
+        // descend the PROPERTY node), so that reference is kept in sync.
+        apply(pairs: LIST[FUNCTION_PAIR]) static is
+            for pair in pairs do
+                let retained = pair.retained;
+                let body = pair.donor.body;
+
+                retained.body = body;
+
+                let property = retained.for_property;
+
+                if property? then
+                    if property.read_function == retained then
+                        property.read_body = body;
+                    elif property.assign_function == retained then
+                        property.assign_body = body;
+                    fi
+                fi
+            od
+        si
+    si
+si

--- a/src/syntax/process/declare_symbols.ghul
+++ b/src/syntax/process/declare_symbols.ghul
@@ -512,6 +512,25 @@ namespace Syntax.Process is
             leave_scope(function);
         si
 
+        // Declare just a function's body — its block scopes, locals and
+        // closures — reusing the body-handling visit methods. The caller
+        // must already have the cursor positioned at the function's
+        // (retained) scope. Used by the incremental body re-walk, which
+        // keeps the interface symbols and re-declares only the edited
+        // bodies; the interface is never re-walked here, so the pass's
+        // non-idempotency on declarations is not exercised.
+        declare_body(function: Definitions.FUNCTION) is
+            if !function.body? then
+                return;
+            fi
+
+            _local_id_generator.enter_function();
+
+            function.body.walk(self);
+
+            _local_id_generator.leave_function();
+        si
+
         pre(property: Definitions.PROPERTY) -> bool is
             let is_static = property.modifiers.is_static;
 

--- a/src/syntax/process/function_pairing.ghul
+++ b/src/syntax/process/function_pairing.ghul
@@ -1,0 +1,88 @@
+namespace Syntax is
+    use Collections.LIST;
+
+    use Trees;
+    use Trees.Definitions.FUNCTION;
+
+    // Collects a parsed file's `Definitions.FUNCTION` declarations in
+    // declaration order. After `add_accessors_for_properties` (run as part of
+    // rewrite-syntax-trees) this is every method plus the accessor functions
+    // synthesised for properties and indexers. `pre` returns true for a
+    // function, so bodies are not descended into and nested lambdas are not
+    // collected.
+    class FUNCTION_COLLECTOR: Visitor is
+        functions: LIST[FUNCTION] public;
+
+        init() is
+            super.init();
+            functions = LIST[FUNCTION]();
+        si
+
+        pre(function: FUNCTION) -> bool is
+            functions.add(function);
+            return true;
+        si
+    si
+
+    // One retained-to-donor function pairing for the incremental body re-walk.
+    struct FUNCTION_PAIR is
+        retained: FUNCTION public;
+        donor: FUNCTION public;
+
+        init(retained: FUNCTION, donor: FUNCTION) is
+            self.retained = retained;
+            self.donor = donor;
+        si
+    si
+
+    // Pairs the function declarations of two parses of the same file — the
+    // retained AST and a freshly parsed donor — for the incremental body
+    // re-walk. Only interface-preserving edits reach this, so the two parses
+    // have an identical declaration sequence and the pairing is positional;
+    // name and argument count are checked per pair purely as a desync guard.
+    //
+    // `pairs` is null when the two parses do not pair cleanly: the caller must
+    // then fall back to a full rebuild rather than splice.
+    class FUNCTION_PAIRING is
+        pairs: LIST[FUNCTION_PAIR]? public;
+
+        init(retained_root: Node, donor_root: Node) is
+            let retained = collect(retained_root);
+            let donor = collect(donor_root);
+
+            if retained.count != donor.count then
+                pairs = null;
+                return;
+            fi
+
+            let result = LIST[FUNCTION_PAIR]();
+
+            for i in 0..retained.count do
+                let r = retained[i];
+                let d = donor[i];
+
+                if !signatures_match(r, d) then
+                    pairs = null;
+                    return;
+                fi
+
+                result.add(FUNCTION_PAIR(r, d));
+            od
+
+            pairs = result;
+        si
+
+        collect(root: Node) -> LIST[FUNCTION] static is
+            let collector = FUNCTION_COLLECTOR();
+            root.walk(collector);
+            return collector.functions;
+        si
+
+        signatures_match(a: FUNCTION, b: FUNCTION) -> bool static =>
+            name_of(a) =~ name_of(b) /\
+            a.arguments.variables.count == b.arguments.variables.count;
+
+        name_of(function: FUNCTION) -> string static =>
+            if function.name? then function.name.name else "" fi;
+    si
+si

--- a/src/syntax/process/location_refresh.ghul
+++ b/src/syntax/process/location_refresh.ghul
@@ -1,0 +1,195 @@
+namespace Syntax.Process is
+    use Collections.LIST;
+
+    use Source;
+    use Trees;
+
+    // Refreshes the line/column LOCATIONs of one AST against another that is
+    // structurally identical but freshly parsed — used by the incremental
+    // body re-walk. An interface-preserving EDIT keeps the retained AST's
+    // interface nodes (their symbols stay valid) but those nodes carry
+    // pre-edit line numbers; a body edit shifts every line below it. This
+    // visitor copies the donor parse's correct locations onto the retained
+    // nodes so diagnostics and the rebuilt location maps come out in current
+    // coordinates.
+    //
+    // It harvests locations from the donor in walk order, then applies them
+    // to the retained tree in the same walk order. Body interiors are not
+    // descended (`pre` returns true for the body node types): after the
+    // splice the retained AST's bodies *are* the donor's body nodes, already
+    // current, and skipping them keeps the harvest and apply walks counting
+    // the same nodes. `is_consistent` is false if the two walks disagreed —
+    // the caller must then fall back to a full rebuild.
+    class LOCATION_TRANSFER: Visitor is
+        _harvesting: bool;
+        _locations: LIST[LOCATION];
+        _index: int;
+
+        init() is
+            super.init();
+            _locations = LIST[LOCATION]();
+        si
+
+        harvest(root: Node) is
+            _harvesting = true;
+            _locations = LIST[LOCATION]();
+            root.walk(self);
+        si
+
+        apply_to(root: Node) is
+            _harvesting = false;
+            _index = 0;
+            root.walk(self);
+        si
+
+        is_consistent: bool => !_harvesting /\ _index == _locations.count;
+
+        transfer(node: Node) is
+            if _harvesting then
+                _locations.add(node.location);
+            else
+                if _index < _locations.count then
+                    node.location = _locations[_index];
+                fi
+
+                _index = _index + 1;
+            fi
+        si
+
+        // Body interiors are donor nodes already in current coordinates —
+        // skip them so harvest and apply walk the same node set.
+        pre(block: Bodies.BLOCK) -> bool => true;
+        pre(expression: Bodies.EXPRESSION) -> bool => true;
+        pre(innate_body: Bodies.INNATE) -> bool => true;
+        pre(null_body: Bodies.NULL) -> bool => true;
+
+        visit(identifier: Identifiers.Identifier) is transfer(identifier); si
+        visit(identifier: Identifiers.QUALIFIED) is transfer(identifier); si
+
+        visit(modifier: Modifiers.Modifier) is transfer(modifier); si
+        visit(modifiers: Modifiers.LIST) is transfer(modifiers); si
+        visit(pragma: Pragmas.PRAGMA) is transfer(pragma); si
+
+        visit(definition: Definitions.Definition) is transfer(definition); si
+        visit(definitions: Definitions.LIST) is transfer(definitions); si
+        visit(pragma: Definitions.PRAGMA) is transfer(pragma); si
+        visit(`namespace: Definitions.NAMESPACE) is transfer(`namespace); si
+        visit(`use: Definitions.USE) is transfer(`use); si
+        visit(`class: Definitions.CLASS) is transfer(`class); si
+        visit(`trait: Definitions.TRAIT) is transfer(`trait); si
+        visit(`struct: Definitions.STRUCT) is transfer(`struct); si
+        visit(`union: Definitions.UNION) is transfer(`union); si
+        visit(variant: Definitions.VARIANT) is transfer(variant); si
+        visit(`enum: Definitions.ENUM) is transfer(`enum); si
+        visit(enum_member: Definitions.ENUM_MEMBER) is transfer(enum_member); si
+        visit(function: Definitions.FUNCTION) is transfer(function); si
+        visit(functions: Definitions.FUNCTION_GROUP) is transfer(functions); si
+        visit(property: Definitions.PROPERTY) is transfer(property); si
+        visit(indexer: Definitions.INDEXER) is transfer(indexer); si
+
+        visit(variable: Variables.VARIABLE) is transfer(variable); si
+        visit(variables: Variables.LIST) is transfer(variables); si
+        visit(left: Trees.Variables.SIMPLE_VARIABLE_LEFT) is transfer(left); si
+        visit(destructure_left: Trees.Variables.DESTRUCTURING_VARIABLE_LEFT) is transfer(destructure_left); si
+
+        visit(type_expression: TypeExpressions.TypeExpression) is transfer(type_expression); si
+        visit(type_expression: TypeExpressions.INFER) is transfer(type_expression); si
+        visit(structured: TypeExpressions.Structured) is transfer(structured); si
+        visit(array: TypeExpressions.ARRAY_) is transfer(array); si
+        visit(pointer: TypeExpressions.POINTER) is transfer(pointer); si
+        visit(optional: TypeExpressions.OPTIONAL) is transfer(optional); si
+        visit(reference: TypeExpressions.REFERENCE) is transfer(reference); si
+        visit(member: TypeExpressions.MEMBER) is transfer(member); si
+        visit(named: TypeExpressions.NAMED) is transfer(named); si
+        visit(types: TypeExpressions.LIST) is transfer(types); si
+        visit(generic: TypeExpressions.GENERIC) is transfer(generic); si
+        visit(function: TypeExpressions.FUNCTION) is transfer(function); si
+        visit(functions: TypeExpressions.FUNCTION_GROUP) is transfer(functions); si
+        visit(tuple: TypeExpressions.TUPLE) is transfer(tuple); si
+        visit(element: TypeExpressions.NAMED_TUPLE_ELEMENT) is transfer(element); si
+        visit(constraint: TypeExpressions.TYPE_PARAMETER_CONSTRAINT) is transfer(constraint); si
+        visit(element: TypeExpressions.UNDEFINED) is transfer(element); si
+
+        visit(expression: Expressions.Expression) is transfer(expression); si
+        visit(identifier: Expressions.IDENTIFIER) is transfer(identifier); si
+        visit(literal: Expressions.Literals.Literal) is transfer(literal); si
+        visit(`string: Expressions.Literals.STRING) is transfer(`string); si
+        visit(interpolation: Expressions.STRING_INTERPOLATION) is transfer(interpolation); si
+        visit(integer: Expressions.Literals.INTEGER) is transfer(integer); si
+        visit(float: Expressions.Literals.FLOAT) is transfer(float); si
+        visit(character: Expressions.Literals.CHARACTER) is transfer(character); si
+        visit(boolean: Expressions.Literals.BOOLEAN) is transfer(boolean); si
+        visit(variable: Expressions.VARIABLE) is transfer(variable); si
+        visit(variable: Expressions.TUPLE_ELEMENT) is transfer(variable); si
+        visit(none: Expressions.Literals.NONE) is transfer(none); si
+        visit(`null: Expressions.NULL) is transfer(`null); si
+        visit(`self: Expressions.SELF) is transfer(`self); si
+        visit(`super: Expressions.SUPER) is transfer(`super); si
+        visit(`new: Expressions.NEW) is transfer(`new); si
+        visit(`cast: Expressions.CAST) is transfer(`cast); si
+        visit(`isa: Expressions.ISA) is transfer(`isa); si
+        visit(`isa: Expressions.TYPEOF) is transfer(`isa); si
+        visit(`default: Expressions.DEFAULT) is transfer(`default); si
+        visit(function: Expressions.FUNCTION) is transfer(function); si
+        visit(recurse: Expressions.RECURSE) is transfer(recurse); si
+        visit(tuple: Expressions.TUPLE) is transfer(tuple); si
+        visit(sequence: Expressions.SEQUENCE) is transfer(sequence); si
+        visit(list: Expressions.LIST) is transfer(list); si
+        visit(call: Expressions.CALL) is transfer(call); si
+        visit(member: Expressions.MEMBER) is transfer(member); si
+        visit(member: Expressions.EXPLICIT_SPECIALIZATION) is transfer(member); si
+        visit(ambiguous_expression: Expressions.AMBIGUOUS_EXPRESSION) is transfer(ambiguous_expression); si
+        visit(ambiguous_expression: Expressions.GENERIC_APPLICATION) is transfer(ambiguous_expression); si
+        visit(index: Expressions.INDEX) is transfer(index); si
+        visit(has_value: Expressions.HAS_VALUE) is transfer(has_value); si
+        visit(unwrap: Expressions.UNWRAP) is transfer(unwrap); si
+        visit(reference: Expressions.REFERENCE) is transfer(reference); si
+        visit(unary: Expressions.UNARY) is transfer(unary); si
+        visit(binary: Expressions.BINARY) is transfer(binary); si
+        visit(statement: Expressions.STATEMENT) is transfer(statement); si
+        visit(statement: Expressions.LET_IN) is transfer(statement); si
+
+        visit(left: Trees.Expressions.SIMPLE_LEFT_EXPRESSION) is transfer(left); si
+        visit(destructure_left: Trees.Expressions.DESTRUCTURING_LEFT_EXPRESSION) is transfer(destructure_left); si
+
+        visit(statement: Statements.Statement) is transfer(statement); si
+        visit(statements: Statements.LIST) is transfer(statements); si
+        visit(l: Statements.LET) is transfer(l); si
+        visit(assign: Statements.ASSIGNMENT) is transfer(assign); si
+        visit(expression: Statements.EXPRESSION) is transfer(expression); si
+        visit(`return: Statements.RETURN) is transfer(`return); si
+        visit(`throw: Statements.THROW) is transfer(`throw); si
+        visit(assert__: Statements.ASSERT) is transfer(assert__); si
+        visit(`if: Statements.IF) is transfer(`if); si
+        visit(if_branch: Statements.IF_BRANCH) is transfer(if_branch); si
+        visit(`case: Statements.CASE) is transfer(`case); si
+        visit(case_match: Statements.CASE_MATCH) is transfer(case_match); si
+        visit(`try: Statements.TRY) is transfer(`try); si
+        visit(`catch: Statements.CATCH) is transfer(`catch); si
+        visit(`do: Statements.DO) is transfer(`do); si
+        visit(`for: Statements.FOR) is transfer(`for); si
+        visit(labelled: Statements.LABELLED) is transfer(labelled); si
+        visit(`break: Statements.BREAK) is transfer(`break); si
+        visit(`continue: Statements.CONTINUE) is transfer(`continue); si
+        visit(pragma: Statements.PRAGMA) is transfer(pragma); si
+
+        visit(expression: Bodies.EXPRESSION) is transfer(expression); si
+        visit(block: Bodies.BLOCK) is transfer(block); si
+        visit(block: Bodies.NULL) is transfer(block); si
+        visit(block: Bodies.INNATE) is transfer(block); si
+    si
+
+    // Copies the donor parse's locations onto the structurally-identical
+    // retained AST. Returns false if the two walks disagreed on node count —
+    // the caller must then fall back to a full rebuild.
+    class LOCATION_REFRESH is
+        apply(retained_root: Trees.Node, donor_root: Trees.Node) -> bool static is
+            let transfer = LOCATION_TRANSFER();
+
+            transfer.harvest(donor_root);
+            transfer.apply_to(retained_root);
+
+            return transfer.is_consistent;
+        si
+    si
+si

--- a/src/syntax/trees/definitions/function.ghul
+++ b/src/syntax/trees/definitions/function.ghul
@@ -8,7 +8,7 @@ namespace Syntax.Trees.Definitions is
         generic_arguments: TypeExpressions.LIST;
         arguments: Variables.LIST;
         type_expression: TypeExpressions.TypeExpression;
-        body: Bodies.Body;
+        body: Bodies.Body public;
 
         for_property: PROPERTY public;
         

--- a/src/syntax/trees/node.ghul
+++ b/src/syntax/trees/node.ghul
@@ -10,7 +10,7 @@ namespace Syntax.Trees is
         // the default implementations are sufficient: each
         // node is unique and its reference is its identity
 
-        location: LOCATION;
+        location: LOCATION public;
 
         is_poisoned: bool;
 

--- a/unit-tests/src/syntax/process/body_splice_tests.ghul
+++ b/unit-tests/src/syntax/process/body_splice_tests.ghul
@@ -1,0 +1,106 @@
+namespace Syntax.Process.UnitTests is
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    use Collections.LIST;
+
+    use Source;
+
+    use Trees;
+    use Trees.Definitions.FUNCTION;
+
+    use Syntax.BODY_SPLICE;
+    use Syntax.FUNCTION_PAIRING;
+
+    // Fixtures build only what BODY_SPLICE and FUNCTION_PAIRING touch — a
+    // function's name, an (empty) argument list and a body. LOCATION.internal
+    // is null in the unit-test harness, so locations are built explicitly.
+    class BODY_SPLICE_TESTS is
+        @test()
+
+        init() is si
+
+        loc() -> LOCATION => LOCATION("test", 1, 1, 1, 1);
+
+        id(name: string) -> Trees.Identifiers.Identifier =>
+            Trees.Identifiers.Identifier(loc(), name);
+
+        infer() -> Trees.TypeExpressions.TypeExpression =>
+            Trees.TypeExpressions.INFER(loc());
+
+        func(name: string) -> FUNCTION =>
+            FUNCTION(
+                loc(),
+                id(name),
+                Trees.TypeExpressions.LIST(
+                    loc(),
+                    LIST[Trees.TypeExpressions.TypeExpression]()
+                ),
+                Trees.Variables.LIST(loc(), LIST[Trees.Variables.VARIABLE]()),
+                infer(),
+                Trees.Modifiers.LIST(loc(), null, null),
+                Trees.Bodies.NULL(loc())
+            );
+
+        root(definitions: Collections.Iterable[Trees.Definitions.Definition])
+            -> Trees.Definitions.LIST
+        =>
+            Trees.Definitions.LIST(loc(), definitions);
+
+        splice_gives_each_retained_function_the_donor_body() is
+            @test()
+
+            let pairing = FUNCTION_PAIRING(
+                root([func("a"), func("b")]: Trees.Definitions.Definition),
+                root([func("a"), func("b")]: Trees.Definitions.Definition)
+            );
+
+            let pairs = pairing.pairs;
+
+            Assert.is_true(pairs?, "fixtures should pair");
+            Assert.is_false(
+                pairs![0].retained.body == pairs![0].donor.body,
+                "retained and donor bodies should differ before the splice"
+            );
+
+            BODY_SPLICE.apply(pairs!);
+
+            Assert.are_same(pairs![0].donor.body, pairs![0].retained.body);
+            Assert.are_same(pairs![1].donor.body, pairs![1].retained.body);
+        si
+
+        splice_syncs_a_property_accessor_read_body() is
+            @test()
+
+            let getter = func("$get_p");
+
+            let property = Trees.Definitions.PROPERTY(
+                loc(),
+                infer(),
+                id("p"),
+                Trees.Modifiers.LIST(loc(), null, null),
+                Trees.Bodies.NULL(loc()),
+                null,
+                Trees.Bodies.NULL(loc())
+            );
+
+            property.read_function = getter;
+            getter.for_property = property;
+
+            let pairing = FUNCTION_PAIRING(
+                root([getter]: Trees.Definitions.Definition),
+                root([func("$get_p")]: Trees.Definitions.Definition)
+            );
+
+            let pairs = pairing.pairs;
+
+            Assert.is_true(pairs?, "fixtures should pair");
+
+            BODY_SPLICE.apply(pairs!);
+
+            // The accessor function and the PROPERTY node's read_body field
+            // must end up referencing the same donor body node.
+            Assert.are_same(pairs![0].donor.body, getter.body);
+            Assert.are_same(pairs![0].donor.body, property.read_body);
+        si
+    si
+si

--- a/unit-tests/src/syntax/process/function_pairing_tests.ghul
+++ b/unit-tests/src/syntax/process/function_pairing_tests.ghul
@@ -1,0 +1,134 @@
+namespace Syntax.Process.UnitTests is
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+    use Collections.LIST;
+
+    use Source;
+
+    use Trees;
+    use Trees.Definitions.FUNCTION;
+
+    use Syntax.FUNCTION_COLLECTOR;
+    use Syntax.FUNCTION_PAIRING;
+
+    // Fixtures build only what FUNCTION_COLLECTOR and FUNCTION_PAIRING read —
+    // a function's `name` and `arguments`. Every other part is a minimal
+    // real node so the file builds without null-where-non-optional warnings.
+    class FUNCTION_PAIRING_TESTS is
+        @test()
+
+        init() is si
+
+        // loc() is null in the unit-test harness — its static
+        // initialiser does not run here — so fixtures build real locations.
+        loc() -> LOCATION => LOCATION("test", 1, 1, 1, 1);
+
+        id(name: string) -> Trees.Identifiers.Identifier =>
+            Trees.Identifiers.Identifier(loc(), name);
+
+        infer() -> Trees.TypeExpressions.TypeExpression =>
+            Trees.TypeExpressions.INFER(loc());
+
+        args(arity: int) -> Trees.Variables.LIST is
+            let variables = LIST[Trees.Variables.VARIABLE]();
+
+            for i in 0..arity do
+                variables.add(
+                    Trees.Variables.VARIABLE(
+                        loc(),
+                        Trees.Variables.SIMPLE_VARIABLE_LEFT(loc(), id("p")),
+                        infer(),
+                        false,
+                        false,
+                        Trees.Expressions.Literals.INTEGER(loc(), "0")
+                    )
+                );
+            od
+
+            return Trees.Variables.LIST(loc(), variables);
+        si
+
+        func(name: string, arity: int) -> FUNCTION =>
+            FUNCTION(
+                loc(),
+                id(name),
+                Trees.TypeExpressions.LIST(
+                    loc(),
+                    LIST[Trees.TypeExpressions.TypeExpression]()
+                ),
+                args(arity),
+                infer(),
+                Trees.Modifiers.LIST(loc(), null, null),
+                Trees.Bodies.NULL(loc())
+            );
+
+        root(definitions: Collections.Iterable[Trees.Definitions.Definition])
+            -> Trees.Definitions.LIST
+        =>
+            Trees.Definitions.LIST(loc(), definitions);
+
+        collector_collects_functions_in_declaration_order() is
+            @test()
+
+            let collector = FUNCTION_COLLECTOR();
+
+            root([func("a", 0), func("b", 0), func("c", 0)]: Trees.Definitions.Definition)
+                .walk(collector);
+
+            Assert.are_equal(3, collector.functions.count);
+            Assert.are_equal("a", collector.functions[0].name.name);
+            Assert.are_equal("b", collector.functions[1].name.name);
+            Assert.are_equal("c", collector.functions[2].name.name);
+        si
+
+        matching_files_pair_positionally() is
+            @test()
+
+            let pairing = FUNCTION_PAIRING(
+                root([func("a", 1), func("b", 0)]: Trees.Definitions.Definition),
+                root([func("a", 1), func("b", 0)]: Trees.Definitions.Definition)
+            );
+
+            let pairs = pairing.pairs;
+
+            Assert.is_true(pairs?, "expected the two parses to pair");
+            Assert.are_equal(2, pairs!.count);
+            Assert.are_equal("a", pairs![0].retained.name.name);
+            Assert.are_equal("a", pairs![0].donor.name.name);
+            Assert.are_equal("b", pairs![1].retained.name.name);
+        si
+
+        a_differing_function_count_does_not_pair() is
+            @test()
+
+            let pairing = FUNCTION_PAIRING(
+                root([func("a", 0), func("b", 0)]: Trees.Definitions.Definition),
+                root([func("a", 0)]: Trees.Definitions.Definition)
+            );
+
+            Assert.is_false(pairing.pairs?, "a differing function count must not pair");
+        si
+
+        a_name_mismatch_does_not_pair() is
+            @test()
+
+            let pairing = FUNCTION_PAIRING(
+                root([func("a", 0), func("b", 0)]: Trees.Definitions.Definition),
+                root([func("a", 0), func("c", 0)]: Trees.Definitions.Definition)
+            );
+
+            Assert.is_false(pairing.pairs?, "a function name mismatch must not pair");
+        si
+
+        an_arity_mismatch_does_not_pair() is
+            @test()
+
+            let pairing = FUNCTION_PAIRING(
+                root([func("a", 0)]: Trees.Definitions.Definition),
+                root([func("a", 1)]: Trees.Definitions.Definition)
+            );
+
+            Assert.is_false(pairing.pairs?, "an argument-count mismatch must not pair");
+        si
+    si
+si


### PR DESCRIPTION
Enhancements:

- An analysis-mode single-file edit that changes no file's public interface
  is now serviced incrementally: the new function bodies are spliced into the
  retained AST and only the edited file is re-walked, instead of rebuilding
  the whole project's symbol table. Per-keystroke edit latency against the
  compiler's own source (~379 files) drops from ~163 ms to ~1.4 ms (p50).
  Interface-affecting edits keep the full-rebuild path.

Technical:

- FUNCTION_PAIRING / BODY_SPLICE / LOCATION_REFRESH perform the splice;
  BODY_DECLARER and BODY_REWALKER drive declare-symbols and the
  resolve/compile passes body-scoped, leaving the retained interface symbols
  untouched. The analysis profiler gains an interface-affecting-edit workload
  phase.