### PR TITLE
Modernise CI workflow

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "commands": [
         "ghul-compiler"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "ghul.compiler": {
-      "version": "1.0.6",
+      "version": "1.0.5",
       "commands": [
         "ghul-compiler"
       ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,29 +18,55 @@ env:
 
 jobs:
   version:
-    name: Create a version number
+    name: Determine the version number
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
-      tag: ${{ steps.create_version.outputs.tag }}
-      package: ${{ steps.create_version.outputs.package }}
-      
+      tag: ${{ steps.package_version.outputs.tag }}
+      package: ${{ steps.package_version.outputs.package }}
+
     permissions:
-      contents: 'write'
+      contents: read
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
-        fetch-depth: '0'    
+        fetch-depth: '0'
 
-    - name: Create version
-      id: create_version
-      uses: degory/create-version@v0.0.2
+    # Calculates the next version from the git history. This action only
+    # reads the repository - it never creates tags or releases. The next
+    # version is a major/minor/patch bump of the most recent vX.Y.Z tag;
+    # a #major or #minor marker in a commit subject picks the bump level,
+    # otherwise each commit bumps the patch number.
+    - name: Calculate the semantic version
+      id: semver
+      uses: paulhatch/semantic-version@v6.0.2
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-      env:
-        PRERELEASE: ${{ github.event_name == 'pull_request' }}
-        
+        tag_prefix: 'v'
+        major_pattern: '#major'
+        minor_pattern: '#minor'
+        version_format: '${major}.${minor}.${patch}'
+
+    - name: Determine the package version
+      id: package_version
+      run: |
+        manual="${{ github.event.inputs.version }}"
+        if [ -n "$manual" ]; then
+          # version supplied via the workflow_dispatch input
+          package="${manual#v}"
+        else
+          package="${{ steps.semver.outputs.version }}"
+          # pull request builds get a prerelease version so they can
+          # never collide with a real release
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            package="${package}-beta.${{ github.run_number }}"
+          fi
+        fi
+        echo "tag=v${package}" >> "$GITHUB_OUTPUT"
+        echo "package=${package}" >> "$GITHUB_OUTPUT"
+        echo "Version: v${package}"
+
+
   unit_tests:
     name: Run unit tests
     needs: [version]
@@ -52,7 +78,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Add GHCR package source
       run: dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/degory/index.json"    
@@ -78,7 +104,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Add GHCR package source
       run: dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/degory/index.json"    
@@ -129,7 +155,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Download ghul.compiler package
       uses: actions/download-artifact@v4
@@ -184,7 +210,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Download bootstrap compiler tool tree
       uses: actions/download-artifact@v4
@@ -215,7 +241,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Download ghul.compiler package
       uses: actions/download-artifact@v4
@@ -279,7 +305,7 @@ jobs:
         echo "ref=${ref}" >> "$GITHUB_OUTPUT"
 
     - name: Checkout ghul-runtime
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: degory/ghul-runtime
         path: ghul-runtime
@@ -350,7 +376,7 @@ jobs:
         echo "ref=${ref}" >> "$GITHUB_OUTPUT"
 
     - name: Checkout ghul-examples
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: degory/ghul-examples
         path: ghul-examples
@@ -388,7 +414,7 @@ jobs:
 
     if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Download ghul compiler tool package
       uses: actions/download-artifact@v4
@@ -413,7 +439,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Download ghul.compiler package
       uses: actions/download-artifact@v4
@@ -422,7 +448,7 @@ jobs:
         path: nupkg
 
     - name: Docker login to GHCR
-      uses: docker/login-action@v1
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
@@ -454,7 +480,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Add .NET tools to PATH
       run: echo "${HOME}/.dotnet/tools" >> $GITHUB_PATH
@@ -496,17 +522,17 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Docker login to GHCR
-      uses: docker/login-action@v1
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GHCR_PAT }}
 
     - name: Docker login to Docker Hub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKER_USER_NAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -543,7 +569,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Download ghul compiler tool package
       uses: actions/download-artifact@v4
@@ -569,8 +595,13 @@ jobs:
     timeout-minutes: 5
     if: ${{ github.event_name != 'pull_request' }}
 
+    permissions:
+      contents: write
+
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: '0'
 
     - name: Download ghul compiler tool package
       uses: actions/download-artifact@v4
@@ -581,23 +612,11 @@ jobs:
     - name: Create changelog
       run: git log -1 --format="%s%n%n%b%n%n" >changelog.txt
 
-    - name: Create a Release
-      id: create_release
-      uses: actions/create-release@v1
+    - name: Create a release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ needs.version.outputs.tag }}
-        release_name: ${{ needs.version.outputs.tag }}
-        body_path: changelog.txt
-        draft: false
-
-    - name: Upload package asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./nupkg/ghul.compiler.${{ needs.version.outputs.package }}.nupkg
-        asset_name: ghul.compiler.${{ needs.version.outputs.package }}.nupkg
-        asset_content_type: application/octet-stream
+      run: |
+        gh release create "${{ needs.version.outputs.tag }}" \
+          ./nupkg/ghul.compiler.${{ needs.version.outputs.package }}.nupkg \
+          --title "${{ needs.version.outputs.tag }}" \
+          --notes-file changelog.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: '0'
 
@@ -78,7 +78,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Add GHCR package source
       run: dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/degory/index.json"    
@@ -104,7 +104,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Add GHCR package source
       run: dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/degory/index.json"    
@@ -118,7 +118,7 @@ jobs:
         TAG_VERSION: ${{ needs.version.outputs.tag }}
         PACKAGE_VERSION: ${{ needs.version.outputs.package }}
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: ghul-compiler-package
         path: ./nupkg/ghul.compiler.${{ needs.version.outputs.package }}.nupkg
@@ -137,7 +137,7 @@ jobs:
         unzip -o nupkg/ghul.compiler.${{ needs.version.outputs.package }}.nupkg \
           'tools/net8.0/any/*' -d extracted-tool
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: ghul-compiler-tool
         path: ./extracted-tool/tools/net8.0/any
@@ -155,16 +155,16 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Download ghul.compiler package
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ghul-compiler-package
         path: nupkg
 
     - name: Download bootstrap compiler tool tree
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ghul-compiler-tool
         path: bootstrap-tool
@@ -194,7 +194,7 @@ jobs:
         GHUL_RUNTIME_DLL: ${{ github.workspace }}/bootstrap-tool/ghul-runtime.dll
       run: bash -c "set -o pipefail ; dotnet ghul-test integration-tests | tee test-results.txt"
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: test-results
         path: test-results.txt
@@ -210,10 +210,10 @@ jobs:
     timeout-minutes: 5
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Download bootstrap compiler tool tree
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ghul-compiler-tool
         path: bootstrap-tool
@@ -241,10 +241,10 @@ jobs:
     timeout-minutes: 5
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Download ghul.compiler package
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ghul-compiler-package
         path: nupkg
@@ -258,7 +258,7 @@ jobs:
     - name: Run project tests
       run: bash -c "set -o pipefail ; dotnet ghul-test --use-dotnet-build project-tests | tee project-test-results.txt"
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: project-test-results
         path: project-test-results.txt
@@ -305,14 +305,14 @@ jobs:
         echo "ref=${ref}" >> "$GITHUB_OUTPUT"
 
     - name: Checkout ghul-runtime
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: degory/ghul-runtime
         path: ghul-runtime
         ref: ${{ steps.ref.outputs.ref }}
 
     - name: Download ghul.compiler package
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ghul-compiler-package
         path: nupkg
@@ -376,14 +376,14 @@ jobs:
         echo "ref=${ref}" >> "$GITHUB_OUTPUT"
 
     - name: Checkout ghul-examples
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: degory/ghul-examples
         path: ghul-examples
         ref: ${{ steps.ref.outputs.ref }}
 
     - name: Download ghul.compiler package
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ghul-compiler-package
         path: nupkg
@@ -414,10 +414,10 @@ jobs:
 
     if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Download ghul compiler tool package
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ghul-compiler-package
         path: nupkg
@@ -439,10 +439,10 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Download ghul.compiler package
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ghul-compiler-package
         path: nupkg
@@ -480,7 +480,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Add .NET tools to PATH
       run: echo "${HOME}/.dotnet/tools" >> $GITHUB_PATH
@@ -506,7 +506,7 @@ jobs:
     - name: Run integration tests
       run: bash -c "set -o pipefail ; ghul-test integration-tests | tee test-results.txt"
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: ${{ always() }}
       with:
         name: container-test-results
@@ -522,7 +522,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Docker login to GHCR
       uses: docker/login-action@v4
@@ -569,10 +569,10 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Download ghul compiler tool package
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ghul-compiler-package
         path: nupkg
@@ -599,12 +599,12 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: '0'
 
     - name: Download ghul compiler tool package
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ghul-compiler-package
         path: nupkg

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,7 +17,7 @@ jobs:
       # will not occur.
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1.6.0
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       # Here the PR gets approved.


### PR DESCRIPTION
- replace `degory/create-version` with `paulhatch/semantic-version`; the release tag is now created only by the existing `gh release create` step on push to main; pull requests no longer push prerelease tags
- replace the archived `actions/create-release` and `actions/upload-release-asset` with a single `gh release create` step
- bump `actions/checkout` v3 → v4 across all jobs (including the cross-repo remote-checkout steps for the runtime / examples builds)
- bump `docker/login-action` v1 → v4
- bump `dependabot/fetch-metadata` v1.6.0 → v3

Pull request builds continue to version as `X.Y.Z-beta.<run-number>`, unchanged from the existing convention. The published `vX.Y.Z` tag is now created by the release job (`gh release create`) rather than ahead of time by the version job — same effective behaviour for the `#major` / `#minor` PR-title markers.